### PR TITLE
fix: Remove PUT method from exposed port configuration

### DIFF
--- a/apps/vs-agent/.gitignore
+++ b/apps/vs-agent/.gitignore
@@ -6,3 +6,4 @@ build
 logs.txt
 examples/**/afj
 tails/
+.env

--- a/apps/vs-agent/src/services/FullTailsFileService.ts
+++ b/apps/vs-agent/src/services/FullTailsFileService.ts
@@ -1,10 +1,9 @@
 import type { AnonCredsRevocationRegistryDefinition } from '@credo-ts/anoncreds'
-import type { AgentContext } from '@credo-ts/core'
+import type { AgentContext, Logger } from '@credo-ts/core'
 
 import { BasicTailsFileService } from '@credo-ts/anoncreds'
 import { utils } from '@credo-ts/core'
-import axios from 'axios'
-import FormData from 'form-data'
+import { createHash } from 'crypto'
 import fs from 'fs'
 
 export class FullTailsFileService extends BasicTailsFileService {
@@ -24,17 +23,62 @@ export class FullTailsFileService extends BasicTailsFileService {
     const localTailsFilePath = revocationRegistryDefinition.value.tailsLocation
 
     const tailsFileId = utils.uuid()
-    const data = new FormData()
-    const readStream = fs.createReadStream(localTailsFilePath)
-    data.append('file', readStream)
-    const response = await axios.put(`${this.tailsServerBaseUrl}/${encodeURIComponent(tailsFileId)}`, data, {
-      headers: {
-        ...data.getHeaders(),
-      },
-    })
-    if (response.status !== 200) {
-      throw new Error('Cannot upload tails file')
+    try {
+      await processTailsFile(localTailsFilePath, tailsFileId, agentContext.config.logger)
+      console.log('Tails file processed successfully!')
+    } catch (error) {
+      console.error(`Failed to process tails file: ${error.message}`)
     }
     return { tailsFileUrl: `${this.tailsServerBaseUrl}/${encodeURIComponent(tailsFileId)}` }
   }
+}
+
+export const baseFilePath = './tails'
+const indexFilePath = `./${baseFilePath}/index.json`
+
+if (!fs.existsSync(baseFilePath)) {
+  fs.mkdirSync(baseFilePath, { recursive: true })
+}
+export const tailsIndex = (
+  fs.existsSync(indexFilePath) ? JSON.parse(fs.readFileSync(indexFilePath, { encoding: 'utf-8' })) : {}
+) as Record<string, string>
+
+function fileHash(filePath: string, algorithm = 'sha256') {
+  return new Promise<string>((resolve, reject) => {
+    const shasum = createHash(algorithm)
+    try {
+      const s = fs.createReadStream(filePath)
+      s.on('data', function (data) {
+        shasum.update(data)
+      })
+      // making digest
+      s.on('end', function () {
+        const hash = shasum.digest('hex')
+        return resolve(hash)
+      })
+    } catch (error) {
+      return reject('error in calculation')
+    }
+  })
+}
+
+async function processTailsFile(localFilePath: string, tailsFileId: string, logger: Logger) {
+  logger.info(`Processing tails file: ${tailsFileId}`)
+
+  if (!localFilePath) throw new Error('No file path was provided.')
+  if (!tailsFileId) throw new Error('Missing tailsFileId')
+  if (tailsIndex[tailsFileId]) throw new Error(`There is already an entry for: ${tailsFileId}`)
+
+  const hash = await fileHash(localFilePath)
+  const destinationPath = `${baseFilePath}/${hash}`
+  if (fs.existsSync(destinationPath)) {
+    logger.warn('Tails file already exists')
+  } else {
+    fs.copyFileSync(localFilePath, destinationPath)
+  }
+
+  tailsIndex[tailsFileId] = hash
+  fs.writeFileSync(indexFilePath, JSON.stringify(tailsIndex))
+
+  logger.info(`Successfully processed tails file ${tailsFileId}`)
 }

--- a/apps/vs-agent/src/services/FullTailsFileService.ts
+++ b/apps/vs-agent/src/services/FullTailsFileService.ts
@@ -7,10 +7,10 @@ import { createHash } from 'crypto'
 import fs from 'fs'
 
 export class FullTailsFileService extends BasicTailsFileService {
-  private tailsServerBaseUrl?: string
-  public constructor(options?: { tailsDirectoryPath?: string; tailsServerBaseUrl?: string }) {
+  private tailsServerBaseUrl: string
+  public constructor(options: { tailsDirectoryPath?: string; tailsServerBaseUrl: string }) {
     super(options)
-    this.tailsServerBaseUrl = options?.tailsServerBaseUrl
+    this.tailsServerBaseUrl = options.tailsServerBaseUrl
   }
 
   public async uploadTailsFile(

--- a/apps/vs-agent/src/services/FullTailsFileService.ts
+++ b/apps/vs-agent/src/services/FullTailsFileService.ts
@@ -24,7 +24,7 @@ export class FullTailsFileService extends BasicTailsFileService {
 
     const tailsFileId = utils.uuid()
     try {
-      await processTailsFile(localTailsFilePath, tailsFileId, agentContext.config.logger)
+      await saveTailsFile(localTailsFilePath, tailsFileId, agentContext.config.logger)
       console.log('Tails file processed successfully!')
     } catch (error) {
       console.error(`Failed to process tails file: ${error.message}`)
@@ -62,7 +62,7 @@ function fileHash(filePath: string, algorithm = 'sha256') {
   })
 }
 
-async function processTailsFile(localFilePath: string, tailsFileId: string, logger: Logger) {
+async function saveTailsFile(localFilePath: string, tailsFileId: string, logger: Logger) {
   logger.info(`Processing tails file: ${tailsFileId}`)
 
   if (!localFilePath) throw new Error('No file path was provided.')

--- a/apps/vs-agent/src/services/index.ts
+++ b/apps/vs-agent/src/services/index.ts
@@ -1,0 +1,3 @@
+export * from './FullTailsFileService'
+export * from './UrlShorteningService'
+export * from './VsAgentService'


### PR DESCRIPTION
## Summary
This PR moves the `PUT /didcomm` method in order to update the tails file management system.
We moved a function because the agent port is publicly exposed, which means anyone could potentially modify the tails revocation file — and that's sensitive information.
We based our implementation on the default method but adapted it to fit our specific use case.
## Changes
- <!-- Describe the main changes made in this PR. List them point-by-point. -->

## Related Issues
<!-- Reference any open issues this PR addresses (e.g., "Fixes #123" or "Fixed problem with ..."). -->

## Testing
<!-- Describe the tests that were run to ensure the changes are working as expected. Include any specific commands or steps needed to reproduce. -->

## Checklist
- [ ] I have commented on my code, especially in areas that are hard to understand.
- [ ] I have added only changes relevant to the issue in question.
- [ ] I have added tests to confirm that my fix is effective or that my feature works as intended.
- [ ] I have modified existing tests as needed to accommodate my changes.
- [ ] I have flagged specific areas for further review, if necessary.
- [ ] I have updated the documentation where necessary.
