### PR TITLE
fix: don't recreate DIDComm keys at every startup

### DIFF
--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -95,7 +95,7 @@ const run = async () => {
 
   const publicDid = AGENT_PUBLIC_DID ? parseDid(AGENT_PUBLIC_DID) : null
 
-  if (AGENT_PUBLIC_DID) {
+  if (!AGENT_PUBLIC_DID) {
     serverLogger.warn('AGENT_PUBLIC_DID is not defined. You must set it in production releases')
   }
 

--- a/apps/vs-agent/src/utils/setupAgent.ts
+++ b/apps/vs-agent/src/utils/setupAgent.ts
@@ -159,12 +159,35 @@ export const setupAgent = async ({
     )
 
     const didRepository = agent.context.dependencyManager.resolve(DidRepository)
+    const existingRecord = await didRepository.findCreatedDid(agent.context, publicDid)
+
     const builder = new DidDocumentBuilder(publicDid)
 
-    // Create a set of keys suitable for did communication
-    if (endpoints && endpoints.length > 0) {
-      const keyAgreementId = `${publicDid}#key-agreement-1`
+    builder
+      .addContext('https://w3id.org/security/suites/ed25519-2018/v1')
+      .addContext('https://w3id.org/security/suites/x25519-2019/v1')
 
+    // If the document already exists (i.e. DID record previously created), take base keys from it
+    // and just populate those services that can vary according to the configuration
+    const keyAgreementId = `${publicDid}#key-agreement-1`
+    if (existingRecord?.didDocument) {
+      logger?.debug('Public did record already stored. DidDocument keys will be restored from it')
+      const verificationMethods = existingRecord.didDocument.verificationMethod ?? []
+      for (const method of verificationMethods) {
+        builder.addVerificationMethod(method)
+      }
+
+      const authentications = existingRecord.didDocument.authentication ?? []
+      for (const auth of authentications) {
+        builder.addAuthentication(auth)
+      }
+
+      const keyAgreements = existingRecord.didDocument.keyAgreement ?? []
+      for (const key of keyAgreements) {
+        builder.addKeyAgreement(key)
+      }
+    } else {
+      logger?.debug('Public did record not found. Creating key pair and DidDocument')
       const ed25519 = await agent.context.wallet.createKey({ keyType: KeyType.Ed25519 })
       const verificationMethodId = `${publicDid}#${ed25519.fingerprint}`
       const publicKeyX25519 = TypedArrayEncoder.toBase58(
@@ -189,58 +212,59 @@ export const setupAgent = async ({
         .addAuthentication(verificationMethodId)
         .addAssertionMethod(verificationMethodId)
         .addKeyAgreement(keyAgreementId)
-      if (selfVtrEnabled) {
-        builder
-          .addService(
-            new DidDocumentService({
-              id: `${publicDid}#vpr-ecs-trust-registry-1234`,
-              serviceEndpoint: `${publicApiBaseUrl}/self-vtr`,
-              type: 'VerifiablePublicRegistry',
-            }),
-          )
-          .addService(
-            new DidDocumentService({
-              id: `${publicDid}#vpr-ecs-service-c-vp`,
-              serviceEndpoint: `${publicApiBaseUrl}/self-vtr/ecs-service-c-vp.json`,
-              type: 'LinkedVerifiablePresentation',
-            }),
-          )
-          .addService(
-            new DidDocumentService({
-              id: `${publicDid}#vpr-ecs-org-c-vp`,
-              serviceEndpoint: `${publicApiBaseUrl}/self-vtr/ecs-org-c-vp.json`,
-              type: 'LinkedVerifiablePresentation',
-            }),
-          )
-      }
-
-      for (let i = 0; i < agent.config.endpoints.length; i++) {
-        builder.addService(
-          new DidCommV1Service({
-            id: `${publicDid}#did-communication`,
-            serviceEndpoint: agent.config.endpoints[i],
-            priority: i,
-            routingKeys: [], // TODO: Support mediation
-            recipientKeys: [keyAgreementId],
-            accept: ['didcomm/aip2;env=rfc19'],
-          }),
-        )
-      }
-
-      if (publicApiBaseUrl) {
-        builder.addService(
-          new DidDocumentService({
-            id: `${publicDid}#anoncreds`,
-            serviceEndpoint: `${publicApiBaseUrl}/anoncreds/v1`,
-            type: 'AnonCredsRegistry',
-          }),
-        )
-      }
     }
 
-    const existingRecord = await didRepository.findCreatedDid(agent.context, publicDid)
+    // Create a set of keys suitable for did communication
+    if (selfVtrEnabled) {
+      builder
+        .addService(
+          new DidDocumentService({
+            id: `${publicDid}#vpr-ecs-trust-registry-1234`,
+            serviceEndpoint: `${publicApiBaseUrl}/self-vtr`,
+            type: 'VerifiablePublicRegistry',
+          }),
+        )
+        .addService(
+          new DidDocumentService({
+            id: `${publicDid}#vpr-ecs-service-c-vp`,
+            serviceEndpoint: `${publicApiBaseUrl}/self-vtr/ecs-service-c-vp.json`,
+            type: 'LinkedVerifiablePresentation',
+          }),
+        )
+        .addService(
+          new DidDocumentService({
+            id: `${publicDid}#vpr-ecs-org-c-vp`,
+            serviceEndpoint: `${publicApiBaseUrl}/self-vtr/ecs-org-c-vp.json`,
+            type: 'LinkedVerifiablePresentation',
+          }),
+        )
+    }
+
+    for (let i = 0; i < agent.config.endpoints.length; i++) {
+      builder.addService(
+        new DidCommV1Service({
+          id: `${publicDid}#did-communication`,
+          serviceEndpoint: agent.config.endpoints[i],
+          priority: i,
+          routingKeys: [], // TODO: Support mediation
+          recipientKeys: [keyAgreementId],
+          accept: ['didcomm/aip2;env=rfc19'],
+        }),
+      )
+    }
+
+    if (publicApiBaseUrl) {
+      builder.addService(
+        new DidDocumentService({
+          id: `${publicDid}#anoncreds`,
+          serviceEndpoint: `${publicApiBaseUrl}/anoncreds/v1`,
+          type: 'AnonCredsRegistry',
+        }),
+      )
+    }
+
     if (existingRecord) {
-      logger?.debug('Public did record already stored. DidDocument updated')
+      logger?.debug('Public did record updated')
       existingRecord.didDocument = builder.build()
       await didRepository.update(agent.context, existingRecord)
     } else {


### PR DESCRIPTION
Updated agent setup logic to only create DIDComm key pairs for public DID when it did not already exists. It will still recreate/update DID Document at each startup because we may want to update some configs (such as VTR or endpoints)