### PR TITLE
fix: update retrieve json schema

### DIFF
--- a/apps/vs-agent/src/controllers/public/self-tr/SelfTrController.ts
+++ b/apps/vs-agent/src/controllers/public/self-tr/SelfTrController.ts
@@ -119,20 +119,7 @@ export class SelfTrController {
       }
       const ecsSchema = this.service.getSchemas(schemaId)
       return {
-        id: 101,
-        tr_id: 1002,
-        created: '2024-03-12T12:00:00Z',
-        modified: '2024-03-12T12:30:00Z',
-        archived: '',
-        deposit: 5000,
-        json_schema: JSON.stringify(ecsSchema),
-        issuer_grantor_validation_validity_period: 365,
-        verifier_grantor_validation_validity_period: 180,
-        issuer_validation_validity_period: 730,
-        verifier_validation_validity_period: 90,
-        holder_validation_validity_period: 60,
-        issuer_perm_management_mode: 'STRICT',
-        verifier_perm_management_mode: 'FLEXIBLE',
+        schema: JSON.stringify(ecsSchema),
       }
     } catch (error) {
       this.logger.error(`Error loading schema file: ${error.message}`)


### PR DESCRIPTION
Based on https://github.com/verana-labs/verifiable-trust-vpr-spec/blob/main/spec.md#mod-cs-qry-3-render-json-schema

This update modifies the method used to return a 
https://verana-labs.github.io/verifiable-trust-spec/#json-schema-credentials 
object, including a `$ref` inside its `credentialSubject` to reference a specific schema.

The `$ref` now returns a schema object containing only the schema in the format:
{ schema: "schema_data..." }

After this change, an update to the `verre` feature will be required to support this new behavior.