### PR TITLE
refactor: standardize creation of admin and public endpoints

### DIFF
--- a/apps/vs-agent/src/admin.module.ts
+++ b/apps/vs-agent/src/admin.module.ts
@@ -57,5 +57,3 @@ export class VsAgentModule {
     }
   }
 }
-
-export class AppModule {}

--- a/apps/vs-agent/src/controllers/admin/health/health.controller.ts
+++ b/apps/vs-agent/src/controllers/admin/health/health.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common'
+import { ApiTags } from '@nestjs/swagger'
 
-@Controller('health')
+@ApiTags('Health')
+@Controller({path: 'health', version: '1'})
 export class HealthController {
   @Get()
   getHealth() {

--- a/apps/vs-agent/src/controllers/admin/health/health.controller.ts
+++ b/apps/vs-agent/src/controllers/admin/health/health.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get } from '@nestjs/common'
 import { ApiTags } from '@nestjs/swagger'
 
 @ApiTags('Health')
-@Controller({path: 'health', version: '1'})
+@Controller({ path: 'health', version: '1' })
 export class HealthController {
   @Get()
   getHealth() {

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -56,12 +56,11 @@ export const startServer = async (
 
   const adminApp = await NestFactory.create(VsAgentModule.register(agent, publicApiBaseUrl))
   commonAppConfig(adminApp, cors)
-  const publicApp = await NestFactory.create(PublicModule.register(agent, publicApiBaseUrl))
-  commonAppConfig(publicApp, cors)
-
   await adminApp.listen(port)
 
   // PublicModule-specific config
+  const publicApp = await NestFactory.create(PublicModule.register(agent, publicApiBaseUrl))
+  commonAppConfig(publicApp, cors)
   publicApp.use(express.json({ limit: '5mb' }))
   publicApp.use(express.urlencoded({ extended: true, limit: '5mb' }))
   publicApp.getHttpAdapter().getInstance().set('json spaces', 2)

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -47,7 +47,7 @@ import { VsAgentWsInboundTransport } from './utils/VsAgentWsInboundTransport'
 import { TsLogger } from './utils/logger'
 import { commonAppConfig, setupAgent } from './utils/setupAgent'
 
-export const startServer = async (
+export const startServers = async (
   module: typeof PublicModule | typeof VsAgentModule,
   agent: VsAgent,
   serverConfig: ServerConfig,
@@ -157,6 +157,8 @@ const run = async () => {
     discoveryOptions,
     endpoints,
   }
+
+  await startServers(agent, conf)
 
   // Listen to events emitted by the agent
   connectionEvents(agent, conf)

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -47,11 +47,7 @@ import { VsAgentWsInboundTransport } from './utils/VsAgentWsInboundTransport'
 import { TsLogger } from './utils/logger'
 import { commonAppConfig, setupAgent } from './utils/setupAgent'
 
-export const startServers = async (
-  module: typeof PublicModule | typeof VsAgentModule,
-  agent: VsAgent,
-  serverConfig: ServerConfig,
-) => {
+export const startServers = async (agent: VsAgent, serverConfig: ServerConfig) => {
   const { port, cors, endpoints, publicApiBaseUrl } = serverConfig
 
   const adminApp = await NestFactory.create(VsAgentModule.register(agent, publicApiBaseUrl))

--- a/apps/vs-agent/src/public.module.ts
+++ b/apps/vs-agent/src/public.module.ts
@@ -27,5 +27,3 @@ export class PublicModule {
     }
   }
 }
-
-export class AppModule {}

--- a/apps/vs-agent/src/utils/HttpInboundTransport.ts
+++ b/apps/vs-agent/src/utils/HttpInboundTransport.ts
@@ -14,7 +14,7 @@ import express, { text } from 'express'
 const supportedContentTypes: string[] = [DidCommMimeType.V0, DidCommMimeType.V1]
 
 export class HttpInboundTransport implements InboundTransport {
-  public readonly app: Express
+  public app: Express
   private port: number
   private path: string
   private _server?: Server
@@ -30,6 +30,15 @@ export class HttpInboundTransport implements InboundTransport {
     this.app = app ?? express()
     this.path = path ?? '/'
 
+    this.setupMiddleware()
+  }
+
+  public setApp(app: Express) {
+    this.app = app
+    this.setupMiddleware()
+  }
+
+  private setupMiddleware() {
     this.app.use(text({ type: supportedContentTypes, limit: '5mb' }))
   }
 

--- a/apps/vs-agent/src/utils/HttpInboundTransport.ts
+++ b/apps/vs-agent/src/utils/HttpInboundTransport.ts
@@ -14,7 +14,7 @@ import express, { text } from 'express'
 const supportedContentTypes: string[] = [DidCommMimeType.V0, DidCommMimeType.V1]
 
 export class HttpInboundTransport implements InboundTransport {
-  public app: Express
+  public app?: Express
   private port: number
   private path: string
   private _server?: Server
@@ -23,14 +23,9 @@ export class HttpInboundTransport implements InboundTransport {
     return this._server
   }
 
-  public constructor({ app, path, port }: { app?: Express; path?: string; port: number }) {
+  public constructor({ path, port }: { path?: string; port: number }) {
     this.port = port
-
-    // Create Express App
-    this.app = app ?? express()
     this.path = path ?? '/'
-
-    this.setupMiddleware()
   }
 
   public setApp(app: Express) {
@@ -39,10 +34,14 @@ export class HttpInboundTransport implements InboundTransport {
   }
 
   private setupMiddleware() {
-    this.app.use(text({ type: supportedContentTypes, limit: '5mb' }))
+    this.app?.use(text({ type: supportedContentTypes, limit: '5mb' }))
   }
 
-  public async start(agent: Agent) {
+  public async start(agent: Agent, app?: Express) {
+    if (!this.app) {
+      this.app = app ?? express()
+      this.setupMiddleware()
+    }
     const transportService = agent.dependencyManager.resolve(TransportService)
     const messageReceiver = agent.dependencyManager.resolve(MessageReceiver)
 

--- a/apps/vs-agent/src/utils/ServerConfig.ts
+++ b/apps/vs-agent/src/utils/ServerConfig.ts
@@ -12,6 +12,7 @@ export interface ServerConfig {
   logger: TsLogger
   webhookUrl?: string
   discoveryOptions?: FeatureQueryOptions[]
+  endpoints: string[]
 }
 
 export interface DidWebServerConfig extends ServerConfig {

--- a/apps/vs-agent/src/utils/VsAgentWsInboundTransport.ts
+++ b/apps/vs-agent/src/utils/VsAgentWsInboundTransport.ts
@@ -81,6 +81,12 @@ export class VsAgentWsInboundTransport implements InboundTransport {
     })
   }
 
+  public getServer() {
+    this.logger.debug('Get WebSocket Server')
+
+    return this.socketServer
+  }
+
   private startIdleSocketTimer(interval: number) {
     setInterval(() => {
       const currentDate = new Date()

--- a/apps/vs-agent/src/utils/setupAgent.ts
+++ b/apps/vs-agent/src/utils/setupAgent.ts
@@ -74,13 +74,13 @@ export const setupAgent = async ({
   let webSocketServer: WebSocket.Server | undefined
   let httpInboundTransport: HttpInboundTransport | undefined
   if (enableHttp) {
-    agent.config.logger.info('Inbound HTTP transport enabled')
+    logger.info('Inbound HTTP transport enabled')
     httpInboundTransport = new HttpInboundTransport({ port })
     agent.registerInboundTransport(httpInboundTransport)
   }
 
   if (enableWs) {
-    agent.config.logger.info('Inbound WebSocket transport enabled')
+    logger.info('Inbound WebSocket transport enabled')
     webSocketServer = new WebSocket.Server({ noServer: true })
     agent.registerInboundTransport(new VsAgentWsInboundTransport({ server: webSocketServer }))
   }

--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
             -  containerPort: {{ .Values.didcommPort }}
             livenessProbe:
               httpGet:
-                path: /health
+                path: /v1/health
                 port: {{ .Values.adminPort }}
               initialDelaySeconds: 30
               periodSeconds: 60
@@ -177,7 +177,7 @@ spec:
               failureThreshold: 2
             readinessProbe:
               httpGet:
-                path: /health
+                path: /v1/health
                 port: {{ .Values.adminPort }}
               initialDelaySeconds: 15
               periodSeconds: 60


### PR DESCRIPTION
Hey @genaris,
This PR unifies both `AppModule` instances: `over` and `vs-agent`.
The only doubt I have is regarding the `HttpInboundTransport` setup in Credo. Previously, we initialized it like this:
```ts
httpInboundTransport = new HttpInboundTransport({
  app: app.getHttpAdapter().getInstance(),
  port,
});
```
But in the new version, we initialize it only with the port:
```ts
httpInboundTransport = new HttpInboundTransport({ port });
```
And later we set the app like this:
```ts
httpInboundTransport?.setApp(publicApp.getHttpAdapter().getInstance());
```
Is that enough?