### PR TITLE
fix: add public did method selector to Helm chart

### DIFF
--- a/charts/vs-agent/README.md
+++ b/charts/vs-agent/README.md
@@ -37,13 +37,14 @@ This Helm chart deploys **VS Agent** application with a StatefulSet, supporting 
 | `adminPort`   | Port for admin interface                 | `3000`  |
 | `didcommPort`   | Port for agent communication (`didcomm`) | `3001`  |
 
-### Didcomm Configuration
+### Agent Configuration
 
 | Parameter                  | Description                                      | Default                          |
 | -------------------------- | ------------------------------------------------ | -------------------------------- |
 | `didcommLabel`                | Label for the agent                              | `VS Agent`                      |
 | `eventsBaseUrl`            | Base URL for events                              | `https://events.example.com`    |
 | `didcommInvitationImageUrl`  | URL for the agent invitation image               | `https://example.com/invitation.png` |
+| `publicDidMethod`          | DID method to use for public DID: 'web' or 'webvh' | `webvh` |
 | `extraEnv`                 | Additional environment variables for the agent   | `[]`                            |
 
 ### Database Configuration (Optional)

--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -157,7 +157,7 @@ spec:
             - name: EVENTS_BASE_URL
               value: "{{ tpl .Values.eventsBaseUrl . }}"
             - name: AGENT_PUBLIC_DID
-              value: "did:web:{{ tpl .Values.ingress.host . }}"
+              value: "did:{{ default "webvh" .Values.publicDidMethod }}:{{ tpl .Values.ingress.host . }}"
 {{- with .Values.extraEnv }}
 {{- range . }}
             - name: {{ .name }}

--- a/charts/vs-agent/values.yaml
+++ b/charts/vs-agent/values.yaml
@@ -14,6 +14,7 @@ didcommPort: 3001 # Port for DIDComm
 didcommLabel: "VS Agent"
 eventsBaseUrl: "https://events.{{ .Values.global.domain }}"
 didcommInvitationImageUrl: "https://image.{{ .Values.global.domain }}/invitation.png"
+publicDidMethod: "webvh"
 
 # DB and Redis configuration
 database:


### PR DESCRIPTION
The idea here is to use did:webvh by default, but, if for some reason we only want to support did:web, be able to do so.