### PR TITLE
fix: return legacy did:web document when resolving legacy did

### DIFF
--- a/apps/vs-agent/src/controllers/admin/invitation/InvitationController.ts
+++ b/apps/vs-agent/src/controllers/admin/invitation/InvitationController.ts
@@ -27,7 +27,7 @@ export class InvitationController {
 
   @Get('/')
   @ApiQuery({ name: 'legacy', required: false, type: Boolean })
-  public async getInvitation(@Query('legacy') useLegacyDid?: boolean,): Promise<CreateInvitationResult> {
+  public async getInvitation(@Query('legacy') useLegacyDid?: boolean): Promise<CreateInvitationResult> {
     return await createInvitation({ agent: await this.agentService.getAgent(), useLegacyDid })
   }
 

--- a/apps/vs-agent/src/utils/CachedWebDidResolver.ts
+++ b/apps/vs-agent/src/utils/CachedWebDidResolver.ts
@@ -7,7 +7,16 @@ import {
 } from '@credo-ts/core'
 import { ParsedDID } from 'did-resolver'
 
+import { getLegacyDidDocument } from './legacyDidWeb'
+
 export class CachedWebDidResolver extends WebDidResolver {
+  private publicApiBaseUrl: string
+
+  public constructor(options: { publicApiBaseUrl: string }) {
+    super()
+    this.publicApiBaseUrl = options.publicApiBaseUrl
+  }
+
   public async resolve(
     agentContext: AgentContext,
     did: string,
@@ -17,10 +26,8 @@ export class CachedWebDidResolver extends WebDidResolver {
     // First check within our own public dids, as there is no need to resolve it through HTTPS
     const didRepository = agentContext.dependencyManager.resolve(DidRepository)
     const didRecord = await didRepository.findSingleByQuery(agentContext, {
-      $or: [
-        { did, method: 'web' },
-        { domain: parsed.id, method: 'webvh' }, // Find equivalent did:webvh, since this might be a legacy alias
-      ],
+      did,
+      method: 'web',
     })
 
     if (didRecord?.didDocument) {
@@ -28,6 +35,23 @@ export class CachedWebDidResolver extends WebDidResolver {
         didDocument: didRecord.didDocument,
         didDocumentMetadata: {},
         didResolutionMetadata: {},
+      }
+    }
+
+    // Find equivalent did:webvh, since this might be a legacy alias
+    const webVhdDidRecord = await didRepository.findSingleByQuery(agentContext, {
+      domain: parsed.id,
+      method: 'webvh',
+    })
+
+    if (webVhdDidRecord?.didDocument) {
+      const legacyDidDocument = getLegacyDidDocument(webVhdDidRecord.didDocument, this.publicApiBaseUrl)
+      if (legacyDidDocument) {
+        return {
+          didDocument: legacyDidDocument,
+          didDocumentMetadata: {},
+          didResolutionMetadata: {},
+        }
       }
     }
 

--- a/apps/vs-agent/src/utils/VsAgent.ts
+++ b/apps/vs-agent/src/utils/VsAgent.ts
@@ -371,7 +371,10 @@ export const createVsAgent = (options: VsAgentOptions): VsAgent => {
         ],
       }),
       dids: new DidsModule({
-        resolvers: [new CachedWebDidResolver(), new WebvhDidResolver()],
+        resolvers: [
+          new CachedWebDidResolver({ publicApiBaseUrl: options.publicApiBaseUrl }),
+          new WebvhDidResolver(),
+        ],
         registrars: [new WebDidRegistrar(), new WebVhDidRegistrar()],
       }),
       mrtd: new DidCommMrtdModule({ masterListCscaLocation: options.masterListCscaLocation }),

--- a/apps/vs-agent/src/utils/legacyDidWeb.ts
+++ b/apps/vs-agent/src/utils/legacyDidWeb.ts
@@ -1,0 +1,44 @@
+import { DidDocument, parseDid, DidDocumentService, JsonTransformer } from '@credo-ts/core'
+
+/**
+ * Returns a Legacy did:web document, based on an input document. If it is already a did:web,
+ * it returns the same document.
+ * If it isn't supported (i.e. it is not a did:webvh DID Document), it returns undefined
+ * @param didDocument
+ * @param publicApiBaseUrl
+ * @returns
+ */
+export function getLegacyDidDocument(didDocument: DidDocument, publicApiBaseUrl: string) {
+  const parsedDid = parseDid(didDocument.id)
+
+  if (parsedDid.method === 'web') return didDocument
+
+  // In case of did:webvh, we'll need to add some steps to publish a did:web, as per
+  // https://identity.foundation/didwebvh/v1.0/#publishing-a-parallel-didweb-did
+  if (parsedDid.method === 'webvh' && parsedDid.id.includes(':')) {
+    const scid = parsedDid.id.split(':')[0]
+
+    // Start with resolved version of the DIDDoc from did:webvh
+    const legacyDidDocument = new DidDocument(didDocument)
+
+    // We add the legacy did:web AnonCreds service (important in case the agent had previously did:web objects)
+    legacyDidDocument.service = [
+      ...(legacyDidDocument.service ?? []),
+      new DidDocumentService({
+        id: `${didDocument.id}#anoncreds`,
+        serviceEndpoint: `${publicApiBaseUrl}/anoncreds/v1`,
+        type: 'AnonCredsRegistry',
+      }),
+    ]
+
+    // Execute text replacement: did:webvh:<scid> by did:web
+    const stringified = JSON.stringify(legacyDidDocument.toJSON())
+    const replaced = stringified.replace(new RegExp(`did:webvh:${scid}`, 'g'), 'did:web')
+
+    return new DidDocument({
+      ...JsonTransformer.fromJSON(JSON.parse(replaced), DidDocument),
+      // Update alsoKnownAs
+      alsoKnownAs: [parsedDid.did],
+    })
+  }
+}


### PR DESCRIPTION
When resolving did:web version of our did:webvh, we were returning the did:webvh DID Document instead of the legacy one, which was needed for agents resolving did:web AnonCreds objects to properly get the AnonCredsRegistry service.