### PR TITLE
fix: remove PUBLIC_API_BASE_URL constant on invitation url

### DIFF
--- a/apps/vs-agent/src/controllers/admin/agent/VsAgentController.ts
+++ b/apps/vs-agent/src/controllers/admin/agent/VsAgentController.ts
@@ -1,10 +1,9 @@
 import { Controller, Get } from '@nestjs/common'
 import { ApiTags, ApiOperation, ApiOkResponse, getSchemaPath, ApiExtraModels } from '@nestjs/swagger'
 
-
-
 import { VsAgentService } from '../../../services/VsAgentService'
 import { VsAgentInfoDto } from '../../agent/dto/vs-agent-info.dto'
+
 @ApiTags('agent')
 @ApiExtraModels(VsAgentInfoDto)
 @Controller({ path: 'agent', version: '1' })

--- a/apps/vs-agent/src/controllers/admin/connections/ConnectionController.ts
+++ b/apps/vs-agent/src/controllers/admin/connections/ConnectionController.ts
@@ -22,8 +22,8 @@ import {
   ApiExtraModels,
   getSchemaPath,
 } from '@nestjs/swagger'
-
 import { Response } from 'express'
+
 import { VsAgentService } from '../../../services/VsAgentService'
 import { ConnectionDto } from '../../connections/dto/connection.dto'
 

--- a/apps/vs-agent/src/controllers/admin/invitation/InvitationController.ts
+++ b/apps/vs-agent/src/controllers/admin/invitation/InvitationController.ts
@@ -4,7 +4,7 @@ import {
   CreateInvitationResult,
 } from '@2060.io/vs-agent-model'
 import { AnonCredsRequestedAttribute } from '@credo-ts/anoncreds'
-import { Controller, Get, Post, Body, Query } from '@nestjs/common'
+import { Controller, Get, Post, Body, Query, Inject } from '@nestjs/common'
 import {
   ApiBadRequestResponse,
   ApiBody,
@@ -14,7 +14,6 @@ import {
   ApiTags,
 } from '@nestjs/swagger'
 
-import { PUBLIC_API_BASE_URL } from '../../../config/constants'
 import { UrlShorteningService } from '../../../services/UrlShorteningService'
 import { VsAgentService } from '../../../services/VsAgentService'
 import { createInvitation } from '../../../utils/agent'
@@ -30,6 +29,7 @@ export class InvitationController {
   constructor(
     private readonly agentService: VsAgentService,
     private readonly urlShortenerService: UrlShorteningService,
+    @Inject('PUBLIC_API_BASE_URL') private readonly publicApiBaseUrl: string,
   ) {}
 
   @Get('/')
@@ -84,7 +84,7 @@ export class InvitationController {
       example: {
         proofExchangeId: '123e4567-e89b-12d3-a456-426614174000',
         url: 'didcomm://example.com/...',
-        shortUrl: `${PUBLIC_API_BASE_URL}/s?id=abcd1234`,
+        shortUrl: `https://mydomain.com/s?id=abcd1234`,
       },
     },
   })
@@ -162,7 +162,7 @@ export class InvitationController {
       longUrl: url,
       relatedFlowId: request.proofRecord.id,
     })
-    const shortUrl = `${PUBLIC_API_BASE_URL}/s?id=${shortUrlId}`
+    const shortUrl = `${this.publicApiBaseUrl}/s?id=${shortUrlId}`
 
     return {
       proofExchangeId: request.proofRecord.id,
@@ -198,7 +198,7 @@ export class InvitationController {
       example: {
         credentialExchangeId: 'abcd1234-5678efgh-9012ijkl-3456mnop',
         url: 'didcomm://example.com/offer/...',
-        shortUrl: `${PUBLIC_API_BASE_URL}/s?id=wxyz7890`,
+        shortUrl: `https://mydomain.com/s?id=wxyz7890`,
       },
     },
   })
@@ -276,7 +276,7 @@ export class InvitationController {
       longUrl: url,
       relatedFlowId: request.credentialRecord.id,
     })
-    const shortUrl = `${PUBLIC_API_BASE_URL}/s?id=${shortUrlId}`
+    const shortUrl = `${this.publicApiBaseUrl}/s?id=${shortUrlId}`
 
     return {
       credentialExchangeId: request.credentialRecord.id,

--- a/apps/vs-agent/src/controllers/admin/message/MessageController.ts
+++ b/apps/vs-agent/src/controllers/admin/message/MessageController.ts
@@ -1,24 +1,19 @@
-import { BaseMessage, MessageType } from '@2060.io/vs-agent-model'
+import { BaseMessage } from '@2060.io/vs-agent-model'
 import { DidExchangeState, utils } from '@credo-ts/core'
 import { Body, Controller, HttpException, HttpStatus, Logger, Post } from '@nestjs/common'
 import {
   ApiBody,
   ApiTags,
   ApiOkResponse,
-  ApiBadRequestResponse,
   ApiInternalServerErrorResponse,
   getSchemaPath,
-  ApiOperation,
-  ApiParam,
 } from '@nestjs/swagger'
 
 import { VsAgentService } from '../../../services/VsAgentService'
-
-import { MessageServiceFactory } from './services/MessageServiceFactory'
-
+import { VsAgent } from '../../../utils/VsAgent'
 import { BaseMessageDto } from '../../message/dto/base-message.dto'
 
-import { VsAgent } from '../../../utils/VsAgent'
+import { MessageServiceFactory } from './services/MessageServiceFactory'
 
 @ApiTags('message')
 @Controller({ path: 'message', version: '1' })

--- a/apps/vs-agent/src/controllers/admin/presentations/PresentationsController.ts
+++ b/apps/vs-agent/src/controllers/admin/presentations/PresentationsController.ts
@@ -10,18 +10,16 @@ import {
   NotFoundException,
   Param,
 } from '@nestjs/common'
-import { ApiTags } from '@nestjs/swagger'
-
-import { VsAgentService } from '../../../services/VsAgentService'
-
 import {
+  ApiTags,
   ApiOperation,
   ApiOkResponse,
   ApiNoContentResponse,
   ApiBadRequestResponse,
   ApiNotFoundResponse,
-  ApiInternalServerErrorResponse,
 } from '@nestjs/swagger'
+
+import { VsAgentService } from '../../../services/VsAgentService'
 import { PresentationDataDto } from '../../presentations/dto/presentation-data.dto'
 
 @ApiTags('presentations')

--- a/apps/vs-agent/src/controllers/connections/dto/connection.dto.ts
+++ b/apps/vs-agent/src/controllers/connections/dto/connection.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger'
 import { DidExchangeState } from '@credo-ts/core'
+import { ApiProperty } from '@nestjs/swagger'
 
 /**
  * Data Transfer Object for a Connection record.

--- a/apps/vs-agent/src/controllers/message/dto/base-message.dto.ts
+++ b/apps/vs-agent/src/controllers/message/dto/base-message.dto.ts
@@ -1,7 +1,7 @@
 // src/modules/message/dto/base-message.dto.ts
 
-import { ApiProperty, ApiPropertyOptional, ApiHideProperty } from '@nestjs/swagger'
 import { BaseMessage, MessageType } from '@2060.io/vs-agent-model'
+import { ApiProperty, ApiPropertyOptional, ApiHideProperty } from '@nestjs/swagger'
 
 export class BaseMessageDto extends BaseMessage {
   @ApiProperty({

--- a/apps/vs-agent/src/controllers/presentations/dto/presentation-data.dto.ts
+++ b/apps/vs-agent/src/controllers/presentations/dto/presentation-data.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger'
 import { RequestedCredential, Claim } from '@2060.io/vs-agent-model'
+import { ApiProperty } from '@nestjs/swagger'
 
 export class PresentationDataDto {
   @ApiProperty({


### PR DESCRIPTION
Important!!
Bug detected - When the VS Agent controller creates a new invitation, the agent uses the PUBLIC_API_BASE_URL and ignores the controls on the main method, which is why the URL has been undefined, and the QR code can't be resolved.