### PR TITLE
fix: credential key generation logic and improve naming clarity

### DIFF
--- a/apps/vs-agent/src/controllers/admin/verifiable/TrustService.ts
+++ b/apps/vs-agent/src/controllers/admin/verifiable/TrustService.ts
@@ -206,7 +206,11 @@ export class TrustService {
   ) {
     const unsignedCredential = createCredential({
       id: did,
-      type: ['VerifiableCredential', 'VerifiableTrustCredential'],
+      type: [
+        'VerifiableCredential',
+        'VerifiableTrustCredential',
+        this.buildCredentialKey(jsonSchemaCredential),
+      ],
       issuer: agent.did,
       credentialSubject: {
         id: did,
@@ -414,5 +418,29 @@ export class TrustService {
       throw new HttpException(`Missing credentialSubject.id in credential`, HttpStatus.BAD_REQUEST)
     }
     return id
+  }
+
+  /**
+   * Derives a standardized credential type key from a JSON Schema file URL or path.
+   * Examples:
+   *  - "https://example.com/schemas-person-identity.json" → "PersonIdentityCredential"
+   *
+   * @param schemaUrl - The URL or local path of the JSON schema file.
+   * @todo Review whether this approach is the best way to derive and store keys
+   *       for GenericRecord entities. Consider future schema naming conventions
+   *       or other potential conflicts.
+   */
+  private buildCredentialKey(schemaUrl: string): string {
+    if (!schemaUrl) {
+      throw new Error('Schema URL or path cannot be empty')
+    }
+    const fileName = schemaUrl.split('/').pop() ?? ''
+    const baseName = fileName
+      .replace(/^schemas[-_]?/, '')
+      .replace(/\jsc.json$/i, '')
+      .trim()
+    const words = baseName.split(/[-_]/).filter(Boolean)
+    const pascalCaseName = words.map(word => word.charAt(0).toUpperCase() + word.slice(1)).join('')
+    return `${pascalCaseName}Credential`
   }
 }


### PR DESCRIPTION
This PR refactors the credential key generation method to improve naming clarity, validation, and documentation, while adding a `@todo` to review whether this is the best approach for storing keys in `GenericRecord`. It also removes the destructuring statement `const { proof: _proof, ...rest } = (didRecord.metadata.get(id) as W3cJsonLdVerifiableCredential) ?? null` to prevent runtime errors when the value is null or undefined.