### PR TITLE
fix: add support to legacy Ed25519VerificationKey2018

### DIFF
--- a/apps/vs-agent/src/utils/setupSelfTr.ts
+++ b/apps/vs-agent/src/utils/setupSelfTr.ts
@@ -511,7 +511,7 @@ export function getVerificationMethodId(didRecord: DidRecord): string {
   try {
     const verificationMethod = didRecord.didDocument?.verificationMethod?.find(
       method =>
-        method.type === 'Ed25519VerificationKey2020' &&
+        (method.type === 'Ed25519VerificationKey2020' || method.type === 'Ed25519VerificationKey2018') &&
         method.id === didRecord.didDocument?.assertionMethod?.[0],
     )
     if (!verificationMethod) {


### PR DESCRIPTION
@genaris I have a question here. This is required to sign credentials and presentations for JSON-LD.
The other option would be to reload the DID, but I prefer allowing legacy signatures.
Credo’s verifier validation supports both key types by default.