### PR TITLE
ci: implement dev deployment for vs agent chart

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -121,11 +121,18 @@ jobs:
       - name: Push Helm chart to Docker Hub OCI repo
         if: steps.semantic.outputs.new-release-published == 'true'
         run: |
-          sed -i "s/^version:.*/version: v$RELEASE_VERSION/" ./charts/vs-agent/Chart.yaml
-          CHART_NAME=$(grep '^name:' ./charts/vs-agent/Chart.yaml | awk '{print $2}')
-          helm dependency update ./charts/vs-agent
-          helm package ./charts/vs-agent -d ./charts
-          helm push ./charts/${CHART_NAME}-v$RELEASE_VERSION.tgz oci://docker.io/$DH_USERNAME
+          TAGS=(
+            "v${RELEASE_MAJOR}.${RELEASE_MINOR}.${RELEASE_PATCH:0:1}-${IMAGE_TAG}"
+            "v${RELEASE_VERSION}"
+          )
+          for tag in "${TAGS[@]}"; do
+            docker push $DH_USERNAME/$IMAGE_NAME:$tag
+            sed -i "s/^version:.*/version: $tag/" ./charts/vs-agent/Chart.yaml
+            CHART_NAME=$(grep '^name:' ./charts/vs-agent/Chart.yaml | awk '{print $2}')
+            helm dependency update ./charts/vs-agent
+            helm package ./charts/vs-agent -d ./charts
+            helm push ./charts/${CHART_NAME}-$tag.tgz oci://docker.io/$DH_USERNAME
+          done
 
       - name: Push Helm chart Chatbot Demo to Docker Hub OCI repo
         if: steps.semantic.outputs.new-release-published == 'true'


### PR DESCRIPTION
Hey @genaris, during the recent test deployment in our sandbox environment, we didn’t encounter any issues using a dev version.
In this PR, I’m introducing this feature specifically for testing the vs-agent chart only. I’m not sure if applying it to other services would be a good idea, so I prefer to update only this chart with this approach.