### PR TITLE
fix: use vpr:verana:vna-testnet in place api

### DIFF
--- a/apps/vs-agent/src/controllers/admin/verifiable/TrustController.ts
+++ b/apps/vs-agent/src/controllers/admin/verifiable/TrustController.ts
@@ -124,7 +124,7 @@ export class TrustController {
         summary: 'JsonSchemaCredential Example',
         value: {
           schemaId: 'example-service',
-          jsonSchemaRef: 'vpr:verana:mainnet/cs/v1/js/12345678',
+          jsonSchemaRef: 'vpr:verana:vna-testnet-1/cs/v1/js/12345678',
         },
       },
     },

--- a/apps/vs-agent/src/controllers/admin/verifiable/TrustService.ts
+++ b/apps/vs-agent/src/controllers/admin/verifiable/TrustService.ts
@@ -153,7 +153,7 @@ export class TrustService {
     try {
       const { agent, didRecord } = await this.getDidRecord()
       const savedCredential = didRecord.metadata.get(id)
-      const { id: subjectId, claims } = createJsonSubjectRef(mapToEcosystem(jsonSchemaRef))
+      const { id: subjectId, claims } = createJsonSubjectRef(jsonSchemaRef)
       const credentialSubject = {
         id: subjectId,
         claims: await addDigestSRI(subjectId, claims, this.ecsSchemas),

--- a/apps/vs-agent/src/controllers/admin/verifiable/dto/json-schema-credential.dto.ts
+++ b/apps/vs-agent/src/controllers/admin/verifiable/dto/json-schema-credential.dto.ts
@@ -22,7 +22,7 @@ export class JsonSchemaCredentialDto {
       'URL to the JSON Schema definition. ' +
       'If omitted, it will be treated as a self essential schema (' +
       '`schemas-example-service.json`).',
-    example: 'vpr:verana:mainnet/cs/v1/js/12345678',
+    example: 'vpr:verana:vna-testnet-1/cs/v1/js/12345678',
   })
   @IsString()
   @Matches(/^(https?:\/\/[^\s]+|vpr:[^\s]+)$/i, {

--- a/apps/vs-agent/src/utils/setupSelfTr.ts
+++ b/apps/vs-agent/src/utils/setupSelfTr.ts
@@ -436,7 +436,7 @@ export async function addDigestSRI<T extends object>(
   if (!id || !data) {
     throw new Error(`id and data has requiered`)
   }
-  const response = await fetch(id)
+  const response = await fetch(mapToEcosystem(id))
   const key = id.split('/').pop()
   const fallbackSchema = key && ecsSchemas?.[key]
 

--- a/examples/chatbot/.gitignore
+++ b/examples/chatbot/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+build
+.yalc
+*.txn
+logs.txt
+examples/**/afj
+tails/
+.env


### PR DESCRIPTION
This update is necessary because the JSON schema credential currently uses `api.network` instead of `vpr:verana:vna-testnet-1`. However, according to the [specification](https://verana-labs.github.io/verifiable-trust-spec/#json-schema-credentials), the `vpr`, `vs-agent`, and `verre` components must handle the resolution process. Currently, `verre` supports verification through public registries, which must be specified in the options.