### PR TITLE
fix: update structure on credentials

### DIFF
--- a/apps/vs-agent/src/controllers/admin/verifiable/TrustService.ts
+++ b/apps/vs-agent/src/controllers/admin/verifiable/TrustService.ts
@@ -492,7 +492,7 @@ export class TrustService {
 
     const record = didRecord.metadata.get(key) ?? {}
     record[ref] = {
-      credential,
+      credential: credential.jsonCredential,
       verifiablePresentation,
       didDocumentServiceId,
     }


### PR DESCRIPTION
Currently, the `credentialSubject` field in the credentials is being generated like this:

```json
"credentialSubject": {
  "claims": {
    "type": "JsonSchema",
    "jsonSchema": {
      "$ref": "vpr:verana:vna-testnet-1/cs/v1/js/14"
    },
    "digestSRI": "sha256-/ogA15GhhATGkeNqtZSxYbN6H1mlhpUaJJfhs0Hyl0E="
  }
}
```

However, it should be generated with the following structure instead:

```json
"credentialSubject": {
  "type": "JsonSchema",
  "jsonSchema": {
    "$ref": "vpr:verana:vna-testnet-1/cs/v1/js/14"
  },
  "digestSRI": "sha256-/ogA15GhhATGkeNqtZSxYbN6H1mlhpUaJJfhs0Hyl0E="
}
```
