### PR TITLE
fix: DID Update Flow to Conditionally Refresh Services and Remove Legacy Verification Methods

### DIFF
--- a/apps/vs-agent/src/utils/VsAgent.ts
+++ b/apps/vs-agent/src/utils/VsAgent.ts
@@ -251,7 +251,6 @@ export class VsAgent extends Agent<VsAgentModules> {
       didDocument.authentication = (didDocument.authentication ?? []).filter(id => id !== legacyAuthId)
       didDocument.assertionMethod = (didDocument.assertionMethod ?? []).filter(id => id !== legacyAuthId)
     }
-
     const filteredMethods = (didDocument.verificationMethod ?? []).filter(
       vm => !['Ed25519VerificationKey2018', 'X25519KeyAgreementKey2019'].includes(vm.type),
     )


### PR DESCRIPTION
This update separates the DID update workflow to avoid unnecessary regeneration of services and verification methods.
Now, this.getDidCommServices(didDocument.id) is refreshed only when required, and legacy methods (Ed25519VerificationKey2018, X25519KeyAgreementKey2019) are removed.
This prevents duplicate verification methods (VM) from being created when both legacy and modern methods are handled simultaneously.