### PR TITLE
fix: allow querying anoncreds resources by object type

### DIFF
--- a/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeController.ts
+++ b/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeController.ts
@@ -467,7 +467,11 @@ export class CredentialTypesController {
       )
 
       // save registration metadata for webvh
-      const revocationRecord = await this.service.saveAttestedResource(agent, revocationRegistration)
+      const revocationRecord = await this.service.saveAttestedResource(
+        agent,
+        revocationRegistration,
+        'anonCredsRevocRegDef',
+      )
 
       const { revocationStatusListState, registrationMetadata: revListMetadata } =
         await agent.modules.anoncreds.registerRevocationStatusList({
@@ -509,7 +513,7 @@ export class CredentialTypesController {
             ],
           },
         )
-        await this.service.saveAttestedResource(agent, statusRegistration)
+        await this.service.saveAttestedResource(agent, statusRegistration, 'anonCredsStatusList')
 
         revocationRecord.content = registrationMetadata
         await agent.genericRecords.update(revocationRecord)

--- a/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeService.ts
+++ b/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeService.ts
@@ -16,12 +16,16 @@ export class CredentialTypesService {
 
   constructor(private readonly agentService: VsAgentService) {}
 
-  public async saveAttestedResource(agent: VsAgent, resource: Record<string, unknown>) {
+  public async saveAttestedResource(agent: VsAgent, resource: Record<string, unknown>, resourceType: string) {
     if (!resource) return
     return await agent.genericRecords.save({
       id: utils.uuid(),
       content: resource,
-      tags: { attestedResourceId: resource.id as string, type: 'AttestedResource' },
+      tags: {
+        attestedResourceId: resource.id as string,
+        type: 'AttestedResource',
+        resourceType,
+      },
     })
   }
 
@@ -77,7 +81,7 @@ export class CredentialTypesService {
       if (!schemaId || !schema) {
         throw new Error('Schema for the credential definition could not be created')
       }
-      await this.saveAttestedResource(agent, schemaRegistration)
+      await this.saveAttestedResource(agent, schemaRegistration, 'anonCredsSchema')
     }
     return { issuerId, schemaId, schema }
   }
@@ -129,7 +133,7 @@ export class CredentialTypesService {
     if (jsonSchemaCredential)
       credentialDefinitionRecord.setTag('relatedJsonSchemaCredential', jsonSchemaCredential)
 
-    await this.saveAttestedResource(agent, credentialRegistration)
+    await this.saveAttestedResource(agent, credentialRegistration, 'anonCredsCredDef')
     await credentialDefinitionRepository.update(agent.context, credentialDefinitionRecord)
     return { credentialDefinitionId }
   }


### PR DESCRIPTION
**Changes:**
* Updated the `saveAttestedResource` method to allow including `resourceType` in `genericRecords`.
* Updated the delete control to use an API query parameter for stronger security, since passing the ID as a path parameter was causing issues.

Hey @genaris, I prefer using `resourceType` values like `anonCredsSchema`, `anonCredsCredDef`, `anonCredsRevocRegDef`, and `anonCredsStatusList` as the metadata resource type registries based on [examples](https://github.com/openwallet-foundation/credo-ts/blob/main/packages/webvh/src/anoncreds/services/__tests__/mock-resources.ts).