### PR TITLE
fix(VTC): refactor update object with post method

### DIFF
--- a/apps/vs-agent/src/controllers/admin/agent/VsAgentController.ts
+++ b/apps/vs-agent/src/controllers/admin/agent/VsAgentController.ts
@@ -55,7 +55,7 @@ export class VsAgentController {
   })
   @ApiQuery({
     name: 'schemaId',
-    required: true,
+    required: false,
     type: String,
     description:
       'The identifier of the stored credential schema. This ID specifies which Verifiable Credential schema should be used to generate or retrieve the corresponding Verifiable Trust Credential (VTC).',


### PR DESCRIPTION
**Changes:**
- Previously in VTC api, when trying to update objects didn't replace correctly; this has been fixed.
- Allowed the get VTC method without schemaId to getAll().