### PR TITLE
fix: references to veranalabs in DockerHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ VS Agent is a web application that can be used as a framework for building conve
 The easiest way to get started with VS Agent is by using Docker. Pull the image from Docker Hub:
 
 ```
-docker pull verana-labs/vs-agent
+docker pull veranalabs/vs-agent
 ```
 
 Or build it directly from this repo:
@@ -30,7 +30,7 @@ docker build -t vs-agent:dev -f ./apps/vs-agent/Dockerfile .
 Then, you can just run it. Don't forget to set the environment variables as required! See [VS Agent Configuration](./apps/vs-agent/README.md#configuration) for a detailed description:
 
 ```
-docker run --env-file ./env-vars verana-labs/vs-agent
+docker run --env-file ./env-vars veranalabs/vs-agent
 ```
 
 Once your VS Agent is up and running, you can manage it from your backend basically in three different ways

--- a/charts/chatbot/Chart.yaml
+++ b/charts/chatbot/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 name: vs-agent-demo-chatbot-vs-chart
-description: Helm chart for deploying a demo chatbot to validate new functionalities of VS-Agent.
+description: Helm chart for deploying a demo chatbot to validate new functionalities of VS Agent.
 type: application
 version: 0.0.1
 appVersion: 1.0.0
 dependencies:
   - name: vs-agent-chart
     version: 0.0.1
-    repository: oci://registry-1.docker.io/verana-labs
+    repository: oci://registry-1.docker.io/veranalabs
     condition: vs-agent-chart.enabled

--- a/charts/chatbot/templates/deployment.yaml
+++ b/charts/chatbot/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
       spec:
          containers:
          -  name: {{ .Values.name }}-backend-container
-            image: verana-labs/vs-agent-demo-chatbot-backend:{{ .Chart.Version }}
+            image: veranalabs/vs-agent-demo-chatbot-backend:{{ .Chart.Version }}
             imagePullPolicy: Always
             env:
             # Base URL for the Agent Admin API

--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -174,7 +174,7 @@ spec:
       spec:
          containers:
          -  name: {{ .Values.name }}-sa-container
-            image: verana-labs/vs-agent:{{ .Chart.Version }}
+            image: veranalabs/vs-agent:{{ .Chart.Version }}
             imagePullPolicy: Always
             env:
             - name: AGENT_LABEL


### PR DESCRIPTION
Some more fixes in the naming (in DockerHub it is veranalabs instead of verana-labs)