### PR TITLE
fix: credential types based on JSON Schema credentials

### DIFF
--- a/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeDto.ts
+++ b/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeDto.ts
@@ -22,7 +22,9 @@ export class CreateCredentialTypeDto {
     description: 'Schema attributes',
     example: `['name', 'age']`,
   })
-  attributes!: string[]
+  @IsOptional()
+  @IsNotEmpty()
+  attributes?: string[]
 
   @ApiProperty({
     description:


### PR DESCRIPTION
Although a very good refactoring is needed here to avoid code duplication, this fix makes Credential Type creation based on `relatedJsonSchemaCredentialId` work.

It's important to get working examples in https://docs.verana.io/docs/next/use/verifiable-service-builders/issuing-and-verifying-credentials 