### PR TITLE
fix: scaped json schema

### DIFF
--- a/apps/vs-agent/src/controllers/public/self-tr/SelfTrController.ts
+++ b/apps/vs-agent/src/controllers/public/self-tr/SelfTrController.ts
@@ -52,7 +52,7 @@ export class SelfTrController {
       }
       const ecsSchema = this.ecsSchemas[schemaId]
       return {
-        schema: JSON.stringify(ecsSchema),
+        schema: ecsSchema,
       }
     } catch (error) {
       this.logger.error(`Error loading schema file: ${error.message}`)


### PR DESCRIPTION
Updated the scaped JSON schema. This is now the response.
```
{
  "schema": {
    "$id": "https://p2801.ovpndev.mobiera.io/vt/cs/v1/js/ecs-service",
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "title": "ServiceCredential",
    "description": "ServiceCredential using JsonSchema",
    "type": "object",
    "properties": {
      "credentialSubject": {
        "type": "object",
        "properties": {
          "id": {
            "type": "string",
            "format": "uri"
          },
          "name": {
            "type": "string",
            "minLength": 1,
            "maxLength": 512
          },
          "type": {
            "type": "string",
            "minLength": 1,
            "maxLength": 128
          },
          "description": {
            "type": "string",
            "minLength": 0,
            "maxLength": 4096
          },
          "logo": {
            "type": "string",
            "contentEncoding": "base64",
            "contentMediaType": "image/png"
          },
          "minimumAgeRequired": {
            "type": "number",
            "minimum": 0,
            "exclusiveMaximum": 150
          },
          "termsAndConditions": {
            "type": "string",
            "format": "uri",
            "maxLength": 2048
          },
          "termsAndConditionsHash": {
            "type": "string"
          },
          "privacyPolicy": {
            "type": "string",
            "format": "uri",
            "maxLength": 2048
          },
          "privacyPolicyHash": {
            "type": "string"
          }
        },
        "required": [
          "id",
          "name",
          "type",
          "description",
          "logo",
          "minimumAgeRequired",
          "termsAndConditions",
          "privacyPolicy"
        ]
      }
    }
  }
}
```