### PR TITLE
fix: add sync with main version

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - run: corepack enable
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
**Changes**
Currently, our deployment shows the VS Agent version based on the package.json file, and this could generate a misunderstanding.
