### PR TITLE
fix: upgrade chatbot demo base image

### DIFF
--- a/examples/chatbot/Dockerfile
+++ b/examples/chatbot/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as base
+FROM node:22 as base
 
 # Setup pnpm version
 RUN corepack enable

--- a/examples/chatbot/docker-compose.yml
+++ b/examples/chatbot/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   vs-agent:
     build: 

--- a/examples/verifier/Dockerfile
+++ b/examples/verifier/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 as base
+FROM node:22 as base
 
 # Setup pnpm version
 RUN corepack enable


### PR DESCRIPTION
**Changes**
- By ESM compatibility, the chatbot demo required Node 20 at least
