### PR TITLE
fix: digestSRI calculation

### DIFF
--- a/apps/vs-agent/src/controllers/public/self-tr/SelfTrController.ts
+++ b/apps/vs-agent/src/controllers/public/self-tr/SelfTrController.ts
@@ -50,10 +50,8 @@ export class SelfTrController {
       if (!schemaId) {
         throw new HttpException('Schema not found', HttpStatus.NOT_FOUND)
       }
-      const ecsSchema = this.ecsSchemas[schemaId]
-      return {
-        schema: ecsSchema,
-      }
+      return this.ecsSchemas[schemaId]
+      
     } catch (error) {
       this.logger.error(`Error loading schema file: ${error.message}`)
       throw new HttpException('Failed to load schema', HttpStatus.INTERNAL_SERVER_ERROR)

--- a/apps/vs-agent/src/utils/data.ts
+++ b/apps/vs-agent/src/utils/data.ts
@@ -1,238 +1,254 @@
-import { AnySchemaObject } from 'ajv'
-
-export function getEcsSchemas(publicApiBaseUrl: string): AnySchemaObject {
+export function getEcsSchemas(publicApiBaseUrl: string): Record<string, string> {
   return {
-    'ecs-org': {
-      $id: `${publicApiBaseUrl}/vt/cs/v1/js/ecs-org`,
-      $schema: 'https://json-schema.org/draft/2020-12/schema',
-      title: 'OrganizationCredential',
-      description: 'OrganizationCredential using JsonSchema',
-      type: 'object',
-      properties: {
-        credentialSubject: {
-          type: 'object',
-          properties: {
-            id: {
-              type: 'string',
-              format: 'uri',
-            },
-            name: {
-              type: 'string',
-              minLength: 0,
-              maxLength: 256,
-            },
-            logo: {
-              type: 'string',
-              contentEncoding: 'base64',
-              contentMediaType: 'image/png',
-            },
-            registryId: {
-              type: 'string',
-              minLength: 0,
-              maxLength: 256,
-            },
-            registryUrl: {
-              type: 'string',
-              minLength: 0,
-              maxLength: 256,
-            },
-            address: {
-              type: 'string',
-              minLength: 0,
-              maxLength: 1024,
-            },
-            type: {
-              type: 'string',
-              enum: ['PUBLIC', 'PRIVATE', 'FOUNDATION'],
-            },
-            countryCode: {
-              type: 'string',
-              minLength: 2,
-              maxLength: 2,
-            },
-          },
-          required: ['id', 'name', 'logo', 'registryId', 'registryUrl', 'address', 'type', 'countryCode'],
+    'ecs-org': `{
+  "$id": "${publicApiBaseUrl}/vt/cs/v1/js/ecs-org",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OrganizationCredential",
+  "description": "OrganizationCredential using JsonSchema",
+  "type": "object",
+  "properties": {
+    "credentialSubject": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri"
         },
-      },
-    },
-    'ecs-person': {
-      $id: `${publicApiBaseUrl}/vt/cs/v1/js/ecs-person`,
-      $schema: 'https://json-schema.org/draft/2020-12/schema',
-      title: 'PersonCredential',
-      description: 'PersonCredential using JsonSchema',
-      type: 'object',
-      properties: {
-        credentialSubject: {
-          type: 'object',
-          properties: {
-            id: {
-              type: 'string',
-              format: 'uri',
-            },
-            firstName: {
-              type: 'string',
-              minLength: 0,
-              maxLength: 256,
-            },
-            lastName: {
-              type: 'string',
-              minLength: 1,
-              maxLength: 256,
-            },
-            avatar: {
-              type: 'string',
-              contentEncoding: 'base64',
-              contentMediaType: 'image/png',
-            },
-            birthDate: {
-              type: 'string',
-              format: 'date',
-            },
-            countryOfResidence: {
-              type: 'string',
-              minLength: 2,
-              maxLength: 2,
-            },
-          },
-          required: ['id', 'lastName', 'birthDate', 'countryOfResidence'],
+        "name": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 256
         },
-      },
-    },
-    'ecs-service': {
-      $id: `${publicApiBaseUrl}/vt/cs/v1/js/ecs-service`,
-      $schema: 'https://json-schema.org/draft/2020-12/schema',
-      title: 'ServiceCredential',
-      description: 'ServiceCredential using JsonSchema',
-      type: 'object',
-      properties: {
-        credentialSubject: {
-          type: 'object',
-          properties: {
-            id: {
-              type: 'string',
-              format: 'uri',
-            },
-            name: {
-              type: 'string',
-              minLength: 1,
-              maxLength: 512,
-            },
-            type: {
-              type: 'string',
-              minLength: 1,
-              maxLength: 128,
-            },
-            description: {
-              type: 'string',
-              minLength: 0,
-              maxLength: 4096,
-            },
-            logo: {
-              type: 'string',
-              contentEncoding: 'base64',
-              contentMediaType: 'image/png',
-            },
-            minimumAgeRequired: {
-              type: 'number',
-              minimum: 0,
-              exclusiveMaximum: 150,
-            },
-            termsAndConditions: {
-              type: 'string',
-              format: 'uri',
-              maxLength: 2048,
-            },
-            termsAndConditionsHash: {
-              type: 'string',
-            },
-            privacyPolicy: {
-              type: 'string',
-              format: 'uri',
-              maxLength: 2048,
-            },
-            privacyPolicyHash: {
-              type: 'string',
-            },
-          },
-          required: [
-            'id',
-            'name',
-            'type',
-            'description',
-            'logo',
-            'minimumAgeRequired',
-            'termsAndConditions',
-            'privacyPolicy',
-          ],
+        "logo": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "contentMediaType": "image/png"
         },
-      },
-    },
-    'ecs-user-agent': {
-      $id: `${publicApiBaseUrl}/vt/cs/v1/js/ecs-user-agent`,
-      $schema: 'https://json-schema.org/draft/2020-12/schema',
-      title: 'UserAgentCredential',
-      description: 'UserAgentCredential using JsonSchema',
-      type: 'object',
-      properties: {
-        credentialSubject: {
-          type: 'object',
-          properties: {
-            id: {
-              type: 'string',
-              format: 'uri',
-            },
-            name: {
-              type: 'string',
-              minLength: 1,
-              maxLength: 512,
-            },
-            description: {
-              type: 'string',
-              minLength: 0,
-              maxLength: 4096,
-            },
-            category: {
-              type: 'string',
-              minLength: 1,
-              maxLength: 128,
-            },
-            logo: {
-              type: 'string',
-              contentEncoding: 'base64',
-              contentMediaType: 'image/png',
-            },
-            wallet: {
-              type: 'boolean',
-            },
-            termsAndConditions: {
-              type: 'string',
-              format: 'uri',
-              maxLength: 2048,
-            },
-            termsAndConditionsHash: {
-              type: 'string',
-            },
-            privacyPolicy: {
-              type: 'string',
-              format: 'uri',
-              maxLength: 2048,
-            },
-            privacyPolicyHash: {
-              type: 'string',
-            },
-          },
-          required: [
-            'id',
-            'name',
-            'description',
-            'category',
-            'logo',
-            'wallet',
-            'termsAndConditions',
-            'privacyPolicy',
-          ],
+        "registryId": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 256
         },
+        "registryUrl": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 256
+        },
+        "address": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 1024
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "PUBLIC",
+            "PRIVATE",
+            "FOUNDATION"
+          ]
+        },
+        "countryCode": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 2
+        }
       },
-    },
+      "required": [
+        "id",
+        "name",
+        "logo",
+        "registryId",
+        "registryUrl",
+        "address",
+        "type",
+        "countryCode"
+      ]
+    }
+  }
+}`,
+    'ecs-person': `{
+  "$id": "${publicApiBaseUrl}/vt/cs/v1/js/ecs-person",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PersonCredential",
+  "description": "PersonCredential using JsonSchema",
+  "type": "object",
+  "properties": {
+    "credentialSubject": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "firstName": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 256
+        },
+        "lastName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "avatar": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "contentMediaType": "image/png"
+        },
+        "birthDate": {
+          "type": "string",
+          "format": "date"
+        },
+        "countryOfResidence": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 2
+        }
+      },
+      "required": [
+        "id",
+        "lastName",
+        "birthDate",
+        "countryOfResidence"
+      ]
+    }
+  }
+}`,
+    'ecs-service': `{
+  "$id": "${publicApiBaseUrl}/vt/cs/v1/js/ecs-service",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ServiceCredential",
+  "description": "ServiceCredential using JsonSchema",
+  "type": "object",
+  "properties": {
+    "credentialSubject": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "type": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "description": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 4096
+        },
+        "logo": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "contentMediaType": "image/png"
+        },
+        "minimumAgeRequired": {
+          "type": "number",
+          "minimum": 0,
+          "exclusiveMaximum": 150
+        },
+        "termsAndConditions": {
+          "type": "string",
+          "format": "uri",
+          "maxLength": 2048
+        },
+        "termsAndConditionsHash": {
+          "type": "string"
+        },
+        "privacyPolicy": {
+          "type": "string",
+          "format": "uri",
+          "maxLength": 2048
+        },
+        "privacyPolicyHash": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "type",
+        "description",
+        "logo",
+        "minimumAgeRequired",
+        "termsAndConditions",
+        "privacyPolicy"
+      ]
+    }
+  }
+}`,
+    'ecs-user-agent': `{
+  "$id": "${publicApiBaseUrl}/vt/cs/v1/js/ecs-user-agent",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "UserAgentCredential",
+  "description": "UserAgentCredential using JsonSchema",
+  "type": "object",
+  "properties": {
+    "credentialSubject": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uri"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "description": {
+          "type": "string",
+          "minLength": 0,
+          "maxLength": 4096
+        },
+        "category": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "logo": {
+          "type": "string",
+          "contentEncoding": "base64",
+          "contentMediaType": "image/png"
+        },
+        "wallet": {
+          "type": "boolean"
+        },
+        "termsAndConditions": {
+          "type": "string",
+          "format": "uri",
+          "maxLength": 2048
+        },
+        "termsAndConditionsHash": {
+          "type": "string"
+        },
+        "privacyPolicy": {
+          "type": "string",
+          "format": "uri",
+          "maxLength": 2048
+        },
+        "privacyPolicyHash": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "description",
+        "category",
+        "logo",
+        "wallet",
+        "termsAndConditions",
+        "privacyPolicy"
+      ]
+    }
+  }
+}`,
   }
 }


### PR DESCRIPTION
Performs calculation of digest SRI based on bytes, and not JSON object representation.

This also updates the rendering of ECS schemas when running in self-tr mode: it no longers adds the { schema: "content" } wrapping.

Note that this is a breaking change! Before releasing a stable release with this change, we need to make sure that at least Verana Indexer, Verre and Hologram App are ready to be released in stable/production mode.