### PR TITLE
fix: speed-up docker image startup

### DIFF
--- a/apps/vs-agent/Dockerfile
+++ b/apps/vs-agent/Dockerfile
@@ -34,4 +34,4 @@ COPY apps/vs-agent/nest-cli.json apps/vs-agent/nest-cli.json
 
 
 RUN pnpm build
-CMD ["pnpm", "start"]
+CMD ["pnpm", "--filter", "@verana-labs/vs-agent", "start:prod"]

--- a/apps/vs-agent/package.json
+++ b/apps/vs-agent/package.json
@@ -50,7 +50,7 @@
     "start": "nest start",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node build/src/main",
     "version": "pnpm version --allow-same-version",
     "test": "vitest"
   },

--- a/apps/vs-agent/src/events/ConnectionEvents.ts
+++ b/apps/vs-agent/src/events/ConnectionEvents.ts
@@ -19,7 +19,7 @@ import { sendWebhookEvent } from './WebhookEvent'
 export const connectionEvents = async (agent: VsAgent, config: ServerConfig) => {
   // Get the first record matching agent's DID and obtain all alternatives for it
   const [agentPublicDidRecord] = await agent.dids.getCreatedDids({ did: agent.did })
-  const alternativeDids = agentPublicDidRecord.getTag('alternativeDids')
+  const alternativeDids = agentPublicDidRecord?.getTag('alternativeDids')
   const agentPublicDids = [agent.did, ...(Array.isArray(alternativeDids) ? alternativeDids : [])]
 
   agent.events.on(


### PR DESCRIPTION
`pnpm start` was calling `nest start`, which made a TypeScript JIT compilation at runtime. The Dockerfile already runs pnpm build, so there's no reason to recompile on every container start. 

`nest start` was taking around 200MB only for this recompilation process, making the container to spend more memory only because of this startup. It also took some seconds instead of miliseconds to start.

