### PR TITLE
fix: speed-up nest module loading

### DIFF
--- a/apps/vs-agent/src/admin.module.ts
+++ b/apps/vs-agent/src/admin.module.ts
@@ -25,6 +25,7 @@ import { VsAgent } from './utils'
 @Module({})
 export class VsAgentModule {
   static register(agent: VsAgent, publicApiBaseUrl: string): DynamicModule {
+    const agentRef = { get: () => agent, toJSON: () => 'VsAgent' }
     return {
       module: VsAgentModule,
       imports: [HandledRedisModule.forRoot()],
@@ -42,11 +43,11 @@ export class VsAgentModule {
       providers: [
         {
           provide: 'VSAGENT',
-          useValue: agent,
+          useFactory: () => agentRef.get(),
         },
         {
           provide: 'PUBLIC_API_BASE_URL',
-          useValue: publicApiBaseUrl,
+          useFactory: () => publicApiBaseUrl,
         },
         VsAgentService,
         UrlShorteningService,

--- a/apps/vs-agent/src/public.module.ts
+++ b/apps/vs-agent/src/public.module.ts
@@ -14,6 +14,7 @@ import { VsAgent } from './utils'
 @Module({})
 export class PublicModule {
   static register(agent: VsAgent, publicApiBaseUrl: string): DynamicModule {
+    const agentRef = { get: () => agent, toJSON: () => 'VsAgent' }
     return {
       module: PublicModule,
       imports: [],
@@ -21,11 +22,11 @@ export class PublicModule {
       providers: [
         {
           provide: 'VSAGENT',
-          useValue: agent,
+          useFactory: () => agentRef.get(),
         },
         {
           provide: 'PUBLIC_API_BASE_URL',
-          useValue: publicApiBaseUrl,
+          useFactory: () => publicApiBaseUrl,
         },
         VsAgentService,
         TrustService,


### PR DESCRIPTION
Getting rid of the warnings we have at startup when loading VsAgentModule:

>WARN [ModuleTokenFactory] The module "VsAgentModule" is taking 90.74ms to serialize, this may be caused by larger objects statically assigned to the module. More details: https://github.com/nestjs/nest/issues/12738 +93ms

And the same for PublicModule:

>WARN [ModuleTokenFactory] The module "PublicModule" is taking 85.50ms to serialize, this may be caused by larger objects statically assigned to the module. More details: https://github.com/nestjs/nest/issues/12738 +86ms

With the wrapping done on this PR, app startup is faster and we don't have these warnings anymore.
