### PR TITLE
feat: reduce examples image sizes

### DIFF
--- a/examples/chatbot/Dockerfile
+++ b/examples/chatbot/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:22 as base
+FROM node:22.19-alpine AS build
 
-# Setup pnpm version
-RUN corepack enable
+ENV COREPACK_INTEGRITY_KEYS=0
 
-# AFJ specifc setup
+RUN apk add --no-cache python3 make g++ && \
+    corepack enable && \
+    corepack prepare pnpm@9.15.3 --activate
+
 WORKDIR /www
 ENV RUN_MODE="docker"
 
@@ -12,33 +14,41 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.json tsconf
 
 COPY packages/model/package.json packages/model/package.json
 COPY packages/client/package.json packages/client/package.json
+COPY examples/chatbot/package.json examples/chatbot/package.json
+
+RUN pnpm install --frozen-lockfile
 
 COPY packages/model/src ./packages/model/src
-COPY packages/client/src ./packages/client/src
-
 COPY packages/model/tsconfig.json packages/model/tsconfig.json
 COPY packages/model/tsconfig.build.json packages/model/tsconfig.build.json
+
+COPY packages/client/src ./packages/client/src
 COPY packages/client/tsconfig.json packages/client/tsconfig.json
 COPY packages/client/tsconfig.build.json packages/client/tsconfig.build.json
 
-COPY examples/chatbot/package.json examples/chatbot/package.json
 COPY examples/chatbot/tsconfig.json examples/chatbot/tsconfig.json
 COPY examples/chatbot/data.ts examples/chatbot/data.ts
 COPY examples/chatbot/index.ts examples/chatbot/index.ts
-COPY examples/chatbot/public/ examples/chatbot/public/
 
-RUN pnpm install --frozen-lockfile
-RUN pnpm build
+RUN pnpm --filter @verana-labs/vs-agent-model build && \
+    pnpm --filter @verana-labs/vs-agent-client build && \
+    pnpm --filter demo-chatbot build
 
-FROM base as final
+FROM node:22.19-alpine AS final
 
-# AFJ specifc setup
 WORKDIR /www
 ENV RUN_MODE="docker"
 
-# Run install after copying only depdendency file
-# to make use of docker layer caching
-COPY --from=base /www/packages ./packages
-COPY --from=base /www/examples ./examples
+COPY --from=build /www/node_modules ./node_modules
+COPY --from=build /www/packages/model/node_modules ./packages/model/node_modules
+COPY --from=build /www/packages/model/package.json ./packages/model/package.json
+COPY --from=build /www/packages/model/build ./packages/model/build
+COPY --from=build /www/packages/client/node_modules ./packages/client/node_modules
+COPY --from=build /www/packages/client/package.json ./packages/client/package.json
+COPY --from=build /www/packages/client/build ./packages/client/build
+COPY --from=build /www/examples/chatbot/node_modules ./examples/chatbot/node_modules
+COPY examples/chatbot/package.json ./examples/chatbot/package.json
+COPY --from=build /www/examples/chatbot/build ./examples/chatbot/build
+COPY examples/chatbot/public/ ./examples/chatbot/public/
 
-CMD pnpm start:chatbot
+CMD ["node", "examples/chatbot/build/index.js"]

--- a/examples/verifier/Dockerfile
+++ b/examples/verifier/Dockerfile
@@ -1,36 +1,52 @@
-FROM node:22 as base
+FROM node:22.19-alpine AS build
 
-# Setup pnpm version
-RUN corepack enable
+ENV COREPACK_INTEGRITY_KEYS=0
 
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
+RUN apk add --no-cache python3 make g++ && \
+    corepack enable && \
+    corepack prepare pnpm@9.15.3 --activate
 
-COPY patches ./patches
-COPY packages/model/package.json packages/model/package.json
-COPY packages/client/package.json packages/client/package.json
-
-COPY packages/model/src ./packages/model/src
-COPY packages/client/src ./packages/client/src
-
-COPY packages/model/tsconfig.json packages/model/tsconfig.json
-COPY packages/model/tsconfig.build.json packages/model/tsconfig.build.json
-COPY packages/client/tsconfig.json packages/client/tsconfig.json
-COPY packages/client/tsconfig.build.json packages/client/tsconfig.build.json
-
-COPY examples/verifier/ examples/verifier/
-
-RUN pnpm install
-RUN pnpm build
-
-FROM base as final
-
-# AFJ specifc setup
 WORKDIR /www
 ENV RUN_MODE="docker"
 
-# Run install after copying only depdendency file
-# to make use of docker layer caching
-COPY --from=base /www/packages ./packages
-COPY --from=base /www/examples ./examples
+COPY patches ./patches
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
 
-CMD pnpm start:verifier
+COPY packages/model/package.json packages/model/package.json
+COPY packages/client/package.json packages/client/package.json
+COPY examples/verifier/package.json examples/verifier/package.json
+
+RUN pnpm install --frozen-lockfile
+
+COPY packages/model/src ./packages/model/src
+COPY packages/model/tsconfig.json packages/model/tsconfig.json
+COPY packages/model/tsconfig.build.json packages/model/tsconfig.build.json
+
+COPY packages/client/src ./packages/client/src
+COPY packages/client/tsconfig.json packages/client/tsconfig.json
+COPY packages/client/tsconfig.build.json packages/client/tsconfig.build.json
+
+COPY examples/verifier/tsconfig.json examples/verifier/tsconfig.json
+COPY examples/verifier/index.ts examples/verifier/index.ts
+
+RUN pnpm --filter @verana-labs/vs-agent-model build && \
+    pnpm --filter @verana-labs/vs-agent-client build && \
+    pnpm --filter demo-verifier build
+
+FROM node:22.19-alpine AS final
+
+WORKDIR /www
+ENV RUN_MODE="docker"
+
+COPY --from=build /www/node_modules ./node_modules
+COPY --from=build /www/packages/model/node_modules ./packages/model/node_modules
+COPY --from=build /www/packages/model/package.json ./packages/model/package.json
+COPY --from=build /www/packages/model/build ./packages/model/build
+COPY --from=build /www/packages/client/node_modules ./packages/client/node_modules
+COPY --from=build /www/packages/client/package.json ./packages/client/package.json
+COPY --from=build /www/packages/client/build ./packages/client/build
+COPY --from=build /www/examples/verifier/node_modules ./examples/verifier/node_modules
+COPY examples/verifier/package.json ./examples/verifier/package.json
+COPY --from=build /www/examples/verifier/build ./examples/verifier/build
+
+CMD ["node", "examples/verifier/build/index.js"]

--- a/examples/verifier/docker-compose.yml
+++ b/examples/verifier/docker-compose.yml
@@ -1,11 +1,9 @@
-version: '3'
-
 services:
   vs-agent:
     build: 
       context: ../..
       dockerfile: ./apps/vs-agent/Dockerfile
-    image: 2060-vs-agent
+    image: vs-agent
     container_name: verifier-vs-agent
     restart: always
     networks:
@@ -14,14 +12,12 @@ services:
       - 3000:3000
       - 3001:3001
     environment:
-      - AGENT_PUBLIC_DID=did:web:10.82.14.12%3A3001
-      - PUBLIC_API_BASE_URL=http://10.82.14.12:3001
-      - AGENT_ENDPOINT=ws://10.82.14.12:3001
-      - AGENT_INVITATION_IMAGE_URL=http://10.82.14.12:3001/avatar.png
+      - AGENT_ENDPOINT=ws://192.168.100.105:3001
+      - AGENT_INVITATION_IMAGE_URL=http://192.168.100.105:3001/avatar.png
+      - PUBLIC_API_BASE_URL=http://192.168.100.105:3001
       - AGENT_LABEL=Verifier Agent
       - USE_CORS=true
       - EVENTS_BASE_URL=http://verifier-backend:5100
-      - REDIS_HOST=redis
     volumes:
       - ./afj:/root/.afj
 
@@ -29,7 +25,7 @@ services:
     build: 
       context: ../..
       dockerfile: ./examples/verifier/Dockerfile
-    image: 2060-vs-agent-verifier
+    image: vs-agent-verifier
     container_name: verifier-backend
     restart: always
     networks:
@@ -40,24 +36,6 @@ services:
       - PORT=5100
       - VS_AGENT_ADMIN_BASE_URL=http://verifier-vs-agent:3000
       - PUBLIC_BASE_URL=http://10.82.14.12:5100
-  redis:
-    image: redis:alpine
-    restart: always
-    networks:
-      - verifier
-    ports:
-      - 6379:6379
-    command: redis-server --maxmemory 64mb --maxmemory-policy allkeys-lru
 
-  postgres:
-    image: postgres:15.2
-    restart: always
-    networks:
-      - verifier
-    ports:
-      - 5432:5432
-    environment:
-      - POSTGRES_PASSWORD=64270demo
-      - POSTGRES_USER=emailvs
 networks:
   verifier:


### PR DESCRIPTION
Using now node:22.19-alpine and separating build from runtime image in order to reduce image size for both chatbot and verifier examples.

For instance, chatbot image is now around 500MB instead of 1.7GB.