### PR TITLE
feat: show vs-agent version in agent info endpoint

### DIFF
--- a/apps/vs-agent/src/config/constants.ts
+++ b/apps/vs-agent/src/config/constants.ts
@@ -3,7 +3,11 @@ import { LogLevel } from '@credo-ts/core'
 import { KdfMethod } from '@openwallet-foundation/askar-nodejs'
 import dotenv from 'dotenv'
 
+import packageJson from '../../package.json'
+
 dotenv.config()
+
+export const AGENT_VERSION: string = packageJson.version
 
 // Basic parameters
 

--- a/apps/vs-agent/src/controllers/admin/agent/VsAgentController.ts
+++ b/apps/vs-agent/src/controllers/admin/agent/VsAgentController.ts
@@ -1,7 +1,7 @@
 import { Controller, Get } from '@nestjs/common'
 import { ApiTags, ApiOperation, ApiOkResponse, getSchemaPath, ApiExtraModels } from '@nestjs/swagger'
 
-import { AGENT_LABEL } from '../../../../src/config'
+import { AGENT_LABEL, AGENT_VERSION } from '../../../../src/config'
 import { VsAgentService } from '../../../services/VsAgentService'
 
 import { VsAgentInfoDto } from './dto'
@@ -29,6 +29,7 @@ export class VsAgentController {
       endpoints: vsAgent.didcomm.config.endpoints,
       isInitialized: vsAgent.isInitialized,
       publicDid: vsAgent.did,
+      version: AGENT_VERSION,
     }
   }
 }

--- a/apps/vs-agent/src/controllers/admin/agent/dto/vs-agent-info.dto.ts
+++ b/apps/vs-agent/src/controllers/admin/agent/dto/vs-agent-info.dto.ts
@@ -30,4 +30,10 @@ export class VsAgentInfoDto {
     nullable: true,
   })
   publicDid?: string
+
+  @ApiProperty({
+    description: 'Application version',
+    example: '1.8.1',
+  })
+  version!: string
 }


### PR DESCRIPTION
A very small but useful one: show VS Agent version in `agent` endpoint. Only on admin interface, since we may not want to disclose that on the public one.