### PR TITLE
fix: use a fix node version for deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -177,14 +177,16 @@ jobs:
         uses: actions/checkout@v4
 
       # Pnpm version has been pinned in package.json
-      - name: Setup node v24
+      - name: Setup node v22
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Corepack pnpm
-        run: corepack enable
+        run: |
+          npm install -g npm@11.11.0
+          corepack enable
           
       - name: Install dependencies
         run: |


### PR DESCRIPTION
At the moment, there is a bug in the latest version. (https://github.com/nodejs/node/issues/62425 and https://github.com/npm/cli/issues/9151)