### PR TITLE
fix: update DID Document keys in did:web

### DIFF
--- a/packages/agent-sdk/src/agent/VsAgent.ts
+++ b/packages/agent-sdk/src/agent/VsAgent.ts
@@ -13,6 +13,7 @@ import {
   CredoError,
   DidCommV1Service,
   DidDocument,
+  DidDocumentKey,
   DidDocumentService,
   DidRepository,
   DidsModule,
@@ -117,7 +118,7 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
       if (!existingRecord) {
         if (parsedDid.method === 'web') {
           const didDocument = new DidDocument({ id: parsedDid.did })
-          await this.createAndAddDidCommKeysAndServices(didDocument)
+          const didCommKey = await this.createAndAddDidCommKeysAndServices(didDocument)
 
           // Add Self TR
           await this.createAndAddLinkedVpServices(didDocument)
@@ -129,6 +130,7 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
             method: 'web',
             domain,
             didDocument,
+            keys: [didCommKey],
           })
           this.did = parsedDid.did
         } else if (parsedDid.method === 'webvh') {
@@ -152,7 +154,7 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
           }
 
           // Add DIDComm services and keys
-          await this.createAndAddDidCommKeysAndServices(didDocument)
+          const didCommKey = await this.createAndAddDidCommKeysAndServices(didDocument)
 
           // Add Linked VP services
           await this.createAndAddLinkedVpServices(didDocument)
@@ -161,6 +163,10 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
           await this.createAndAddWebVhImplicitServices(didDocument)
 
           didDocument.alsoKnownAs = [`did:web:${domain}`]
+
+          // The webvh registrar doesn't merge new keys into the DidRecord on update,
+          // so persist the DIDComm key mapping directly on the existing record.
+          await this.persistDidDocumentKey(publicDid, didCommKey)
 
           const result = await this.dids.update({ did: publicDid, didDocument })
           if (result.didState.state !== 'finished') {
@@ -206,9 +212,21 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
             ...this.getDidCommServices(didDocument.id),
           ]
         }
-        if (hasLegacyMethods) await this.createAndAddDidCommKeysAndServices(didDocument)
+        const newKeys: DidDocumentKey[] = []
+        if (hasLegacyMethods) {
+          newKeys.push(await this.createAndAddDidCommKeysAndServices(didDocument))
+        }
 
-        await this.dids.update({ did: didDocument.id, didDocument })
+        if (newKeys.length && parsedDid.method === 'webvh') {
+          // webvh registrar doesn't accept keys in update options; persist directly
+          for (const key of newKeys) await this.persistDidDocumentKey(didDocument.id, key)
+        }
+
+        await this.dids.update({
+          did: didDocument.id,
+          didDocument,
+          ...(newKeys.length && parsedDid.method === 'web' ? { keys: newKeys } : {}),
+        })
         this.logger?.debug('Public did record updated')
       } else {
         this.logger?.debug('Existing DID record found. No updates')
@@ -244,7 +262,17 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
     })
   }
 
-  private async createAndAddDidCommKeysAndServices(didDocument: DidDocument) {
+  private async persistDidDocumentKey(did: string, key: DidDocumentKey) {
+    const didRepository = this.agentContext.resolve(DidRepository)
+    const [record] = await didRepository.findByQuery(this.agentContext, { did })
+    if (!record) return
+    const existing = record.keys ?? []
+    if (existing.some(k => k.didDocumentRelativeKeyId === key.didDocumentRelativeKeyId)) return
+    record.keys = [...existing, key]
+    await didRepository.update(this.agentContext, record)
+  }
+
+  private async createAndAddDidCommKeysAndServices(didDocument: DidDocument): Promise<DidDocumentKey> {
     const publicDid = didDocument.id
 
     const context = [
@@ -254,7 +282,6 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
     ]
     const keyAgreementId = `${publicDid}#key-agreement-1`
     const kms = this.agentContext.resolve(Kms.KeyManagementApi)
-    const didRepository = this.agentContext.resolve(DidRepository)
 
     // Create didcomm keys
     const key = await kms.createKey({ type: { kty: 'OKP', crv: 'Ed25519' } })
@@ -263,12 +290,10 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
       new Uint8Array([0xed, 0x01, ...publicKeyBytes]),
       MultibaseEncoding.BASE58_BTC,
     )
-    const [record] = await didRepository.findByQuery(this.agentContext, { did: publicDid })
-    record.keys?.push({
+    const didDocumentKey: DidDocumentKey = {
       kmsKeyId: key.keyId,
       didDocumentRelativeKeyId: `#${publicKeyMultibase}`,
-    })
-    await didRepository.update(this.agentContext, record)
+    }
     const verificationMethodId = `${publicDid}#${publicKeyMultibase}`
     const publicKeyX25519 = convertPublicKeyToX25519(publicKeyBytes)
     const x25519Key = Kms.PublicJwk.fromPublicKey({ kty: 'OKP', crv: 'X25519', publicKey: publicKeyX25519 })
@@ -325,6 +350,8 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
         : []),
       ...didcommServices,
     ]
+
+    return didDocumentKey
   }
 
   private async createAndAddLinkedVpServices(didDocument: DidDocument) {

--- a/packages/agent-sdk/src/did/WebDidRegistrar.ts
+++ b/packages/agent-sdk/src/did/WebDidRegistrar.ts
@@ -4,6 +4,7 @@ import {
   DidCreateResult,
   DidDeactivateOptions,
   DidDeactivateResult,
+  DidDocumentKey,
   DidRegistrar,
   DidRepository,
   DidUpdateOptions,
@@ -16,11 +17,13 @@ import {
 
 interface WebDidCreateOptions extends DidCreateOptions {
   domain: string
+  keys?: DidDocumentKey[]
 }
 
 interface WebDidUpdateOptions extends DidUpdateOptions {
   didDocument: DidDocument
   domain?: string
+  keys?: DidDocumentKey[]
 }
 
 /**
@@ -56,6 +59,7 @@ export class WebDidRegistrar implements DidRegistrar {
         did,
         didDocument,
         role: DidDocumentRole.Created,
+        keys: options.keys,
       })
       didRecord.setTags({ domain })
       await didRepository.save(agentContext, didRecord)
@@ -99,6 +103,12 @@ export class WebDidRegistrar implements DidRegistrar {
       if (!didRecord) return this.handleError('Did not found')
 
       didRecord.didDocument = inputDidDocument
+
+      if (options.keys?.length) {
+        const existingKeys = didRecord.keys ?? []
+        const existingIds = new Set(existingKeys.map(k => k.didDocumentRelativeKeyId))
+        didRecord.keys = [...existingKeys, ...options.keys.filter(k => !existingIds.has(k.didDocumentRelativeKeyId))]
+      }
 
       await didRepository.update(agentContext, didRecord)
 

--- a/packages/agent-sdk/src/did/WebDidRegistrar.ts
+++ b/packages/agent-sdk/src/did/WebDidRegistrar.ts
@@ -107,7 +107,10 @@ export class WebDidRegistrar implements DidRegistrar {
       if (options.keys?.length) {
         const existingKeys = didRecord.keys ?? []
         const existingIds = new Set(existingKeys.map(k => k.didDocumentRelativeKeyId))
-        didRecord.keys = [...existingKeys, ...options.keys.filter(k => !existingIds.has(k.didDocumentRelativeKeyId))]
+        didRecord.keys = [
+          ...existingKeys,
+          ...options.keys.filter(k => !existingIds.has(k.didDocumentRelativeKeyId)),
+        ]
       }
 
       await didRepository.update(agentContext, didRecord)


### PR DESCRIPTION
Fixing a crash when using did:web and DID record wasn't present before.

Now we update DID records outside of createAndAddDidCommKeysAndServices(), to make the boundaries of this method clearer.