### PR TITLE
fix: update getShortUrl to use v1 and v2 invitations

### DIFF
--- a/apps/vs-agent/src/controllers/public/invitation/InvitationController.ts
+++ b/apps/vs-agent/src/controllers/public/invitation/InvitationController.ts
@@ -46,7 +46,8 @@ export class InvitationRoutesController {
           }
         }
         const invitation = await agent.didcomm.oob.parseInvitation(longUrl)
-        res.send(invitation.toJSON()).end()
+        const invitationJson = invitation.v2Invitation?.toJSON() ?? invitation.toJSON()
+        res.send(invitationJson).end()
       } else {
         res.status(302).location(longUrl).end()
       }


### PR DESCRIPTION
As discussed in #435, `agent.didcomm.oob.parseInvitation` returns a v1 `DidCommOutOfBandInvitation` wrapper that already carries the original v2 invitation in its public `v2Invitation` field. The `/s` handler now serializes the v2 form when present, falling back to the v1 wrapper otherwise. No Credo API change needed.