### PR TITLE
ci: announce stable releases on discord

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -183,7 +183,7 @@ jobs:
 
 
   discord-notify:
-    needs: resolve-version
+    needs: [resolve-version, docker, helm]
     if: needs.resolve-version.outputs.new-release-published == 'true' && needs.resolve-version.outputs.release-type == 'stable'
     permissions:
       contents: read

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,12 @@ name: Continuous Deployment
 on:
   push:
     branches: [main, 'release/**']
+  workflow_dispatch:
+    inputs:
+      notify_tag:
+        description: "Release tag to (re)announce on Discord, e.g. v1.2.0"
+        required: true
+        type: string
 
 permissions:
   id-token: write   # Required for OIDC
@@ -12,6 +18,7 @@ permissions:
 
 jobs:
   resolve-version:
+    if: github.event_name == 'push'
     uses: 2060-io/organization/.github/workflows/resolve-version-call.yml@main
 
   docker:
@@ -174,3 +181,24 @@ jobs:
         run: |
           pnpm -r publish --no-git-checks --access public
 
+
+  discord-notify:
+    needs: resolve-version
+    if: needs.resolve-version.outputs.new-release-published == 'true' && needs.resolve-version.outputs.release-type == 'stable'
+    permissions:
+      contents: read
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    with:
+      tag_name: ${{ needs.resolve-version.outputs.release-version }}
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}
+
+  discord-notify-manual:
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@main
+    with:
+      tag_name: ${{ inputs.notify_tag }}
+    secrets:
+      DISCORD_UPDATES_WEBHOOK_URL: ${{ secrets.DISCORD_UPDATES_WEBHOOK_URL }}


### PR DESCRIPTION
Wires this repo into the shared Discord release notifier so stable releases land in `#update`, same setup as `veranafoundation.org-website` and `verana-frontend`. Adds a `discord-notify` job to the release workflow, gated on the release being created, calling `2060-io/organization`'s reusable workflow with the tag and the `DISCORD_UPDATES_WEBHOOK_URL` org secret. Also adds a manual `workflow_dispatch` so we can re-announce or backfill any tag without cutting a release.

Stable only, dev pre-releases stay quiet. @mjfelis @genaris @lotharking one of you mind taking a look.
