### PR TITLE
fix(examples): build vt-flow before sdk in docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,3 +15,35 @@ concurrency:
 jobs:
   ci:
     uses: 2060-io/organization/.github/workflows/2060-linter-call.yml@main
+
+  docker-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./apps/vs-agent/Dockerfile
+            target: vs-agent
+          - dockerfile: ./apps/vs-agent/Dockerfile
+            target: vs-agent-chat
+          - dockerfile: ./apps/vs-agent/Dockerfile
+            target: vs-agent-mrtd
+          - dockerfile: ./examples/chatbot/Dockerfile
+          - dockerfile: ./examples/verifier/Dockerfile
+          - dockerfile: ./examples/nestjs-vs/Dockerfile
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build ${{ matrix.dockerfile }} ${{ matrix.target }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          target: ${{ matrix.target }}
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/examples/chatbot/Dockerfile
+++ b/examples/chatbot/Dockerfile
@@ -15,6 +15,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.json tsconf
 COPY packages/model/package.json packages/model/package.json
 COPY packages/client/package.json packages/client/package.json
 COPY packages/agent-sdk/package.json packages/agent-sdk/package.json
+COPY packages/vt-flow/package.json packages/vt-flow/package.json
 COPY packages/plugin-mrtd/package.json packages/plugin-mrtd/package.json
 COPY examples/chatbot/package.json examples/chatbot/package.json
 
@@ -32,6 +33,10 @@ COPY packages/agent-sdk/src ./packages/agent-sdk/src
 COPY packages/agent-sdk/tsconfig.json packages/agent-sdk/tsconfig.json
 COPY packages/agent-sdk/tsconfig.build.json packages/agent-sdk/tsconfig.build.json
 
+COPY packages/vt-flow/src ./packages/vt-flow/src
+COPY packages/vt-flow/tsconfig.json packages/vt-flow/tsconfig.json
+COPY packages/vt-flow/tsconfig.build.json packages/vt-flow/tsconfig.build.json
+
 COPY packages/plugin-mrtd/src ./packages/plugin-mrtd/src
 COPY packages/plugin-mrtd/tsconfig.json packages/plugin-mrtd/tsconfig.json
 COPY packages/plugin-mrtd/tsconfig.build.json packages/plugin-mrtd/tsconfig.build.json
@@ -42,6 +47,7 @@ COPY examples/chatbot/index.ts examples/chatbot/index.ts
 
 RUN pnpm --filter @verana-labs/vs-agent-model build && \
     pnpm --filter @verana-labs/vs-agent-client build && \
+    pnpm --filter @verana-labs/credo-ts-didcomm-vt-flow build && \
     pnpm --filter @verana-labs/vs-agent-sdk build && \
     pnpm --filter @verana-labs/vs-agent-plugin-mrtd build && \
     pnpm --filter demo-chatbot build
@@ -65,6 +71,8 @@ COPY --from=build /www/packages/client/package.json ./packages/client/package.js
 COPY --from=build /www/packages/client/build ./packages/client/build
 COPY --from=build /www/packages/agent-sdk/package.json ./packages/agent-sdk/package.json
 COPY --from=build /www/packages/agent-sdk/build ./packages/agent-sdk/build
+COPY --from=build /www/packages/vt-flow/package.json ./packages/vt-flow/package.json
+COPY --from=build /www/packages/vt-flow/build ./packages/vt-flow/build
 COPY --from=build /www/packages/plugin-mrtd/package.json ./packages/plugin-mrtd/package.json
 COPY --from=build /www/packages/plugin-mrtd/build ./packages/plugin-mrtd/build
 COPY examples/chatbot/package.json ./examples/chatbot/package.json

--- a/examples/nestjs-vs/Dockerfile
+++ b/examples/nestjs-vs/Dockerfile
@@ -13,12 +13,14 @@ COPY patches ./patches
 COPY packages/model/package.json packages/model/package.json
 COPY packages/client/package.json packages/client/package.json
 COPY packages/agent-sdk/package.json packages/agent-sdk/package.json
+COPY packages/vt-flow/package.json packages/vt-flow/package.json
 COPY packages/plugin-mrtd/package.json packages/plugin-mrtd/package.json
 COPY packages/nestjs-client/package.json packages/nestjs-client/package.json
 
 COPY packages/model/src ./packages/model/src
 COPY packages/client/src ./packages/client/src
 COPY packages/agent-sdk/src ./packages/agent-sdk/src
+COPY packages/vt-flow/src ./packages/vt-flow/src
 COPY packages/plugin-mrtd/src ./packages/plugin-mrtd/src
 COPY packages/nestjs-client/src ./packages/nestjs-client/src
 
@@ -28,6 +30,8 @@ COPY packages/client/tsconfig.json packages/client/tsconfig.json
 COPY packages/client/tsconfig.build.json packages/client/tsconfig.build.json
 COPY packages/agent-sdk/tsconfig.json packages/agent-sdk/tsconfig.json
 COPY packages/agent-sdk/tsconfig.build.json packages/agent-sdk/tsconfig.build.json
+COPY packages/vt-flow/tsconfig.json packages/vt-flow/tsconfig.json
+COPY packages/vt-flow/tsconfig.build.json packages/vt-flow/tsconfig.build.json
 COPY packages/plugin-mrtd/tsconfig.json packages/plugin-mrtd/tsconfig.json
 COPY packages/plugin-mrtd/tsconfig.build.json packages/plugin-mrtd/tsconfig.build.json
 COPY packages/nestjs-client/tsconfig.json packages/nestjs-client/tsconfig.json
@@ -38,6 +42,7 @@ COPY examples/nestjs-vs/ examples/nestjs-vs/
 RUN pnpm install
 RUN pnpm --filter @verana-labs/vs-agent-model build && \
     pnpm --filter @verana-labs/vs-agent-client build && \
+    pnpm --filter @verana-labs/credo-ts-didcomm-vt-flow build && \
     pnpm --filter @verana-labs/vs-agent-sdk build && \
     pnpm --filter @verana-labs/vs-agent-plugin-mrtd build && \
     pnpm --filter @verana-labs/vs-agent-nestjs-client build && \


### PR DESCRIPTION
#430 made vs-agent-sdk import vt-flow, but the chatbot and nestjs-vs Docker images never build vt-flow, so the sdk fails to compile (TS2307: cannot find module vt-flow). #461 fixed apps/vs-agent but not the examples, so the release build kept failing on the chatbot image.

Changes:
- chatbot and nestjs-vs Dockerfiles now build vt-flow before the sdk, and ship its build output for runtime.
- New CI job builds all 6 images on every PR (build only, no push), so a broken docker build is caught before it reaches main.

Tested by building all 6 images locally.