### PR TITLE
feat(vs-agent): add revocation-registry kebab-case route alias

### DIFF
--- a/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeController.ts
+++ b/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeController.ts
@@ -192,7 +192,10 @@ export class CredentialTypesController {
    * Delete a revocation registry definition and its associated records
    */
   @Delete(['/revocation-registry', '/revocationRegistry'])
-  @ApiOperation({ summary: 'Delete a revocation registry definition and its associated records' })
+  @ApiOperation({
+    summary: 'Delete a revocation registry definition and its associated records',
+    description: 'The "/revocationRegistry" path is deprecated. Use "/revocation-registry".',
+  })
   @ApiQuery({
     name: 'revocationRegistryDefinitionId',
     description: 'Identifier of the revocation registry definition to delete',
@@ -509,7 +512,10 @@ export class CredentialTypesController {
    * @returns RevocationTypeInfo
    */
   @Post(['/revocation-registry', '/revocationRegistry'])
-  @ApiOperation({ summary: 'Create a new revocation registry definition' })
+  @ApiOperation({
+    summary: 'Create a new revocation registry definition',
+    description: 'The "/revocationRegistry" path is deprecated. Use "/revocation-registry".',
+  })
   @ApiBody({
     description: 'Options to create a revocation registry',
     type: CreateRevocationRegistryDto,
@@ -615,7 +621,10 @@ export class CredentialTypesController {
    * @returns string[] with revocationRegistryDefinitionIds
    */
   @Get(['/revocation-registry', '/revocationRegistry'])
-  @ApiOperation({ summary: 'List revocation registry definitions' })
+  @ApiOperation({
+    summary: 'List revocation registry definitions',
+    description: 'The "/revocationRegistry" path is deprecated. Use "/revocation-registry".',
+  })
   @ApiQuery({
     name: 'credentialDefinitionId',
     required: false,

--- a/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeController.ts
+++ b/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeController.ts
@@ -191,7 +191,7 @@ export class CredentialTypesController {
   /**
    * Delete a revocation registry definition and its associated records
    */
-  @Delete('/revocationRegistry')
+  @Delete(['/revocation-registry', '/revocationRegistry'])
   @ApiOperation({ summary: 'Delete a revocation registry definition and its associated records' })
   @ApiQuery({
     name: 'revocationRegistryDefinitionId',
@@ -508,7 +508,7 @@ export class CredentialTypesController {
    * @param credentialDefinitionId
    * @returns RevocationTypeInfo
    */
-  @Post('/revocationRegistry')
+  @Post(['/revocation-registry', '/revocationRegistry'])
   @ApiOperation({ summary: 'Create a new revocation registry definition' })
   @ApiBody({
     description: 'Options to create a revocation registry',
@@ -614,7 +614,7 @@ export class CredentialTypesController {
    *
    * @returns string[] with revocationRegistryDefinitionIds
    */
-  @Get('/revocationRegistry')
+  @Get(['/revocation-registry', '/revocationRegistry'])
   @ApiOperation({ summary: 'List revocation registry definitions' })
   @ApiQuery({
     name: 'credentialDefinitionId',


### PR DESCRIPTION
Closes #467.

Adds the kebab-case alias `/v1/credential-types/revocation-registry` (GET/POST/DELETE) next to the existing camelCase `/revocationRegistry`. CamelCase stays for backward compat.

The issue's other three items were already spec-compliant, so no code change: `GET /v1/health` returns 200, `GET /v1/qr` takes the spec query params (`size`, `padding`, `level`, `bcolor`, `fcolor`, `legacy`).