### PR TITLE
fix(agent-sdk): migrate did:webvh logs rejected by didwebvh-ts 2.8.0

### DIFF
--- a/apps/vs-agent/package.json
+++ b/apps/vs-agent/package.json
@@ -73,7 +73,7 @@
     "@verana-labs/vs-agent-sdk": "workspace:*",
     "bull": "^4.16.2",
     "credo-ts-didweb-anoncreds": "0.0.2-alpha.5",
-    "didwebvh-ts": "^2.7.4",
+    "didwebvh-ts": "^2.8.0",
     "dotenv": "^17.2.3",
     "express": "^4.18.1",
     "qrcode": "^1.5.3",

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -50,7 +50,7 @@
     "ajv-formats": "^3.0.1",
     "axios": "^1.7.9",
     "credo-ts-didweb-anoncreds": "0.0.2-alpha.5",
-    "didwebvh-ts": "^2.7.4",
+    "didwebvh-ts": "^2.8.0",
     "express": "^4.18.1",
     "tsyringe": "4.8.0"
   },

--- a/packages/agent-sdk/src/agent/VsAgent.ts
+++ b/packages/agent-sdk/src/agent/VsAgent.ts
@@ -42,6 +42,7 @@ import { multibaseEncode, MultibaseEncoding } from 'didwebvh-ts'
 import { VeranaChainService } from '../blockchain/VeranaChainService'
 import { applyAdminApiServiceEntry } from '../did/adminApiService'
 import { migrateWebVhLogIfBroken } from '../did/migrateWebVhLog'
+import { migrateWebVhVersionTimeIfBroken } from '../did/migrateWebVhVersionTime'
 import { baseMessageEvents } from '../events/BaseMessageEvents'
 import { connectionEvents } from '../events/ConnectionEvents'
 
@@ -214,13 +215,13 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
         return
       }
 
-      // If this is a did:webvh record, ensure the stored log is resolvable under the
-      // current didwebvh-ts version. Logs created with didwebvh-ts <2.7.4 used the
-      // SCID placeholder when computing the entry hash for entries beyond #1, which
-      // newer resolvers (correctly) reject as a broken hash chain. We rebuild the
-      // log in-place, preserving entry #1 (and therefore the SCID and the public DID).
+      // Ensure the stored did:webvh log is resolvable under the current didwebvh-ts version:
+      // <2.7.4 wrote broken entry hashes (SCID placeholder), and >=2.8.0 rejects the
+      // same-second versionTimes the old create+update-at-init flow produced. Both migrations
+      // rebuild the log in-place, preserving entry #1 (and therefore the SCID and public DID).
       if (parsedDid.method === 'webvh') {
         try {
+          await migrateWebVhVersionTimeIfBroken(this.agentContext, existingRecord, this.logger)
           await migrateWebVhLogIfBroken(this.agentContext, existingRecord, this.logger)
         } catch (error) {
           this.logger.error(

--- a/packages/agent-sdk/src/did/migrateWebVhVersionTime.ts
+++ b/packages/agent-sdk/src/did/migrateWebVhVersionTime.ts
@@ -1,0 +1,239 @@
+import { AskarStoreManager } from '@credo-ts/askar'
+import { AgentContext, DidRecord, DidRepository, Kms, Logger } from '@credo-ts/core'
+import { KeyAlgorithm } from '@openwallet-foundation/askar-shared'
+import {
+  DIDLog,
+  DIDLogEntry,
+  MultibaseEncoding,
+  multibaseEncode,
+  prepareDataForSigning,
+  resolveDIDFromLog,
+  Signer,
+  SigningInput,
+  SigningOutput,
+  updateDID,
+  Verifier,
+} from 'didwebvh-ts'
+
+// didwebvh-ts >=2.8.0 enforces the spec rule that each entry's versionTime is strictly greater
+// than the previous one; logs written by the old create+update-at-init flow share a second.
+// Hash-chain errors are accepted too: a hash break can mask a same-second pair behind it,
+// and the rebuild recomputes hashes anyway.
+const REBUILDABLE_ERROR = /must be greater than previous entry time|hash chain broken/i
+
+class KmsVerifier implements Verifier {
+  public constructor(private readonly agentContext: AgentContext) {}
+
+  public async verify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean> {
+    try {
+      const kms = this.agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+      const publicJwk = Kms.PublicJwk.fromPublicKey({ kty: 'OKP', crv: 'Ed25519', publicKey })
+      const { verified } = await kms.verify({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        key: { publicJwk: publicJwk.toJson() as any },
+        algorithm: 'EdDSA',
+        signature,
+        data: message,
+      })
+      return verified
+    } catch {
+      return false
+    }
+  }
+}
+
+class KmsSigner implements Signer {
+  public constructor(
+    private readonly agentContext: AgentContext,
+    private readonly kmsKeyId: string,
+    private readonly publicKeyMultibase: string,
+  ) {}
+
+  public getVerificationMethodId(): string {
+    return `did:key:${this.publicKeyMultibase}`
+  }
+
+  public async sign(input: SigningInput): Promise<SigningOutput> {
+    const kms = this.agentContext.dependencyManager.resolve(Kms.KeyManagementApi)
+    const data = await prepareDataForSigning(input.document, input.proof)
+    const { signature } = await kms.sign({
+      keyId: this.kmsKeyId,
+      algorithm: 'EdDSA',
+      data,
+    })
+    return { proofValue: multibaseEncode(signature, MultibaseEncoding.BASE58_BTC) }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const normalizeMethodArray = (arr: any): string[] | undefined =>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  arr?.map((item: any) => (typeof item === 'string' ? item : item.id))
+
+// Compare at second precision because the output is second-truncated.
+function nextVersionTime(previous: string, desired: string): string {
+  const parseSeconds = (value: string): number => Math.floor(Date.parse(value) / 1000) * 1000
+  const previousMs = parseSeconds(previous)
+  const desiredMs = parseSeconds(desired)
+  const chosen = Number.isNaN(desiredMs) || desiredMs <= previousMs ? previousMs + 1000 : desiredMs
+  return new Date(chosen).toISOString().replace(/\.\d+Z$/, 'Z')
+}
+
+async function tryResolveLog(
+  log: DIDLog,
+  verifier: Verifier,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  try {
+    await resolveDIDFromLog(log, { verifier })
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export interface RebuildWebVhVersionTimesOptions {
+  signer: Signer
+  verifier: Verifier
+  domain?: string
+}
+
+export async function rebuildWebVhVersionTimes(
+  log: DIDLog,
+  { signer, verifier, domain }: RebuildWebVhVersionTimesOptions,
+): Promise<DIDLog | null> {
+  if (!log || log.length < 2) return null
+
+  const initial = await tryResolveLog(log, verifier)
+  if (initial.ok) return null
+  if (!REBUILDABLE_ERROR.test(initial.reason)) return null
+
+  const originalScid = log[0].parameters.scid
+  let newLog: DIDLog = [log[0]]
+
+  for (let i = 1; i < log.length; i++) {
+    const oldEntry: DIDLogEntry = log[i]
+    const oldState = oldEntry.state
+    const oldParams = oldEntry.parameters
+    const lastParams = newLog[newLog.length - 1].parameters
+
+    const activeUpdateKeys = lastParams.updateKeys ?? []
+    if (activeUpdateKeys.length === 0) {
+      throw new Error(`Cannot rebuild webvh log: no active updateKeys at entry ${i + 1}`)
+    }
+
+    const controllerValue = Array.isArray(oldState.controller) ? oldState.controller[0] : oldState.controller
+
+    const { log: rebuilt } = await updateDID({
+      log: newLog,
+      signer,
+      verifier,
+      domain,
+      updateKeys: oldParams.updateKeys ?? activeUpdateKeys,
+      verificationMethods: oldState.verificationMethod,
+      services: oldState.service,
+      controller: controllerValue,
+      authentication: normalizeMethodArray(oldState.authentication),
+      assertionMethod: normalizeMethodArray(oldState.assertionMethod),
+      keyAgreement: normalizeMethodArray(oldState.keyAgreement),
+      alsoKnownAs: oldState.alsoKnownAs,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      context: (oldState as any)['@context'],
+      portable: oldParams.portable,
+      nextKeyHashes: oldParams.nextKeyHashes,
+      witness:
+        oldParams.witness && (oldParams.witness.witnesses?.length || oldParams.witness.threshold)
+          ? oldParams.witness
+          : undefined,
+      watchers: oldParams.watchers,
+      updated: nextVersionTime(newLog[newLog.length - 1].versionTime, oldEntry.versionTime),
+    })
+    newLog = rebuilt
+  }
+
+  const verify = await tryResolveLog(newLog, verifier)
+  if (!verify.ok) {
+    throw new Error(`Rebuilt webvh log is still invalid: ${verify.reason}`)
+  }
+  if (newLog[0].parameters.scid !== originalScid) {
+    throw new Error(`Rebuilt webvh log produced a different SCID; aborting migration`)
+  }
+
+  return newLog
+}
+
+async function findKmsKeyIdForFingerprint(
+  agentContext: AgentContext,
+  fingerprint: string,
+): Promise<string | undefined> {
+  try {
+    const storeManager = agentContext.dependencyManager.resolve(AskarStoreManager)
+    return await storeManager.withSession(agentContext, async session => {
+      const entries = await session.fetchAllKeys({ algorithm: KeyAlgorithm.Ed25519 })
+      for (const entry of entries) {
+        const pubBytes = entry.key.publicBytes
+        const computed = multibaseEncode(new Uint8Array([237, 1, ...pubBytes]), MultibaseEncoding.BASE58_BTC)
+        entry.key.handle.free()
+        if (computed === fingerprint) return entry.name
+      }
+      return undefined
+    })
+  } catch {
+    agentContext.config.logger.warn(
+      `Failed to scan Askar keys, cannot recover controller key for webvh versionTime migration`,
+    )
+    return undefined
+  }
+}
+
+export async function migrateWebVhVersionTimeIfBroken(
+  agentContext: AgentContext,
+  didRecord: DidRecord,
+  logger: Logger,
+): Promise<boolean> {
+  const log = didRecord.metadata.get('log') as DIDLog | undefined
+  if (!log || log.length < 2) return false
+
+  const verifier = new KmsVerifier(agentContext)
+
+  const preCheck = await tryResolveLog(log, verifier)
+  if (preCheck.ok) return false
+  if (!REBUILDABLE_ERROR.test(preCheck.reason)) return false
+
+  const domain = didRecord.getTag('domain') as string | undefined
+  const activeUpdateKey = log[log.length - 1].parameters.updateKeys?.[0] ?? log[0].parameters.updateKeys?.[0]
+  if (!activeUpdateKey) {
+    throw new Error(`Cannot migrate webvh log for ${didRecord.did}: no updateKeys present`)
+  }
+
+  let kmsKeyId = didRecord.keys?.[0]?.kmsKeyId
+  if (!kmsKeyId) {
+    kmsKeyId = await findKmsKeyIdForFingerprint(agentContext, activeUpdateKey)
+    if (!kmsKeyId) {
+      throw new Error(`Cannot migrate webvh log for ${didRecord.did}: no controller key on DID record`)
+    }
+    logger.warn(`webvh DID ${didRecord.did}: controller key recovered from Askar scan`)
+    const vm = didRecord.didDocument?.verificationMethod?.find(v => v.publicKeyMultibase === activeUpdateKey)
+    const relativeKeyId = vm?.id ? `#${vm.id.split('#')[1]}` : '#key-1'
+    didRecord.keys = [{ kmsKeyId, didDocumentRelativeKeyId: relativeKeyId }]
+  }
+
+  logger.warn(
+    `webvh DID log for ${didRecord.did} has non-monotonic versionTimes. ` +
+      `Rebuilding entries 2..${log.length} while preserving SCID.`,
+  )
+
+  const signer = new KmsSigner(agentContext, kmsKeyId, activeUpdateKey)
+
+  const newLog = await rebuildWebVhVersionTimes(log, { signer, verifier, domain })
+  if (!newLog) return false
+
+  didRecord.metadata.set('log', newLog)
+  const didRepository = agentContext.dependencyManager.resolve(DidRepository)
+  await didRepository.update(agentContext, didRecord)
+
+  logger.info(
+    `webvh DID log for ${didRecord.did} versionTimes migrated; ${newLog.length} entries; SCID preserved (${log[0].parameters.scid}).`,
+  )
+
+  return true
+}

--- a/packages/agent-sdk/tests/fixtures/webvh-same-second-2.7.4.json
+++ b/packages/agent-sdk/tests/fixtures/webvh-same-second-2.7.4.json
@@ -1,0 +1,103 @@
+[
+  {
+    "versionId": "1-QmaBFyTCB1FPAk1LLK5rDHPLaywUHmXLboLupncjRE2LhH",
+    "versionTime": "2026-07-01T13:16:29Z",
+    "parameters": {
+      "method": "did:webvh:1.0",
+      "scid": "QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk",
+      "updateKeys": [
+        "z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z"
+      ],
+      "portable": false,
+      "nextKeyHashes": [],
+      "watchers": [],
+      "witness": {},
+      "deactivated": false
+    },
+    "state": {
+      "@context": [
+        "https://www.w3.org/ns/did/v1",
+        "https://w3id.org/security/multikey/v1"
+      ],
+      "id": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com",
+      "controller": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com",
+      "verificationMethod": [
+        {
+          "id": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com#6Thv5T3Z",
+          "controller": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com",
+          "type": "Multikey",
+          "publicKeyMultibase": "z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z"
+        }
+      ],
+      "authentication": [
+        "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com#6Thv5T3Z"
+      ],
+      "assertionMethod": [],
+      "keyAgreement": [],
+      "capabilityDelegation": [],
+      "capabilityInvocation": []
+    },
+    "proof": [
+      {
+        "type": "DataIntegrityProof",
+        "cryptosuite": "eddsa-jcs-2022",
+        "verificationMethod": "did:key:z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z",
+        "created": "2026-07-01T13:16:29Z",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "z2Li1JKNJe8EkxFkhhtJcFnqZ96HpbXoTh9figxbBUd5qbLqH74gbbc6kCN2xcmN6Kuf1ATPe2VUVWtvtkxfYZxs1"
+      }
+    ]
+  },
+  {
+    "versionId": "2-QmbAF1EnHDeDD2xkYmUvcsXELKmVFd2Ma8xRtf5rknoFwG",
+    "versionTime": "2026-07-01T13:16:29Z",
+    "parameters": {
+      "updateKeys": [
+        "z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z"
+      ],
+      "nextKeyHashes": [],
+      "witness": {},
+      "watchers": []
+    },
+    "state": {
+      "@context": [
+        "https://www.w3.org/ns/did/v1",
+        "https://w3id.org/security/multikey/v1"
+      ],
+      "id": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com",
+      "controller": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com",
+      "verificationMethod": [
+        {
+          "id": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com#6Thv5T3Z",
+          "controller": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com",
+          "type": "Multikey",
+          "publicKeyMultibase": "z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z"
+        }
+      ],
+      "authentication": [
+        "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com#6Thv5T3Z"
+      ],
+      "assertionMethod": [],
+      "keyAgreement": [],
+      "capabilityDelegation": [],
+      "capabilityInvocation": [],
+      "service": [
+        {
+          "id": "did:webvh:QmYQUqrBb5shqbzb1VKoX8RBnunii5d9vhVu65NuGbNERk:example.com#test-service",
+          "type": "TestService",
+          "serviceEndpoint": "https://example.com/test"
+        }
+      ]
+    },
+    "proof": [
+      {
+        "type": "DataIntegrityProof",
+        "cryptosuite": "eddsa-jcs-2022",
+        "verificationMethod": "did:key:z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z",
+        "created": "2026-07-01T13:16:29Z",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "z2tvceHKXPmwMFbLGuswMZHZFY6kUGGt4MDRwzbkM5TsSgaAghX3xvx5mpMASCxsbdDHN32Na9KUX9NqTpmFGacb9"
+      }
+    ]
+  }
+]

--- a/packages/agent-sdk/tests/migrateWebVhVersionTime.test.ts
+++ b/packages/agent-sdk/tests/migrateWebVhVersionTime.test.ts
@@ -1,0 +1,145 @@
+import { ed25519 } from '@noble/curves/ed25519.js'
+import {
+  createDID,
+  DIDLog,
+  MultibaseEncoding,
+  multibaseEncode,
+  prepareDataForSigning,
+  resolveDIDFromLog,
+  Signer,
+  SigningInput,
+  SigningOutput,
+  updateDID,
+  Verifier,
+} from 'didwebvh-ts'
+import { describe, expect, it } from 'vitest'
+
+import { rebuildWebVhVersionTimes } from '../src/did/migrateWebVhVersionTime'
+
+import sameSecondLegacyLog from './fixtures/webvh-same-second-2.7.4.json'
+
+const secretKey = new Uint8Array(32).fill(7)
+const publicKeyMultibase = multibaseEncode(
+  new Uint8Array([0xed, 0x01, ...ed25519.getPublicKey(secretKey)]),
+  MultibaseEncoding.BASE58_BTC,
+)
+
+class InMemorySigner implements Signer {
+  public getVerificationMethodId(): string {
+    return `did:key:${publicKeyMultibase}`
+  }
+
+  public async sign(input: SigningInput): Promise<SigningOutput> {
+    const data = await prepareDataForSigning(input.document, input.proof)
+    return { proofValue: multibaseEncode(ed25519.sign(data, secretKey), MultibaseEncoding.BASE58_BTC) }
+  }
+}
+
+class InMemoryVerifier implements Verifier {
+  public async verify(signature: Uint8Array, message: Uint8Array, publicKey: Uint8Array): Promise<boolean> {
+    try {
+      return ed25519.verify(signature, message, publicKey)
+    } catch {
+      return false
+    }
+  }
+}
+
+const signer = new InMemorySigner()
+const verifier = new InMemoryVerifier()
+const opts = { signer, verifier, domain: 'example.com' }
+
+async function makeFreshLog(): Promise<DIDLog> {
+  const domain = 'example.com'
+  const baseDid = `did:webvh:{SCID}:${domain}`
+
+  const created = await createDID({
+    domain,
+    signer,
+    verifier,
+    updateKeys: [publicKeyMultibase],
+    verificationMethods: [
+      {
+        id: `${baseDid}#${publicKeyMultibase.slice(-8)}`,
+        controller: baseDid,
+        type: 'Multikey',
+        publicKeyMultibase,
+      },
+    ],
+  })
+
+  const updated = await updateDID({
+    log: created.log,
+    signer,
+    verifier,
+    domain,
+    updateKeys: [publicKeyMultibase],
+    verificationMethods: created.doc.verificationMethod,
+    services: [
+      {
+        id: `${created.did}#test-service`,
+        type: 'TestService',
+        serviceEndpoint: 'https://example.com/test',
+      },
+    ],
+    controller: created.did,
+  })
+
+  return updated.log
+}
+
+describe('rebuildWebVhVersionTimes', () => {
+  it('returns null for an already-valid log (no-op)', async () => {
+    const log = await makeFreshLog()
+    expect(await rebuildWebVhVersionTimes(log, opts)).toBeNull()
+  })
+
+  // Fixture written by didwebvh-ts 2.7.4: create + immediate update landed in the same second,
+  // which >=2.8.0 rejects at resolution.
+  it('re-stamps a same-second legacy log so it resolves again', async () => {
+    const log = sameSecondLegacyLog as unknown as DIDLog
+    expect(log[0].versionTime).toBe(log[1].versionTime)
+    await expect(resolveDIDFromLog(log, { verifier })).rejects.toThrow(
+      /must be greater than previous entry time/i,
+    )
+
+    const newLog = await rebuildWebVhVersionTimes(log, opts)
+    expect(newLog).not.toBeNull()
+    expect(newLog!.length).toBe(log.length)
+    expect(newLog![0]).toEqual(log[0])
+    for (let i = 1; i < newLog!.length; i++) {
+      expect(Date.parse(newLog![i].versionTime)).toBeGreaterThan(Date.parse(newLog![i - 1].versionTime))
+    }
+
+    const resolved = await resolveDIDFromLog(newLog!, { verifier })
+    expect(resolved.meta.scid).toBe(log[0].parameters.scid)
+    expect(resolved.doc.service).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: expect.stringContaining('#test-service') })]),
+    )
+    expect(resolved.doc.verificationMethod).toEqual(log[log.length - 1].state.verificationMethod)
+
+    expect(await rebuildWebVhVersionTimes(newLog!, opts)).toBeNull()
+  })
+
+  it('also repairs hash-chain-broken logs (a hash break can mask a same-second pair)', async () => {
+    const log = await makeFreshLog()
+    const broken = log.map((entry, i) =>
+      i === 0
+        ? entry
+        : {
+            ...entry,
+            versionId: `${entry.versionId.split('-')[0]}-QmCorrupted0000000000000000000000000000000000000`,
+          },
+    ) as DIDLog
+    await expect(resolveDIDFromLog(broken, { verifier })).rejects.toThrow(/hash chain broken/i)
+
+    const newLog = await rebuildWebVhVersionTimes(broken, opts)
+    expect(newLog).not.toBeNull()
+    expect(newLog![0]).toEqual(log[0])
+    for (let i = 1; i < newLog!.length; i++) {
+      expect(newLog![i].versionTime).toBe(log[i].versionTime)
+    }
+    const resolved = await resolveDIDFromLog(newLog!, { verifier })
+    expect(resolved.meta.scid).toBe(log[0].parameters.scid)
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,8 +131,8 @@ importers:
         specifier: 0.0.2-alpha.5
         version: 0.0.2-alpha.5(@credo-ts/anoncreds@0.7.1-pr-2704-20260630143332(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.7.2))(@credo-ts/core@0.7.1-pr-2704-20260630143332(typescript@5.7.2))
       didwebvh-ts:
-        specifier: ^2.7.4
-        version: 2.7.4
+        specifier: ^2.8.0
+        version: 2.8.0
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
@@ -500,8 +500,8 @@ importers:
         specifier: 0.0.2-alpha.5
         version: 0.0.2-alpha.5(@credo-ts/anoncreds@0.7.1-pr-2704-20260630143332(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.8.3))(@credo-ts/core@0.7.1-pr-2704-20260630143332(typescript@5.8.3))
       didwebvh-ts:
-        specifier: ^2.7.4
-        version: 2.7.4
+        specifier: ^2.8.0
+        version: 2.8.0
       express:
         specifier: ^4.18.1
         version: 4.21.2
@@ -1794,6 +1794,10 @@ packages:
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
     engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -3320,8 +3324,8 @@ packages:
   did-resolver@4.1.0:
     resolution: {integrity: sha512-S6fWHvCXkZg2IhS4RcVHxwuyVejPR7c+a4Go0xbQ9ps5kILa8viiYQgrM4gfTyeTjJ0ekgJH9gk/BawTpmkbZA==}
 
-  didwebvh-ts@2.7.4:
-    resolution: {integrity: sha512-4AH4xITOgEQ7EfqGDm3ZgtzD8Rt44xj1z1mZ0YrWZnr5RUaNt30BSMn46HrOt58Ydd03EETNF+jCT4c9qNCy7g==}
+  didwebvh-ts@2.8.0:
+    resolution: {integrity: sha512-JAIK/Udr7xbGoYTDRjbm34nD8iddREIQffRL+vsrCaREyVtZDuy8SdFs5lXoop9zwEjXwh64ZFRSOYm6ZCZcAw==}
     hasBin: true
 
   diff@4.0.2:
@@ -4201,9 +4205,6 @@ packages:
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
-
-  json-canonicalize@1.2.0:
-    resolution: {integrity: sha512-TTdjBvqrqJKSADlEsY5rWbx8/1tOrVlTR/aSLU8N2VSInCTffP0p+byYB8Es+OmL4ZOeEftjUdvV+eJeSzJC/Q==}
 
   json-canonicalize@2.0.0:
     resolution: {integrity: sha512-yyrnK/mEm6Na3ChbJUWueXdapueW0p380RUyTW87XGb1ww8l8hU0pRrGC3vSWHe9CxrbPHX2fGUOZpNiHR0IIg==}
@@ -6743,7 +6744,7 @@ snapshots:
       '@credo-ts/core': 0.7.1-pr-2704-20260630143332(typescript@5.7.2)
       class-transformer: 0.5.1
       class-validator: 0.14.3
-      didwebvh-ts: 2.7.4
+      didwebvh-ts: 2.8.0
       json-canonicalize: 2.0.0
       tsyringe: 4.8.0
     transitivePeerDependencies:
@@ -6758,7 +6759,7 @@ snapshots:
       '@credo-ts/core': 0.7.1-pr-2704-20260630143332(typescript@5.8.3)
       class-transformer: 0.5.1
       class-validator: 0.14.3
-      didwebvh-ts: 2.7.4
+      didwebvh-ts: 2.8.0
       json-canonicalize: 2.0.0
       tsyringe: 4.8.0
     transitivePeerDependencies:
@@ -7551,6 +7552,8 @@ snapshots:
   '@noble/hashes@1.8.0': {}
 
   '@noble/hashes@2.0.1': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8386,7 +8389,7 @@ snapshots:
       ajv-formats: 3.0.1(ajv@8.17.1)
       canonicalize: 2.1.0
       did-resolver: 4.1.0
-      didwebvh-ts: 2.7.4
+      didwebvh-ts: 2.8.0
       jsonld: 8.3.3(web-streams-polyfill@3.3.3)
       tslog: 4.10.2
       web-did-resolver: 2.0.32
@@ -9272,13 +9275,13 @@ snapshots:
 
   did-resolver@4.1.0: {}
 
-  didwebvh-ts@2.7.4:
+  didwebvh-ts@2.8.0:
     dependencies:
-      '@noble/hashes': 1.8.0
+      '@noble/hashes': 2.2.0
       cookie: 1.1.1
       glob: 13.0.6
       js-yaml: 4.1.1
-      json-canonicalize: 1.2.0
+      json-canonicalize: 2.0.0
 
   diff@4.0.2: {}
 
@@ -10438,8 +10441,6 @@ snapshots:
   jsesc@3.1.0: {}
 
   json-buffer@3.0.1: {}
-
-  json-canonicalize@1.2.0: {}
 
   json-canonicalize@2.0.0: {}
 


### PR DESCRIPTION
Bumps `didwebvh-ts` to ^2.8.0 and adds a self-healing migration for existing DID logs.

2.8.0 rejects logs where consecutive entries share the same `versionTime` (spec rule). Our create+update-at-init flow produced exactly that, so existing DIDs fail to resolve and cannot be updated after the bump.

- New `migrateWebVhVersionTimeIfBroken` runs at agent init, before the existing hash-chain migration. It rebuilds entries 2..N with strictly increasing versionTimes (previous + 1s on collision), re-signed with the agent's update key. Entry `#1` is untouched, so the SCID and public DID do not change.
- Also repairs hash-broken logs, since a hash break can mask a same-second pair behind it.
- Idempotent. Migrated logs still resolve on 2.7.x (verified against Hologram's patched 2.7.4).
- Test fixture is a real same-second log written by didwebvh-ts 2.7.4.

Note: an upgraded agent cannot resolve other vs-agent deployments that still publish same-second logs, so all deployments should be upgraded and restarted around the same time. Hologram/Verre stay on 2.7.4 until that is done.

Closes #487 