### PR TITLE
feat(vs-agent-ui): restyle dashboard to the Verana Protocol Grid design

### DIFF
--- a/apps/vs-agent-ui/index.html
+++ b/apps/vs-agent-ui/index.html
@@ -4,6 +4,29 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>VS Agent</title>
+    <!-- Set the theme before paint: stored choice, else the OS preference,
+         falling back to dark (the Protocol Grid default, as on verana.io). -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('vsa-theme')
+          var theme =
+            stored ||
+            (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark')
+          document.documentElement.setAttribute('data-theme', theme)
+        } catch (e) {
+          document.documentElement.setAttribute('data-theme', 'dark')
+        }
+      })()
+    </script>
+    <!-- Family type: Space Grotesk (display), Inter (body), IBM Plex Mono
+         (identifiers). Degrades to system stacks when offline. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -1,24 +1,67 @@
-/* ─── Typography variables ───────────────────────────────── */
-:root {
-  --text-xs:   11px;   /* badges, type labels */
-  --text-sm:   12px;   /* small labels, mono values */
-  --text-base: 14px;   /* body, info rows */
-  --text-md:   15px;   /* default body */
-  --text-lg:   16px;   /* modal h2, form h2 */
-  --text-xl:   20px;   /* section titles */
-  --text-2xl:  24px;   /* large numbers */
-  --text-3xl:  30px;   /* h1 welcome */
+/* ===========================================================================
+   vs-agent-ui — "Protocol Grid" design tokens (verana.io family).
 
-  --fw-normal:  400;
+   Verana purple as PRIMARY, Electric Blue as ACCENT, Signal Green as the
+   verified/trust color. Space Grotesk display, Inter body, IBM Plex Mono for
+   identifiers. Dark-first; tokens re-bound under [data-theme="light"], with
+   the accents adjusted for WCAG-AA on white. Theme is set pre-paint in
+   index.html and toggled from the header.
+=========================================================================== */
+
+:root {
+  /* Brand */
+  --color-primary: #763ef0;        /* Verana purple (family DNA) */
+  --color-primary-bright: #8c5bff; /* hover / emphasis */
+  --color-accent: #2e6be6;         /* Electric Blue — product accent */
+  --color-success: #29c68c;        /* Signal Green — verified fill / chip */
+  --color-success-ink: #29c68c;    /* Signal Green as TEXT */
+  --color-danger: #f0564a;
+
+  /* Surfaces (dark-first) */
+  --color-bg: #0b0b12;             /* page background (Ink Black) */
+  --color-surface: #151824;        /* cards / panels (Graphite) */
+  --color-surface-2: #1f2331;      /* muted surface */
+  --color-rule: #2a2e3d;           /* borders / dividers */
+  --color-ink: #ffffff;            /* primary text */
+  --color-muted: #8b94a5;          /* secondary text */
+
+  /* Type */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-display: 'Space Grotesk', var(--font-sans);
+  --font-mono: 'IBM Plex Mono', ui-monospace, 'SFMono-Regular', Menlo, monospace;
+
+  --text-xs: 11px;
+  --text-sm: 12px;
+  --text-base: 14px;
+  --text-md: 15px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+  --text-3xl: 30px;
+
+  --fw-normal: 400;
   --fw-semibold: 600;
 
-  --color-text-primary:   #111827;
-  --color-text-secondary: #374151;
-  --color-text-muted:     #6b7280;
-  --color-text-subtle:    #9ca3af;
-
-  --lh-tight:  1.25;
+  --lh-tight: 1.25;
   --lh-normal: 1.5;
+
+  color-scheme: dark;
+}
+
+/* Light mode: same tokens, accents adjusted for AA on white. */
+[data-theme='light'] {
+  --color-bg: #ffffff;
+  --color-surface: #f4f5f8;
+  --color-surface-2: #eceef3;
+  --color-rule: #e3e6ec;
+  --color-ink: #0b0b12;
+  --color-muted: #566071;
+
+  --color-accent: #1f57c9;      /* darker electric blue, AA on white */
+  --color-success-ink: #0e7a57; /* darker green for success TEXT on white */
+  --color-primary-bright: #763ef0;
+  --color-danger: #cc2f24;
+  color-scheme: light;
 }
 
 * {
@@ -27,13 +70,69 @@
   padding: 0;
 }
 
+html {
+  background: var(--color-bg);
+  color: var(--color-ink);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 body {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--font-sans);
   font-size: var(--text-md);
   font-weight: var(--fw-normal);
   line-height: var(--lh-normal);
-  background: #f3f4f6;
-  color: var(--color-text-primary);
+  background: var(--color-bg);
+  color: var(--color-ink);
+}
+
+::selection {
+  background: color-mix(in srgb, var(--color-primary) 35%, transparent);
+}
+
+/* ─── Shared recipes (verana.io) ─────────────────────────── */
+.display {
+  font-family: var(--font-display);
+  letter-spacing: -0.025em;
+  font-weight: var(--fw-semibold);
+  line-height: 1.05;
+}
+
+.wordmark {
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--color-ink);
+  white-space: nowrap;
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-rule);
+  color: var(--color-muted);
+  background: var(--color-surface);
+}
+
+.chip-verified {
+  color: var(--color-success-ink);
+  border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-rule));
 }
 
 /* ─── Layout ─────────────────────────────────────────────── */
@@ -45,8 +144,9 @@ body {
 
 /* ─── Header ─────────────────────────────────────────────── */
 .header {
-  background: #fff;
-  border-bottom: 1px solid #e5e7eb;
+  background: color-mix(in srgb, var(--color-bg) 85%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-rule);
   height: 60px;
   display: flex;
   align-items: center;
@@ -62,21 +162,19 @@ body {
   display: flex;
   align-items: center;
   gap: 10px;
-  width: 200px;
   flex-shrink: 0;
 }
 
 .header-logo-icon {
-  width: 32px;
-  height: 32px;
+  width: 26px;
+  height: 26px;
   flex-shrink: 0;
+  border-radius: 6px;
   line-height: var(--lh-tight);
 }
 
 .header-logo-name {
   font-size: var(--text-lg);
-  font-weight: var(--fw-semibold);
-  color: var(--color-text-primary);
   line-height: var(--lh-tight);
 }
 
@@ -87,7 +185,7 @@ body {
 .header h1 {
   font-size: var(--text-md);
   font-weight: var(--fw-normal);
-  color: var(--color-text-muted);
+  color: var(--color-muted);
   line-height: var(--lh-tight);
 }
 
@@ -104,22 +202,49 @@ body {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #9ca3af;
+  background: var(--color-muted);
 }
 
 .status-dot.connected {
-  background: #22c55e;
+  background: var(--color-success);
 }
 
 .status-label {
-  color: var(--color-text-muted);
+  color: var(--color-muted);
 }
 
+/* Theme toggle */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid var(--color-rule);
+  background: transparent;
+  color: var(--color-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.theme-toggle:hover {
+  color: var(--color-ink);
+  border-color: var(--color-primary);
+}
 
 /* ─── Content ────────────────────────────────────────────── */
 .content {
   padding: 28px;
   min-width: 0;
+}
+
+/* Welcome headline */
+.welcome {
+  font-size: 32px;
+  color: var(--color-ink);
+  margin-bottom: 28px;
+  text-align: center;
 }
 
 /* ─── Cards ──────────────────────────────────────────────── */
@@ -131,32 +256,39 @@ body {
 }
 
 .card {
-  background: #fff;
-  border-radius: 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
   padding: 20px 24px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
+  box-shadow: 0 10px 32px -24px rgb(0 0 0 / 0.55);
+}
+
+[data-theme='light'] .card {
+  box-shadow: 0 10px 28px -24px rgb(11 11 18 / 0.28);
 }
 
 .card-label {
-  font-size: var(--text-sm);
-  font-weight: var(--fw-semibold);
-  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-muted);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.16em;
   margin-bottom: 8px;
   line-height: var(--lh-normal);
 }
 
 .card-value {
+  font-family: var(--font-display);
   font-size: var(--text-2xl);
   font-weight: var(--fw-semibold);
-  color: var(--color-text-primary);
+  color: var(--color-ink);
   line-height: var(--lh-tight);
 }
 
 .card-sub {
   font-size: var(--text-sm);
-  color: var(--color-text-muted);
+  color: var(--color-muted);
   margin-top: 4px;
   word-break: break-all;
   line-height: var(--lh-normal);
@@ -169,12 +301,17 @@ body {
 
 /* ─── Agent info card ────────────────────────────────────── */
 .agent-info-card {
-  background: #fff;
-  border-radius: 12px;
-  padding: 8px 0;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
+  padding: 8px 0 24px;
+  box-shadow: 0 10px 32px -24px rgb(0 0 0 / 0.55);
   max-width: 960px;
   margin: 0 auto;
+}
+
+[data-theme='light'] .agent-info-card {
+  box-shadow: 0 10px 28px -24px rgb(11 11 18 / 0.28);
 }
 
 .agent-info-row {
@@ -182,19 +319,22 @@ body {
   align-items: baseline;
   gap: 12px;
   padding: 12px 20px;
-  border-bottom: 1px solid #f3f4f6;
+  border-bottom: 1px solid var(--color-rule);
 }
 
-.agent-info-row:last-child {
+.agent-info-row:last-of-type {
   border-bottom: none;
 }
 
 .agent-info-label {
   flex-shrink: 0;
   width: 120px;
-  font-size: var(--text-base);
-  font-weight: var(--fw-semibold);
-  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--color-muted);
   line-height: var(--lh-normal);
 }
 
@@ -202,7 +342,7 @@ body {
   flex: 1;
   font-size: var(--text-base);
   font-weight: var(--fw-normal);
-  color: var(--color-text-primary);
+  color: var(--color-ink);
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -211,7 +351,7 @@ body {
 }
 
 .agent-info-mono {
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: var(--text-sm);
   white-space: normal;
   word-break: break-all;
@@ -219,30 +359,37 @@ body {
   text-overflow: unset;
 }
 
+.text-subtle {
+  color: var(--color-muted);
+}
+
 .status-pill {
   display: inline-block;
   padding: 2px 10px;
   border-radius: 999px;
+  font-family: var(--font-mono);
   font-size: var(--text-sm);
-  font-weight: var(--fw-semibold);
+  font-weight: 500;
   line-height: var(--lh-normal);
 }
 
 .status-pill--ok {
-  background: #d1fae5;
-  color: #065f46;
+  background: color-mix(in srgb, var(--color-success) 16%, transparent);
+  color: var(--color-success-ink);
 }
 
 .status-pill--warn {
-  background: #fef3c7;
-  color: #92400e;
+  background: color-mix(in srgb, #f5b942 18%, transparent);
+  color: #b97f16;
 }
 
 /* ─── Section title ──────────────────────────────────────── */
 .section-title {
+  font-family: var(--font-display);
+  letter-spacing: -0.025em;
   font-size: var(--text-xl);
   font-weight: var(--fw-semibold);
-  color: var(--color-text-secondary);
+  color: var(--color-ink);
   line-height: var(--lh-tight);
   margin-bottom: 16px;
   margin-top: 8px;
@@ -263,55 +410,100 @@ body {
 }
 
 .subtle-link:hover {
+  color: var(--color-accent);
   text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .cred-card-details-btn {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 14px;
+  right: 14px;
   background: none;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-rule);
   border-radius: 6px;
   padding: 2px 7px;
-  font-size: 11px;
-  font-family: 'Fira Code', 'Courier New', monospace;
-  color: #6b7280;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-muted);
   cursor: pointer;
   line-height: 1.6;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 
 .cred-card-details-btn:hover {
-  background: #f3f4f6;
-  color: #374151;
-  border-color: #9ca3af;
+  background: var(--color-surface-2);
+  color: var(--color-ink);
+  border-color: var(--color-primary);
 }
 
+/* ECS type — a verified chip, as on verana.io's Proof-of-Trust card */
 .cred-card-type {
-  font-size: var(--text-xs);
-  font-weight: var(--fw-semibold);
-  color: #6d28d9;
-  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
   letter-spacing: 0.06em;
-  margin-bottom: 10px;
+  text-transform: uppercase;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--color-success) 45%, var(--color-rule));
+  color: var(--color-success-ink);
+  background: var(--color-surface);
+  margin-bottom: 14px;
   line-height: var(--lh-normal);
 }
 
 .cred-card {
-  background: #fff;
-  border-radius: 12px;
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
   padding: 20px 24px;
-  border: 1px solid #e5e7eb;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 10px 32px -24px rgb(0 0 0 / 0.55);
   width: 100%;
   max-width: 960px;
   min-width: 0;
-  transition: box-shadow 0.15s ease;
+  transition: border-color 0.15s ease;
+}
+
+[data-theme='light'] .cred-card {
+  box-shadow: 0 10px 28px -24px rgb(11 11 18 / 0.28);
 }
 
 .cred-card:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.10), 0 1px 4px rgba(0, 0, 0, 0.06);
+  border-color: color-mix(in srgb, var(--color-primary) 55%, var(--color-rule));
+}
+
+/* Section label inside a credential card (Schema / Issuer / Attributes) */
+.cred-section {
+  margin-bottom: 10px;
+}
+
+.cred-section-label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--color-muted);
+  border-bottom: 1px solid var(--color-rule);
+  padding-bottom: 4px;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.cred-field-value {
+  font-size: var(--text-base);
+  color: var(--color-ink);
+  word-break: break-all;
+  line-height: var(--lh-normal);
+}
+
+.cred-field-mono {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
 }
 
 .cred-card-attrs {
@@ -332,9 +524,9 @@ body {
 }
 
 .cred-card-attrs td:first-child {
+  font-family: var(--font-mono);
   font-size: var(--text-sm);
-  color: var(--color-text-muted);
-  font-weight: var(--fw-semibold);
+  color: var(--color-muted);
   padding-right: 12px;
   white-space: normal;
   word-break: break-word;
@@ -342,7 +534,7 @@ body {
 }
 
 .cred-card-attrs td:last-child {
-  color: var(--color-text-primary);
+  color: var(--color-ink);
   word-break: break-all;
   overflow-wrap: anywhere;
   white-space: normal;
@@ -355,28 +547,62 @@ body {
 
 /* ─── Buttons ────────────────────────────────────────────── */
 .btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
   border: none;
-  border-radius: 6px;
+  border-radius: 0.6rem;
   padding: 6px 14px;
+  font-family: var(--font-sans);
   font-size: var(--text-base);
   font-weight: var(--fw-semibold);
   cursor: pointer;
-  transition: opacity 0.15s;
+  text-decoration: none;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
   line-height: var(--lh-normal);
 }
 
-.btn:hover { opacity: 0.85; }
+.btn:hover {
+  transform: translateY(-1px);
+}
 
-.btn-edit   { background: #ede9fe; color: #6d28d9; }
-.btn-delete { background: #fee2e2; color: #dc2626; }
-.btn-primary   { background: #7c3aed; color: #fff; padding: 8px 18px; }
-.btn-secondary { background: #e5e7eb; color: var(--color-text-secondary); padding: 8px 18px; }
+.btn-edit {
+  background: color-mix(in srgb, var(--color-primary) 16%, transparent);
+  color: var(--color-primary-bright);
+}
+
+.btn-delete {
+  background: color-mix(in srgb, var(--color-danger) 14%, transparent);
+  color: var(--color-danger);
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: #ffffff;
+  padding: 8px 18px;
+}
+
+.btn-primary:hover {
+  background: var(--color-primary-bright);
+}
+
+.btn-secondary {
+  background: transparent;
+  border: 1px solid var(--color-rule);
+  color: var(--color-ink);
+  padding: 8px 18px;
+}
+
+.btn-secondary:hover {
+  border-color: var(--color-primary);
+}
 
 /* ─── Modal ──────────────────────────────────────────────── */
 .modal-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -385,38 +611,74 @@ body {
 }
 
 .modal {
-  background: #fff;
-  border-radius: 14px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
   padding: 28px;
   width: 540px;
   max-width: 100%;
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
 }
 
 .modal h2 {
+  font-family: var(--font-display);
+  letter-spacing: -0.025em;
   font-size: var(--text-lg);
   font-weight: var(--fw-semibold);
-  color: var(--color-text-primary);
+  color: var(--color-ink);
   line-height: var(--lh-tight);
   margin-bottom: 16px;
+}
+
+.modal-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.modal-head h2 {
+  margin: 0;
+}
+
+.modal--json {
+  width: 780px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.json-pre {
+  flex: 1;
+  overflow: auto;
+  font-size: var(--text-sm);
+  font-family: var(--font-mono);
+  background: var(--color-bg);
+  border: 1px solid var(--color-rule);
+  border-radius: 8px;
+  padding: 16px;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  color: var(--color-ink);
 }
 
 .modal textarea {
   width: 100%;
   height: 240px;
-  font-family: 'Fira Code', 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-size: var(--text-sm);
   padding: 12px;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-rule);
   border-radius: 8px;
   resize: vertical;
-  background: #f9fafb;
-  color: var(--color-text-primary);
+  background: var(--color-bg);
+  color: var(--color-ink);
   line-height: var(--lh-normal);
 }
 
 .modal textarea:focus {
-  outline: 2px solid #7c3aed;
+  outline: 2px solid var(--color-primary);
   border-color: transparent;
 }
 
@@ -429,18 +691,20 @@ body {
 
 /* ─── Create form ────────────────────────────────────────── */
 .create-form {
-  background: #fff;
-  border-radius: 12px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
   padding: 24px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
   max-width: 560px;
   margin-bottom: 32px;
 }
 
 .create-form h2 {
+  font-family: var(--font-display);
+  letter-spacing: -0.025em;
   font-size: var(--text-lg);
   font-weight: var(--fw-semibold);
-  color: var(--color-text-primary);
+  color: var(--color-ink);
   line-height: var(--lh-tight);
   margin-bottom: 16px;
 }
@@ -453,7 +717,7 @@ body {
   display: block;
   font-size: var(--text-base);
   font-weight: var(--fw-semibold);
-  color: var(--color-text-secondary);
+  color: var(--color-ink);
   margin-bottom: 6px;
   line-height: var(--lh-normal);
 }
@@ -461,11 +725,11 @@ body {
 .form-group select,
 .form-group textarea {
   width: 100%;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--color-rule);
   border-radius: 8px;
   font-size: var(--text-base);
-  background: #fff;
-  color: var(--color-text-primary);
+  background: var(--color-bg);
+  color: var(--color-ink);
   line-height: var(--lh-normal);
 }
 
@@ -475,16 +739,15 @@ body {
 
 .form-group textarea {
   height: 160px;
-  font-family: 'Fira Code', 'Courier New', monospace;
+  font-family: var(--font-mono);
   font-size: var(--text-sm);
   padding: 10px 12px;
   resize: vertical;
-  background: #f9fafb;
 }
 
 .form-group select:focus,
 .form-group textarea:focus {
-  outline: 2px solid #7c3aed;
+  outline: 2px solid var(--color-primary);
   border-color: transparent;
 }
 
@@ -498,14 +761,29 @@ body {
 }
 
 .qr-card {
-  background: #fff;
-  border-radius: 16px;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
   padding: 40px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.07);
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 20px;
+}
+
+/* White tile behind the QR so it scans in dark mode too */
+.qr-tile {
+  background: #ffffff;
+  border: 1px solid var(--color-rule);
+  border-radius: 12px;
+  padding: 12px;
+  display: inline-block;
+}
+
+.qr-tile img {
+  display: block;
+  width: 256px;
+  height: 256px;
 }
 
 .qr-card img {
@@ -515,20 +793,35 @@ body {
 }
 
 .qr-label {
-  font-size: var(--text-md);
-  font-weight: var(--fw-normal);
-  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  margin-top: 8px;
   line-height: var(--lh-normal);
 }
 
 /* ─── Utilities ──────────────────────────────────────────── */
-.loading  { color: var(--color-text-muted); font-size: var(--text-base); padding: 20px 0; line-height: var(--lh-normal); }
-.empty-msg { color: var(--color-text-subtle); font-size: var(--text-base); padding: 16px 0; line-height: var(--lh-normal); text-align: center; }
+.loading {
+  color: var(--color-muted);
+  font-size: var(--text-base);
+  padding: 20px 0;
+  line-height: var(--lh-normal);
+}
+
+.empty-msg {
+  color: var(--color-muted);
+  font-size: var(--text-base);
+  padding: 16px 0;
+  line-height: var(--lh-normal);
+  text-align: center;
+}
+
 .error-msg {
-  color: #dc2626;
+  color: var(--color-danger);
   font-size: var(--text-base);
   padding: 12px 16px;
-  background: #fee2e2;
+  background: color-mix(in srgb, var(--color-danger) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 35%, var(--color-rule));
   border-radius: 8px;
   margin-bottom: 16px;
   line-height: var(--lh-normal);
@@ -541,6 +834,7 @@ body {
 @media (max-width: 768px) {
   .qr-desktop { display: none; }
   .qr-mobile { display: block; }
+
   .header {
     padding: 0 16px;
     gap: 12px;
@@ -558,6 +852,10 @@ body {
     padding: 20px 16px;
   }
 
+  .welcome {
+    font-size: 26px;
+  }
+
   .cards-grid {
     grid-template-columns: 1fr 1fr;
     gap: 12px;
@@ -569,7 +867,7 @@ body {
 
   .cred-card {
     padding: 16px;
-    border-radius: 8px;
+    border-radius: 12px;
     max-width: 100%;
   }
 
@@ -589,6 +887,11 @@ body {
     padding: 28px 20px;
   }
 
+  .qr-tile img {
+    width: 200px;
+    height: 200px;
+  }
+
   .qr-card img {
     width: 200px;
     height: 200px;
@@ -601,7 +904,7 @@ body {
   }
 
   .header-logo-icon {
-    width: 28px;
-    height: 28px;
+    width: 24px;
+    height: 24px;
   }
 }

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -14,15 +14,15 @@ function JsonModal({ data, onClose }) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" style={{ width: 780, maxHeight: '80vh', display: 'flex', flexDirection: 'column' }} onClick={e => e.stopPropagation()}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-          <h2 style={{ margin: 0 }}>JSON</h2>
+      <div className="modal modal--json" onClick={e => e.stopPropagation()}>
+        <div className="modal-head">
+          <h2>JSON</h2>
           <div style={{ display: 'flex', gap: 8 }}>
             <button className="btn btn-secondary" onClick={copy}>{copied ? 'Copied!' : 'Copy'}</button>
             <button className="btn btn-secondary" onClick={onClose}>Close</button>
           </div>
         </div>
-        <pre style={{ flex: 1, overflow: 'auto', fontSize: 12, fontFamily: "'Fira Code', 'Courier New', monospace", background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: 8, padding: 16, margin: 0, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+        <pre className="json-pre">
           {json}
         </pre>
       </div>
@@ -66,10 +66,8 @@ function AttrValue({ value }) {
 
 function CardSection({ label, children }) {
   return (
-    <div style={{ marginBottom: 10 }}>
-      <div style={{ fontSize: 12, fontWeight: 600, color: '#6b7280', borderBottom: '1px solid #e5e7eb', paddingBottom: 4, marginBottom: 8, textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-        {label}
-      </div>
+    <div className="cred-section">
+      <div className="cred-section-label">{label}</div>
       {children}
     </div>
   )
@@ -83,13 +81,13 @@ function CredentialCard({ vc, type, onSelect }) {
   const hasAttrs = subject.id || attrs.length > 0
 
   return (
-    <div className="cred-card" style={{ position: 'relative' }}>
+    <div className="cred-card">
       <button className="cred-card-details-btn" onClick={onSelect} title="View details">{'{ }'}</button>
       {type && <div className="cred-card-type">{type}</div>}
 
       {schemaId && (
         <CardSection label="Schema">
-          <div style={{ fontSize: 14, color: '#111827', wordBreak: 'break-all', lineHeight: 1.5 }}>
+          <div className="cred-field-value cred-field-mono">
             <LinkOrText text={schemaId} />
           </div>
         </CardSection>
@@ -97,7 +95,7 @@ function CredentialCard({ vc, type, onSelect }) {
 
       {issuer && (
         <CardSection label="Issuer">
-          <div style={{ fontSize: 14, color: '#111827', wordBreak: 'break-all', lineHeight: 1.5 }}>
+          <div className="cred-field-value cred-field-mono">
             <LinkOrText text={issuer} />
           </div>
         </CardSection>
@@ -214,13 +212,13 @@ export default function Dashboard() {
       {selected && <JsonModal data={selected} onClose={() => setSelected(null)} />}
 
       {agentConfig.welcomeMessage && (
-        <h1 style={{ fontSize: 32, fontWeight: 700, color: '#111827', marginBottom: 28, textAlign: 'center' }}>
+        <h1 className="welcome display">
           {agentConfig.welcomeMessage}
         </h1>
       )}
 
       <section style={{ marginBottom: 32 }}>
-        <h2 style={{ fontSize: 20, fontWeight: 600, color: '#111827', marginBottom: 16, textAlign: 'center' }}>
+        <h2 className="section-title">
           VS Agent Information
         </h2>
 
@@ -233,7 +231,7 @@ export default function Dashboard() {
           <div className="agent-info-row">
             <span className="agent-info-label">Public DID</span>
             <span className="agent-info-value agent-info-mono">
-              {webDid ? <LinkOrText text={webDid} /> : <span style={{ color: '#9ca3af' }}>Not assigned</span>}
+              {webDid ? <LinkOrText text={webDid} /> : <span className="text-subtle">Not assigned</span>}
             </span>
           </div>
 
@@ -249,8 +247,10 @@ export default function Dashboard() {
           <div className="qr-desktop">
             <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 24 }}>
               <div style={{ textAlign: 'center' }}>
-                <img src={qrUrl} alt="Invitation QR" style={{ width: 280, height: 280, display: 'block' }} />
-                <p style={{ fontSize: 12, color: '#6b7280', marginTop: 8 }}>Scan to connect</p>
+                <span className="qr-tile">
+                  <img src={qrUrl} alt="Invitation QR" />
+                </span>
+                <p className="qr-label">Scan to connect</p>
               </div>
             </div>
           </div>
@@ -279,10 +279,10 @@ export default function Dashboard() {
         title="Schema Credentials"
         items={jscItems}
         renderItem={(item, i) => (
-          <div key={i} className="cred-card" style={{ position: 'relative' }}>
+          <div key={i} className="cred-card">
             <button className="cred-card-details-btn" onClick={() => setSelected(item.service)} title="View details">{'{ }'}</button>
             <div className="cred-card-type">{item.type}</div>
-            <div style={{ fontSize: 12, color: '#6b7280', wordBreak: 'break-all' }}>
+            <div className="cred-field-value cred-field-mono text-subtle">
               <LinkOrText text={item.service.serviceEndpoint} />
             </div>
           </div>

--- a/apps/vs-agent-ui/src/components/Header.jsx
+++ b/apps/vs-agent-ui/src/components/Header.jsx
@@ -1,12 +1,72 @@
+import { useEffect, useState } from 'react'
 import logoSvg from '../assets/logo.svg'
 
+const THEME_KEY = 'vsa-theme'
+
 export default function Header() {
+  const [theme, setTheme] = useState('dark')
+
+  useEffect(() => {
+    const current = document.documentElement.getAttribute('data-theme')
+    setTheme(current === 'light' ? 'light' : 'dark')
+  }, [])
+
+  function toggleTheme() {
+    const next = theme === 'dark' ? 'light' : 'dark'
+    setTheme(next)
+    document.documentElement.setAttribute('data-theme', next)
+    try {
+      localStorage.setItem(THEME_KEY, next)
+    } catch {
+      /* ignore */
+    }
+  }
+
   return (
     <header className="header">
       <div className="header-logo">
         <img src={logoSvg} alt="Verana" className="header-logo-icon" />
-        <span className="header-logo-name">Verana</span>
+        <span className="header-logo-name wordmark">Verana</span>
       </div>
+      <div className="header-center" />
+      <button
+        type="button"
+        onClick={toggleTheme}
+        className="theme-toggle"
+        aria-label="Switch theme"
+        aria-pressed={theme === 'dark'}
+      >
+        {theme === 'dark' ? (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="12" cy="12" r="4" />
+            <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+          </svg>
+        ) : (
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+          </svg>
+        )}
+      </button>
     </header>
   )
 }


### PR DESCRIPTION
## What

Restyles the vs-agent dashboard (`apps/vs-agent-ui`) to the **Protocol Grid** design system used by [verana.io](https://verana.io), so the agent UI reads as part of the Verana family. **No content or behavior changes** — every section, label, string, and interaction (QR, connect button, JSON modal, loading/empty/error states) is exactly as before.

## Changes

- **Design tokens** (from verana.io's `globals.css`): Ink Black `#0B0B12` page / Graphite `#151824` cards, Verana purple `#763EF0` primary, Electric Blue accent, Signal Green for verified ECS-type chips. The light theme re-binds the same tokens with WCAG-AA-adjusted accents (`#1F57C9` blue, `#0E7A57` green).
- **Type**: Space Grotesk (display), Inter (body), IBM Plex Mono for DIDs, schemas, endpoints, and section eyebrows. Loaded from Google Fonts with graceful system-stack fallback offline.
- **Theming**: dark-first, set pre-paint in `index.html` (stored choice → OS preference → dark, key `vsa-theme`), with a theme toggle in the header — same pattern as the other Verana sites.
- **Cards**: drop-shadow white boxes → bordered graphite/gray surfaces with purple hover; credential ECS-type labels render as the green "verified" chip from verana.io's Proof-of-Trust card language.
- **QR code** sits on a white tile so it scans in dark mode.
- **Dashboard.jsx**: markup and text untouched; hardcoded inline hex colors moved into themed classes so both themes work.

## Verification

- `pnpm build` passes (output to `../vs-agent/public` as before).
- Rendered the built app against a mocked DID document (org credential with attributes + schema credential) and screenshot-checked: light mode, dark mode, and the JSON modal.