### PR TITLE
feat(vs-agent): ECS credential bootstrap for standalone and delegated modes

### DIFF
--- a/apps/vs-agent/README.md
+++ b/apps/vs-agent/README.md
@@ -128,6 +128,9 @@ These variables enable on-chain features (permission management, trust registry 
 | `VERANA_INDEXER_DEFAULT_HANDLERS_OVERRIDE` | OPTIONAL | Comma-separated indexer `msg` names whose default handler is disabled (or `*` for all), so a backend behind the container can override them and react via the `indexer-notification` webhook. State-sync bookkeeping is never affected. |
 | `VERANA_INDEXER_SUBSCRIPTION_SCOPE` | OPTIONAL | Scope of the indexer subscription and REST catch-up: `did` (default, only the agent's own DID) or `corporation` (all events for `VERANA_CORPORATION_ID`). |
 | `VERANA_CORPORATION_ID` | OPTIONAL | Corporation ID used when `VERANA_INDEXER_SUBSCRIPTION_SCOPE` is `corporation`. |
+| `AGENT_MODE` | OPTIONAL | `standalone` (default) or `delegated`. Selects how the agent obtains its ECS credentials at startup. |
+| `AGENT_DELEGATED_PARENT_VS_DID` | CONDITIONAL | DID of the parent Verifiable Service that issues the Service credential. Required when `AGENT_MODE` is `delegated`. |
+| `TRUSTED_ECS_ECOSYSTEM_DIDS` | CONDITIONAL | Comma-separated DIDs of the ECS ecosystems the agent trusts for essential credential schemas (WL-ECS). Required for the standalone ECS bootstrap. |
 
 * Required only if on-chain features are enabled.
 

--- a/apps/vs-agent/src/config/constants.ts
+++ b/apps/vs-agent/src/config/constants.ts
@@ -144,7 +144,10 @@ export const VERANA_INDEXER_SUBSCRIPTION_SCOPE = (process.env.VERANA_INDEXER_SUB
   .toLowerCase()
 export const VERANA_AUTO_TRIGGER_RESOLVER = process.env.VERANA_AUTO_TRIGGER_RESOLVER !== 'false'
 
-export const TRUSTED_ECS_ECOSYSTEM_ID = process.env.TRUSTED_ECS_ECOSYSTEM_ID
+export const TRUSTED_ECS_ECOSYSTEM_DIDS = (process.env.TRUSTED_ECS_ECOSYSTEM_DIDS ?? '')
+  .split(',')
+  .map(did => did.trim())
+  .filter(Boolean)
 export const AGENT_MODE = (process.env.AGENT_MODE ?? '').trim().toLowerCase() || 'standalone'
 export const AGENT_DELEGATED_PARENT_VS_DID = process.env.AGENT_DELEGATED_PARENT_VS_DID
 

--- a/apps/vs-agent/src/config/constants.ts
+++ b/apps/vs-agent/src/config/constants.ts
@@ -144,6 +144,7 @@ export const VERANA_INDEXER_SUBSCRIPTION_SCOPE = (process.env.VERANA_INDEXER_SUB
   .toLowerCase()
 export const VERANA_AUTO_TRIGGER_RESOLVER = process.env.VERANA_AUTO_TRIGGER_RESOLVER !== 'false'
 
+export const TRUSTED_ECS_ECOSYSTEM_ID = process.env.TRUSTED_ECS_ECOSYSTEM_ID
 export const AGENT_MODE = (process.env.AGENT_MODE ?? '').trim().toLowerCase() || 'standalone'
 export const AGENT_DELEGATED_PARENT_VS_DID = process.env.AGENT_DELEGATED_PARENT_VS_DID
 

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -12,6 +12,7 @@ import {
   VeranaChainService,
   IndexerWebSocketService,
   buildDefaultIndexerHandlerRegistry,
+  EcsBootstrapService,
 } from '@verana-labs/vs-agent-sdk'
 import * as express from 'express'
 import * as fs from 'fs'
@@ -72,6 +73,7 @@ import {
   VERANA_AUTO_TRIGGER_RESOLVER,
   AGENT_MODE,
   AGENT_DELEGATED_PARENT_VS_DID,
+  TRUSTED_ECS_ECOSYSTEM_ID,
 } from './config'
 import { MessagingPlugin, VtFlowNestPlugin } from './plugins'
 import { PublicModule } from './public.module'
@@ -157,6 +159,9 @@ const run = async () => {
   }
   if (AGENT_MODE === 'delegated' && !AGENT_DELEGATED_PARENT_VS_DID) {
     configErrors.push('AGENT_DELEGATED_PARENT_VS_DID is required when AGENT_MODE=delegated')
+  }
+  if (TRUSTED_ECS_ECOSYSTEM_ID && !/^\d+$/.test(TRUSTED_ECS_ECOSYSTEM_ID)) {
+    configErrors.push('TRUSTED_ECS_ECOSYSTEM_ID must be a non-negative integer')
   }
   if (configErrors.length > 0) {
     serverLogger.error(`Invalid configuration:\n- ${configErrors.join('\n- ')}`)
@@ -280,7 +285,7 @@ const run = async () => {
     }
   })()
 
-  const { agent } = await setupAgent({
+  const { agent, indexer, verifyPeer } = await setupAgent({
     endpoints,
     discoveryOptions,
     port: AGENT_PORT,
@@ -369,6 +374,22 @@ const run = async () => {
     })
     await indexerWs.start()
   }
+
+  const ecsBootstrap = new EcsBootstrapService(
+    agent,
+    indexer,
+    {
+      mode: AGENT_MODE as 'standalone' | 'delegated',
+      trustedEcosystemId: TRUSTED_ECS_ECOSYSTEM_ID ? Number(TRUSTED_ECS_ECOSYSTEM_ID) : undefined,
+      delegatedParentVsDid: AGENT_DELEGATED_PARENT_VS_DID,
+      verifyPeer,
+    },
+    serverLogger,
+  )
+  void ecsBootstrap.run().catch((error: Error) => {
+    serverLogger.error(`[EcsBootstrap] ${error.message}`)
+    if (AGENT_MODE === 'delegated') process.exit(1)
+  })
 
   // Accept incoming DIDComm only after the catch-up, so the agent does not act on stale chain state.
   if (webSocketServer) {

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -73,7 +73,7 @@ import {
   VERANA_AUTO_TRIGGER_RESOLVER,
   AGENT_MODE,
   AGENT_DELEGATED_PARENT_VS_DID,
-  TRUSTED_ECS_ECOSYSTEM_ID,
+  TRUSTED_ECS_ECOSYSTEM_DIDS,
 } from './config'
 import { MessagingPlugin, VtFlowNestPlugin } from './plugins'
 import { PublicModule } from './public.module'
@@ -160,8 +160,8 @@ const run = async () => {
   if (AGENT_MODE === 'delegated' && !AGENT_DELEGATED_PARENT_VS_DID) {
     configErrors.push('AGENT_DELEGATED_PARENT_VS_DID is required when AGENT_MODE=delegated')
   }
-  if (TRUSTED_ECS_ECOSYSTEM_ID && !/^\d+$/.test(TRUSTED_ECS_ECOSYSTEM_ID)) {
-    configErrors.push('TRUSTED_ECS_ECOSYSTEM_ID must be a non-negative integer')
+  if (TRUSTED_ECS_ECOSYSTEM_DIDS.some(did => !did.startsWith('did:'))) {
+    configErrors.push('TRUSTED_ECS_ECOSYSTEM_DIDS must be a comma-separated list of DIDs')
   }
   if (configErrors.length > 0) {
     serverLogger.error(`Invalid configuration:\n- ${configErrors.join('\n- ')}`)
@@ -380,7 +380,7 @@ const run = async () => {
     indexer,
     {
       mode: AGENT_MODE as 'standalone' | 'delegated',
-      trustedEcosystemId: TRUSTED_ECS_ECOSYSTEM_ID ? Number(TRUSTED_ECS_ECOSYSTEM_ID) : undefined,
+      trustedEcosystemDids: TRUSTED_ECS_ECOSYSTEM_DIDS.length ? TRUSTED_ECS_ECOSYSTEM_DIDS : undefined,
       delegatedParentVsDid: AGENT_DELEGATED_PARENT_VS_DID,
       verifyPeer,
     },

--- a/apps/vs-agent/src/utils/setupAgent.ts
+++ b/apps/vs-agent/src/utils/setupAgent.ts
@@ -120,17 +120,25 @@ export const setupAgent = async ({
           assertVerifiableService: verifiablePublicRegistries
             ? assertVerifiableService({ verifiablePublicRegistries })
             : undefined,
+          autoAcceptCredentialOffer: true,
           verifyCredential: async ({ record }) => {
             if (!orchestrator) {
               logger.warn('[vt-flow] verifyCredential skipped: orchestrator not ready')
               return false
             }
-            try {
-              await orchestrator.verifyOfferedCredential(record.id)
-              return true
-            } catch (error) {
-              logger.error(`[vt-flow] credential verification failed: ${(error as Error).message}`)
-              return false
+            // Retries absorb indexer lag: the validator anchors the session and digest
+            // moments before offering, so the first reads can miss.
+            for (let attempt = 1; ; attempt++) {
+              try {
+                await orchestrator.verifyOfferedCredential(record.id)
+                return true
+              } catch (error) {
+                if (attempt >= 10) {
+                  logger.error(`[vt-flow] credential verification failed: ${(error as Error).message}`)
+                  return false
+                }
+                await new Promise(resolve => setTimeout(resolve, 3000))
+              }
             }
           },
           onCompleted: async ({ record }) => {
@@ -183,7 +191,14 @@ export const setupAgent = async ({
 
   migrateLegacyTailsFiles(agent.context)
 
-  return { agent }
+  const verifyPeer = verifiablePublicRegistries
+    ? async (peerDid: string): Promise<boolean> => {
+        const hook = assertVerifiableService({ verifiablePublicRegistries, logger })
+        return hook({ agentContext: agent.context, peerDid, connectionId: '' })
+      }
+    : undefined
+
+  return { agent, indexer, verifyPeer }
 }
 
 export function commonAppConfig(app: INestApplication, cors?: boolean, publicApp: boolean = false) {

--- a/apps/vs-agent/src/utils/setupAgent.ts
+++ b/apps/vs-agent/src/utils/setupAgent.ts
@@ -126,20 +126,19 @@ export const setupAgent = async ({
               logger.warn('[vt-flow] verifyCredential skipped: orchestrator not ready')
               return false
             }
-            // Retries absorb indexer lag: the validator anchors the session and digest
-            // moments before offering, so the first reads can miss.
-            for (let attempt = 1; ; attempt++) {
+            for (let attempt = 1; attempt <= 10; attempt++) {
               try {
                 await orchestrator.verifyOfferedCredential(record.id)
                 return true
               } catch (error) {
-                if (attempt >= 10) {
+                if (attempt === 10) {
                   logger.error(`[vt-flow] credential verification failed: ${(error as Error).message}`)
-                  return false
+                } else {
+                  await new Promise(resolve => setTimeout(resolve, 3000))
                 }
-                await new Promise(resolve => setTimeout(resolve, 3000))
               }
             }
+            return false
           },
           onCompleted: async ({ record }) => {
             if (!orchestrator) return

--- a/packages/agent-sdk/src/blockchain/VeranaIndexerService.ts
+++ b/packages/agent-sdk/src/blockchain/VeranaIndexerService.ts
@@ -4,6 +4,8 @@ import {
   CredentialSchemaDto,
   DigestDto,
   EcosystemDto,
+  ParticipantRole,
+  ParticipantState,
   IndexerEventsResponse,
   ParticipantDto,
   ParticipantSessionDto,
@@ -67,6 +69,34 @@ export class VeranaIndexerService {
       { timeoutMs: REQUEST_TIMEOUT_MS, allowNotFound: true },
     )
     return data?.session
+  }
+
+  async listCredentialSchemas(ecosystemId: number): Promise<CredentialSchemaDto[]> {
+    this.config.logger.debug(`[VeranaIndexer] listCredentialSchemas ecosystem=${ecosystemId}`)
+    const data = await fetchJson<{ schemas: CredentialSchemaDto[] }>(
+      `${this.baseUrl}/v4/credential-schema/list?ecosystem_id=${ecosystemId}`,
+      REQUEST_TIMEOUT_MS,
+    )
+    return data.schemas
+  }
+
+  async listParticipants(filter: {
+    schemaId?: number
+    role?: ParticipantRole
+    did?: string
+    participantState?: ParticipantState
+  }): Promise<ParticipantDto[]> {
+    const params = new URLSearchParams()
+    if (filter.schemaId != null) params.set('schema_id', String(filter.schemaId))
+    if (filter.role) params.set('role', filter.role)
+    if (filter.did) params.set('did', filter.did)
+    if (filter.participantState) params.set('participant_state', filter.participantState)
+    this.config.logger.debug(`[VeranaIndexer] listParticipants ${params.toString()}`)
+    const data = await fetchJson<{ participants: ParticipantDto[] }>(
+      `${this.baseUrl}/v4/participant/list?${params.toString()}`,
+      REQUEST_TIMEOUT_MS,
+    )
+    return data.participants
   }
 
   async getDigest(digest: string): Promise<DigestDto | undefined> {

--- a/packages/agent-sdk/src/blockchain/VeranaIndexerService.ts
+++ b/packages/agent-sdk/src/blockchain/VeranaIndexerService.ts
@@ -44,6 +44,15 @@ export class VeranaIndexerService {
     return data.ecosystem
   }
 
+  async listEcosystems(): Promise<EcosystemDto[]> {
+    this.config.logger.debug('[VeranaIndexer] listEcosystems')
+    const data = await fetchJson<{ ecosystems: EcosystemDto[] }>(
+      `${this.baseUrl}/v4/ecosystem/list`,
+      REQUEST_TIMEOUT_MS,
+    )
+    return data.ecosystems ?? []
+  }
+
   async getCredentialSchema(id: string | number): Promise<CredentialSchemaDto> {
     this.config.logger.debug(`[VeranaIndexer] getCredentialSchema id=${id}`)
     const data = await fetchJson<{ schema: CredentialSchemaDto }>(

--- a/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
+++ b/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
@@ -1,0 +1,358 @@
+import { BaseLogger } from '@credo-ts/core'
+import {
+  VtFlowApi,
+  VtFlowEventTypes,
+  VtFlowRole,
+  VtFlowState,
+  type VtFlowStateChangedEvent,
+} from '@verana-labs/credo-ts-didcomm-vt-flow'
+import { ECS, identifySchema } from '@verana-labs/vs-agent-model'
+
+import { VsAgent } from '../agent/VsAgent'
+import {
+  CredentialSchemaDto,
+  ParticipantDto,
+  ParticipantRole,
+  ParticipantState,
+  VeranaChainService,
+  VeranaIndexerService,
+} from '../blockchain'
+import { HOLDER_PARTICIPANT_TYPE, ISSUER_PARTICIPANT_TYPE } from '../types'
+
+const START_OP_MSG = '/verana.pp.v1.MsgStartParticipantOP'
+const SELF_CREATE_MSG = '/verana.pp.v1.MsgSelfCreateParticipant'
+
+const ISSUER_ONBOARDING_MODE_OPEN = 1
+const ISSUER_ONBOARDING_MODE_GRANTOR = 3
+
+const ECS_TITLE_BY_TYPE: Record<string, ECS> = {
+  ServiceCredential: ECS.SERVICE,
+  OrganizationCredential: ECS.ORG,
+  PersonaCredential: ECS.PERSONA,
+  UserAgentCredential: ECS.USER_AGENT,
+}
+
+const DELEGATED_OUTCOME_TIMEOUT_MS = 15 * 60_000
+
+export interface EcsBootstrapOptions {
+  mode: 'standalone' | 'delegated'
+  trustedEcosystemId?: number
+  delegatedParentVsDid?: string
+  verifyPeer?: (peerDid: string) => Promise<boolean>
+}
+
+export class EcsBootstrapService {
+  constructor(
+    private readonly agent: VsAgent,
+    private readonly indexer: VeranaIndexerService | undefined,
+    private readonly options: EcsBootstrapOptions,
+    private readonly logger: BaseLogger,
+  ) {}
+
+  async run(): Promise<void> {
+    if (this.options.mode === 'delegated') return this.runDelegated()
+    return this.runStandalone()
+  }
+
+  private async runStandalone(): Promise<void> {
+    const skip = await this.preflight()
+    if (skip) {
+      this.logger.info(`[EcsBootstrap] standalone bootstrap skipped: ${skip}`)
+      return
+    }
+    const chain = this.agent.veranaChain!
+    const indexer = this.indexer!
+
+    await this.acceptPendingOffers()
+    const { credential, credentialType, service } = await this.discoverEcsSchemas(indexer)
+    await this.ensureHolderParticipant(chain, indexer, credential, credentialType)
+    await this.ensureServiceIssuer(chain, indexer, service)
+  }
+
+  private async preflight(): Promise<string | null> {
+    if (!this.agent.did) return 'the agent has no public DID'
+    const chain = this.agent.veranaChain
+    if (!chain) return 'the Verana chain is not configured'
+    if (!this.indexer) return 'the Verana indexer is not configured'
+    if (this.options.trustedEcosystemId == null) return 'TRUSTED_ECS_ECOSYSTEM_ID is not set'
+
+    const operatorAuths = await chain.listOperatorAuthorizations()
+    if (!operatorAuths.some(a => a.msgTypes.includes(START_OP_MSG))) {
+      return `operator ${chain.address} has no OperatorAuthorization covering MsgStartParticipantOP`
+    }
+    const balance = await chain.getBalance()
+    if (Number(balance.amount) === 0) {
+      return `operator ${chain.address} has no ${balance.denom} balance for fees and trust deposits`
+    }
+
+    const ecosystem = await this.indexer.getEcosystem(this.options.trustedEcosystemId).catch(() => undefined)
+    if (!ecosystem) return `ecosystem ${this.options.trustedEcosystemId} is not known to the indexer`
+    if (ecosystem.archived) return `ecosystem ${this.options.trustedEcosystemId} is archived`
+
+    return null
+  }
+
+  // Live offers are accepted by the vt-flow autoAcceptCredentialOffer pipeline; this only
+  // re-drives flows that were sitting at CRED_OFFERED when the agent restarted.
+  private async acceptPendingOffers(): Promise<void> {
+    const api = this.agent.dependencyManager.resolve(VtFlowApi)
+    const pending = await api.findAllByQuery({
+      flowState: VtFlowState.CredOffered,
+      role: VtFlowRole.Applicant,
+    })
+    for (const record of pending) {
+      if (!record.credentialExchangeRecordId) continue
+      try {
+        await this.agent.didcomm.credentials.acceptOffer({
+          credentialExchangeRecordId: record.credentialExchangeRecordId,
+        })
+        this.logger.info(`[EcsBootstrap] re-accepted the pending credential offer for flow ${record.id}`)
+      } catch (error) {
+        this.logger.warn(
+          `[EcsBootstrap] could not re-accept the offer for flow ${record.id}: ${(error as Error).message}`,
+        )
+      }
+    }
+  }
+
+  private async discoverEcsSchemas(indexer: VeranaIndexerService): Promise<{
+    credential: CredentialSchemaDto
+    credentialType: ECS
+    service: CredentialSchemaDto
+  }> {
+    const schemas = await indexer.listCredentialSchemas(this.options.trustedEcosystemId!)
+    const classified = await Promise.all(
+      schemas
+        .filter(schema => !schema.archived)
+        .map(async schema => ({ schema, type: await this.classifySchema(schema) })),
+    )
+    const byType = (type: ECS) => classified.find(c => c.type === type)?.schema
+
+    const service = byType(ECS.SERVICE)
+    if (!service) {
+      throw new Error(
+        `ecosystem ${this.options.trustedEcosystemId} does not publish an ECS Service credential schema`,
+      )
+    }
+    const org = byType(ECS.ORG)
+    const persona = byType(ECS.PERSONA)
+    const credential = org ?? persona
+    if (!credential) {
+      throw new Error(
+        `ecosystem ${this.options.trustedEcosystemId} publishes neither an ECS Organization nor an ECS Persona credential schema`,
+      )
+    }
+    return { credential, credentialType: org ? ECS.ORG : ECS.PERSONA, service }
+  }
+
+  private async classifySchema(schema: CredentialSchemaDto): Promise<ECS | null> {
+    try {
+      const parsed = JSON.parse(schema.json_schema) as Record<string, unknown>
+      const byDigest = await identifySchema(parsed)
+      if (byDigest) return byDigest
+      const title = typeof parsed.title === 'string' ? parsed.title : ''
+      return ECS_TITLE_BY_TYPE[title] ?? null
+    } catch {
+      return null
+    }
+  }
+
+  private async ensureHolderParticipant(
+    chain: VeranaChainService,
+    indexer: VeranaIndexerService,
+    schema: CredentialSchemaDto,
+    credentialType: ECS,
+  ): Promise<void> {
+    const existing = await indexer.listParticipants({
+      schemaId: schema.id,
+      did: this.agent.did,
+      role: ParticipantRole.Holder,
+    })
+    const usable = existing.find(p => this.isUsableParticipant(p))
+    if (usable) {
+      this.logger.info(
+        `[EcsBootstrap] reusing HOLDER participant ${usable.id} for the ECS ${credentialType} schema`,
+      )
+      return
+    }
+
+    const validator = await this.findActiveValidator(indexer, schema.id, ParticipantRole.Issuer)
+    if (!validator) {
+      throw new Error(`no active ISSUER found for the ECS ${credentialType} schema ${schema.id}`)
+    }
+
+    // No vs_operator on bootstrap OPs: the operator account holds the OA that signs them,
+    // and the chain forbids the same account from also holding a VSOA.
+    const { participantId } = await chain.startParticipantOP({
+      role: HOLDER_PARTICIPANT_TYPE,
+      validatorParticipantId: validator.id,
+      did: this.agent.did!,
+    })
+    this.logger.info(
+      `[EcsBootstrap] started HOLDER onboarding ${participantId} for the ECS ${credentialType} schema with validator ${validator.id}`,
+    )
+  }
+
+  private async ensureServiceIssuer(
+    chain: VeranaChainService,
+    indexer: VeranaIndexerService,
+    schema: CredentialSchemaDto,
+  ): Promise<void> {
+    const existing = await indexer.listParticipants({
+      schemaId: schema.id,
+      did: this.agent.did,
+      role: ParticipantRole.Issuer,
+    })
+    const usable = existing.find(p => this.isUsableParticipant(p))
+    if (usable) {
+      this.logger.info(`[EcsBootstrap] reusing Service ISSUER participant ${usable.id}`)
+      return
+    }
+
+    const onChainSchema = await chain.getCredentialSchema(schema.id)
+    if (!onChainSchema) throw new Error(`Service schema ${schema.id} not found on chain`)
+
+    if (onChainSchema.issuerOnboardingMode === ISSUER_ONBOARDING_MODE_OPEN) {
+      const operatorAuths = await chain.listOperatorAuthorizations()
+      if (!operatorAuths.some(a => a.msgTypes.includes(SELF_CREATE_MSG))) {
+        throw new Error(
+          `operator ${chain.address} has no OperatorAuthorization covering MsgSelfCreateParticipant (required for OPEN issuer onboarding)`,
+        )
+      }
+      const root = await this.findActiveValidator(indexer, schema.id, ParticipantRole.Ecosystem)
+      if (!root) throw new Error(`no active ECOSYSTEM participant found for Service schema ${schema.id}`)
+      const { participantId } = await chain.selfCreateParticipant({
+        role: ISSUER_PARTICIPANT_TYPE,
+        validatorParticipantId: root.id,
+        did: this.agent.did!,
+        effectiveUntil: root.effective_until ? new Date(root.effective_until) : undefined,
+      })
+      this.logger.info(`[EcsBootstrap] self-created Service ISSUER participant ${participantId}`)
+      return
+    }
+
+    const validatorRole =
+      onChainSchema.issuerOnboardingMode === ISSUER_ONBOARDING_MODE_GRANTOR
+        ? ParticipantRole.IssuerGrantor
+        : ParticipantRole.Ecosystem
+    const validator = await this.findActiveValidator(indexer, schema.id, validatorRole)
+    if (!validator) {
+      throw new Error(`no active ${validatorRole} validator found for Service schema ${schema.id}`)
+    }
+
+    const { participantId } = await chain.startParticipantOP({
+      role: ISSUER_PARTICIPANT_TYPE,
+      validatorParticipantId: validator.id,
+      did: this.agent.did!,
+    })
+    this.logger.info(
+      `[EcsBootstrap] started Service ISSUER onboarding ${participantId} with validator ${validator.id}`,
+    )
+  }
+
+  private async findActiveValidator(
+    indexer: VeranaIndexerService,
+    schemaId: number,
+    role: ParticipantRole,
+  ): Promise<ParticipantDto | undefined> {
+    const candidates = await indexer.listParticipants({
+      schemaId,
+      role,
+      participantState: ParticipantState.Active,
+    })
+    return candidates.find(p => !p.revoked && !p.slashed && p.did !== this.agent.did)
+  }
+
+  private isUsableParticipant(p: ParticipantDto): boolean {
+    return (
+      !p.revoked &&
+      !p.slashed &&
+      (p.participant_state === ParticipantState.Active ||
+        p.participant_state === ParticipantState.Future ||
+        p.op_state === 'PENDING')
+    )
+  }
+
+  private async runDelegated(): Promise<void> {
+    const parentDid = this.options.delegatedParentVsDid
+    if (!parentDid) throw new Error('AGENT_DELEGATED_PARENT_VS_DID is not set')
+    if (!this.agent.did) throw new Error('delegated bootstrap requires a public DID')
+    if (!this.indexer) throw new Error('delegated bootstrap requires the Verana indexer')
+    if (!this.options.verifyPeer) {
+      throw new Error(
+        `cannot verify parent VS ${parentDid}: verifiable public registries are not configured (set VERANA_CHAIN_ID)`,
+      )
+    }
+
+    const verified = await this.options.verifyPeer(parentDid).catch(() => false)
+    if (!verified) {
+      throw new Error(`parent VS ${parentDid} is not a Verifiable Service`)
+    }
+
+    const schemaId = await this.findParentServiceSchemaId(parentDid)
+
+    let connectionId: string
+    try {
+      const { connectionRecord } = await this.agent.didcomm.oob.receiveImplicitInvitation({
+        did: parentDid,
+        ourDid: this.agent.did,
+        label: this.agent.label,
+        didCommVersion: 'v2',
+      })
+      if (!connectionRecord) throw new Error('no connection record returned')
+      const ready = await this.agent.didcomm.connections.returnWhenIsConnected(connectionRecord.id)
+      connectionId = ready.id
+    } catch (error) {
+      throw new Error(`parent VS ${parentDid} is unreachable: ${(error as Error).message}`)
+    }
+
+    const api = this.agent.dependencyManager.resolve(VtFlowApi)
+    const record = await api.sendIssuanceRequest({
+      connectionId,
+      schemaId: String(schemaId),
+      agentParticipantId: '0',
+      walletAgentParticipantId: '0',
+    })
+    this.logger.info(
+      `[EcsBootstrap] requested the Service credential (schema ${schemaId}) from parent VS ${parentDid}`,
+    )
+
+    await this.awaitDelegatedOutcome(record.id, parentDid)
+  }
+
+  private async findParentServiceSchemaId(parentDid: string): Promise<number> {
+    const participants = await this.indexer!.listParticipants({
+      did: parentDid,
+      role: ParticipantRole.Issuer,
+      participantState: ParticipantState.Active,
+    })
+    for (const participant of participants) {
+      const schema = await this.indexer!.getCredentialSchema(participant.schema_id).catch(() => undefined)
+      if (!schema) continue
+      if ((await this.classifySchema(schema)) === ECS.SERVICE) return schema.id
+    }
+    throw new Error(`parent VS ${parentDid} holds no active ISSUER participant for an ECS Service schema`)
+  }
+
+  private awaitDelegatedOutcome(recordId: string, parentDid: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`parent VS ${parentDid} did not complete the issuance in time`))
+      }, DELEGATED_OUTCOME_TIMEOUT_MS)
+      timer.unref()
+      this.agent.events.on<VtFlowStateChangedEvent>(VtFlowEventTypes.VtFlowStateChanged, ({ payload }) => {
+        if (payload.vtFlowRecordId !== recordId) return
+        if (payload.state === VtFlowState.Completed) {
+          clearTimeout(timer)
+          resolve()
+        } else if (
+          payload.state === VtFlowState.TerminatedByValidator ||
+          payload.state === VtFlowState.Error
+        ) {
+          clearTimeout(timer)
+          reject(new Error(`parent VS ${parentDid} rejected the Service credential request`))
+        }
+      })
+    })
+  }
+}

--- a/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
+++ b/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
@@ -36,7 +36,7 @@ const DELEGATED_OUTCOME_TIMEOUT_MS = 15 * 60_000
 
 export interface EcsBootstrapOptions {
   mode: 'standalone' | 'delegated'
-  trustedEcosystemId?: number
+  trustedEcosystemDids?: string[]
   delegatedParentVsDid?: string
   verifyPeer?: (peerDid: string) => Promise<boolean>
 }
@@ -74,7 +74,7 @@ export class EcsBootstrapService {
     const chain = this.agent.veranaChain
     if (!chain) return 'the Verana chain is not configured'
     if (!this.indexer) return 'the Verana indexer is not configured'
-    if (this.options.trustedEcosystemId == null) return 'TRUSTED_ECS_ECOSYSTEM_ID is not set'
+    if (!this.options.trustedEcosystemDids?.length) return 'TRUSTED_ECS_ECOSYSTEM_DIDS is not set'
 
     const operatorAuths = await chain.listOperatorAuthorizations()
     if (!operatorAuths.some(a => a.msgTypes.includes(START_OP_MSG))) {
@@ -84,10 +84,6 @@ export class EcsBootstrapService {
     if (Number(balance.amount) === 0) {
       return `operator ${chain.address} has no ${balance.denom} balance for fees and trust deposits`
     }
-
-    const ecosystem = await this.indexer.getEcosystem(this.options.trustedEcosystemId).catch(() => undefined)
-    if (!ecosystem) return `ecosystem ${this.options.trustedEcosystemId} is not known to the indexer`
-    if (ecosystem.archived) return `ecosystem ${this.options.trustedEcosystemId} is archived`
 
     return null
   }
@@ -115,12 +111,34 @@ export class EcsBootstrapService {
     }
   }
 
+  // WL-ECS: only ecosystems on the configured allowlist may provide the essential credential schemas.
   private async discoverEcsSchemas(indexer: VeranaIndexerService): Promise<{
     credential: CredentialSchemaDto
     credentialType: ECS
     service: CredentialSchemaDto
   }> {
-    const schemas = await indexer.listCredentialSchemas(this.options.trustedEcosystemId!)
+    const ecosystems = await indexer.listEcosystems()
+    const failures: string[] = []
+    for (const did of this.options.trustedEcosystemDids!) {
+      const ecosystem = ecosystems.find(e => e.did === did && !e.archived)
+      if (!ecosystem) {
+        failures.push(`${did}: not a known active ecosystem`)
+        continue
+      }
+      try {
+        return await this.discoverFromEcosystem(indexer, ecosystem.id)
+      } catch (error) {
+        failures.push(`${did}: ${(error as Error).message}`)
+      }
+    }
+    throw new Error(`no trusted ECS ecosystem is usable: ${failures.join('; ')}`)
+  }
+
+  private async discoverFromEcosystem(
+    indexer: VeranaIndexerService,
+    ecosystemId: number,
+  ): Promise<{ credential: CredentialSchemaDto; credentialType: ECS; service: CredentialSchemaDto }> {
+    const schemas = await indexer.listCredentialSchemas(ecosystemId)
     const classified = await Promise.all(
       schemas
         .filter(schema => !schema.archived)
@@ -129,19 +147,11 @@ export class EcsBootstrapService {
     const byType = (type: ECS) => classified.find(c => c.type === type)?.schema
 
     const service = byType(ECS.SERVICE)
-    if (!service) {
-      throw new Error(
-        `ecosystem ${this.options.trustedEcosystemId} does not publish an ECS Service credential schema`,
-      )
-    }
+    if (!service) throw new Error('no ECS Service credential schema')
     const org = byType(ECS.ORG)
     const persona = byType(ECS.PERSONA)
     const credential = org ?? persona
-    if (!credential) {
-      throw new Error(
-        `ecosystem ${this.options.trustedEcosystemId} publishes neither an ECS Organization nor an ECS Persona credential schema`,
-      )
-    }
+    if (!credential) throw new Error('no ECS Organization or Persona credential schema')
     return { credential, credentialType: org ? ECS.ORG : ECS.PERSONA, service }
   }
 

--- a/packages/agent-sdk/src/bootstrap/index.ts
+++ b/packages/agent-sdk/src/bootstrap/index.ts
@@ -1,0 +1,1 @@
+export * from './EcsBootstrapService'

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -1,5 +1,6 @@
 // Agent
 export * from './agent'
+export * from './bootstrap'
 export * from './types'
 
 // Events

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -29,3 +29,4 @@ export interface VsAgentNestPlugin {
 }
 
 export const ISSUER_PARTICIPANT_TYPE = 1
+export const HOLDER_PARTICIPANT_TYPE = 6

--- a/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
+++ b/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
@@ -13,7 +13,7 @@ import {
 import { BaseAgentModules, VsAgent } from '../agent'
 import { VeranaIndexerService } from '../blockchain/VeranaIndexerService'
 import { ParticipantRole, ParticipantState } from '../blockchain/types'
-import { ISSUER_PARTICIPANT_TYPE } from '../types'
+import { HOLDER_PARTICIPANT_TYPE, ISSUER_PARTICIPANT_TYPE } from '../types'
 import { createCredential, createVtc, findMetadataEntry } from '../utils'
 
 import { credentialContentDigest } from './credentialDigest'
@@ -59,8 +59,11 @@ export class VtFlowOrchestrator {
     if (holderParticipant.did !== this.agent.did) {
       throw new Error(`Applicant participant ${input.applicantParticipantId} does not belong to this agent`)
     }
-    if (holderParticipant.role !== ISSUER_PARTICIPANT_TYPE) {
-      throw new Error(`Participant ${input.applicantParticipantId} is not an ISSUER participant`)
+    if (
+      holderParticipant.role !== ISSUER_PARTICIPANT_TYPE &&
+      holderParticipant.role !== HOLDER_PARTICIPANT_TYPE
+    ) {
+      throw new Error(`Participant ${input.applicantParticipantId} is not an ISSUER or HOLDER participant`)
     }
     if (!holderParticipant.validatorParticipantId) {
       throw new Error(`Applicant participant ${input.applicantParticipantId} has no validator_participant_id`)

--- a/packages/agent-sdk/tests/EcsBootstrapService.test.ts
+++ b/packages/agent-sdk/tests/EcsBootstrapService.test.ts
@@ -45,7 +45,7 @@ function makeMocks() {
     selfCreateParticipant: vi.fn().mockResolvedValue({ participantId: 88, txHash: 'BB' }),
   }
   const indexer = {
-    getEcosystem: vi.fn().mockResolvedValue({ id: 1, did: 'did:example:eco', archived: null }),
+    listEcosystems: vi.fn().mockResolvedValue([{ id: 1, did: 'did:example:eco', archived: null }]),
     getCredentialSchema: vi.fn().mockResolvedValue(serviceSchema),
     listCredentialSchemas: vi.fn().mockResolvedValue([orgSchema, serviceSchema]),
     listParticipants: vi.fn().mockResolvedValue([]),
@@ -82,22 +82,20 @@ function makeService(
   return new EcsBootstrapService(
     mocks.agent as unknown as VsAgent,
     mocks.indexer as unknown as VeranaIndexerService,
-    { mode: 'standalone', trustedEcosystemId: 1, ...options },
+    { mode: 'standalone', trustedEcosystemDids: ['did:example:eco'], ...options },
     logger as never,
   )
 }
 
 describe('EcsBootstrapService standalone', () => {
   it.each([
-    ['TRUSTED_ECS_ECOSYSTEM_ID is not set', {}, { trustedEcosystemId: undefined }],
+    ['TRUSTED_ECS_ECOSYSTEM_DIDS is not set', {}, { trustedEcosystemDids: undefined }],
     ['no OperatorAuthorization', { oas: [] }, {}],
     ['no balance', { balance: '0' }, {}],
-    ['ecosystem unknown', { ecosystem: undefined }, {}],
   ])('skips without starting anything when %s', async (_name, mockTweaks, optionTweaks) => {
     const mocks = makeMocks()
     if ('oas' in mockTweaks) mocks.chain.listOperatorAuthorizations.mockResolvedValue([])
     if ('balance' in mockTweaks) mocks.chain.getBalance.mockResolvedValue({ denom: 'uvna', amount: '0' })
-    if ('ecosystem' in mockTweaks) mocks.indexer.getEcosystem.mockResolvedValue(undefined)
 
     await makeService(mocks, optionTweaks).run()
 
@@ -120,12 +118,22 @@ describe('EcsBootstrapService standalone', () => {
       },
     )
 
-    await makeService(mocks).run()
+    await makeService(mocks, {
+      trustedEcosystemDids: ['did:example:unknown', 'did:example:eco'],
+    }).run()
 
     expect(mocks.chain.startParticipantOP).toHaveBeenCalledTimes(2)
     const [holderCall, issuerCall] = mocks.chain.startParticipantOP.mock.calls
     expect(holderCall[0]).toMatchObject({ role: 6, validatorParticipantId: 2, did: 'did:web:agent' })
     expect(issuerCall[0]).toMatchObject({ role: 1, validatorParticipantId: 1 })
+  })
+
+  it('fails when no trusted ecosystem DID resolves to a usable ecosystem', async () => {
+    const mocks = makeMocks()
+    mocks.indexer.listEcosystems.mockResolvedValue([])
+
+    await expect(makeService(mocks).run()).rejects.toThrow('no trusted ECS ecosystem is usable')
+    expect(mocks.chain.startParticipantOP).not.toHaveBeenCalled()
   })
 
   it('excludes expired participants from reuse', async () => {

--- a/packages/agent-sdk/tests/EcsBootstrapService.test.ts
+++ b/packages/agent-sdk/tests/EcsBootstrapService.test.ts
@@ -1,0 +1,287 @@
+import type { VsAgent } from '../src/agent/VsAgent'
+import type { VeranaIndexerService } from '../src/blockchain'
+
+import { VtFlowRole, VtFlowState } from '@verana-labs/credo-ts-didcomm-vt-flow'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ParticipantRole, ParticipantState } from '../src/blockchain'
+import { EcsBootstrapService, type EcsBootstrapOptions } from '../src/bootstrap/EcsBootstrapService'
+
+const START_OP = '/verana.pp.v1.MsgStartParticipantOP'
+const SELF_CREATE = '/verana.pp.v1.MsgSelfCreateParticipant'
+
+const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+
+const orgSchema = {
+  id: 4,
+  ecosystem_id: 1,
+  json_schema: JSON.stringify({ title: 'OrganizationCredential', type: 'object' }),
+  archived: null,
+  created: '',
+  modified: '',
+}
+const serviceSchema = {
+  id: 5,
+  ecosystem_id: 1,
+  json_schema: JSON.stringify({ title: 'ServiceCredential', type: 'object' }),
+  archived: null,
+  created: '',
+  modified: '',
+}
+
+function makeMocks() {
+  const eventHandlers: ((event: { payload: Record<string, unknown> }) => Promise<void> | void)[] = []
+  const chain = {
+    address: 'verana1agent',
+    listOperatorAuthorizations: vi.fn().mockResolvedValue([{ msgTypes: [START_OP] }]),
+    getBalance: vi.fn().mockResolvedValue({ denom: 'uvna', amount: '1000000' }),
+    getCredentialSchema: vi.fn().mockResolvedValue({
+      id: 5,
+      ecosystemId: 1,
+      jsonSchema: serviceSchema.json_schema,
+      issuerOnboardingMode: 2,
+    }),
+    startParticipantOP: vi.fn().mockResolvedValue({ participantId: 77, txHash: 'AA' }),
+    selfCreateParticipant: vi.fn().mockResolvedValue({ participantId: 88, txHash: 'BB' }),
+  }
+  const indexer = {
+    getEcosystem: vi.fn().mockResolvedValue({ id: 1, did: 'did:example:eco', archived: null }),
+    getCredentialSchema: vi.fn().mockResolvedValue(serviceSchema),
+    listCredentialSchemas: vi.fn().mockResolvedValue([orgSchema, serviceSchema]),
+    listParticipants: vi.fn().mockResolvedValue([]),
+  }
+  const vtFlowApi = {
+    findAllByQuery: vi.fn().mockResolvedValue([]),
+    sendIssuanceRequest: vi.fn().mockResolvedValue({ id: 'rec-1' }),
+  }
+  const agent = {
+    did: 'did:web:agent',
+    label: 'Agent',
+    publicApiBaseUrl: 'https://agent',
+    veranaChain: chain,
+    config: { logger },
+    events: {
+      on: (_type: string, cb: (event: { payload: Record<string, unknown> }) => void) => {
+        eventHandlers.push(cb)
+      },
+    },
+    dependencyManager: { resolve: () => vtFlowApi },
+    didcomm: {
+      oob: { receiveImplicitInvitation: vi.fn().mockResolvedValue({ connectionRecord: { id: 'conn-1' } }) },
+      connections: { returnWhenIsConnected: vi.fn().mockResolvedValue({ id: 'conn-1' }) },
+      credentials: { acceptOffer: vi.fn().mockResolvedValue(undefined) },
+    },
+  }
+  return { agent, chain, indexer, vtFlowApi, eventHandlers }
+}
+
+function makeService(
+  mocks: ReturnType<typeof makeMocks>,
+  options: Partial<EcsBootstrapOptions> = {},
+): EcsBootstrapService {
+  return new EcsBootstrapService(
+    mocks.agent as unknown as VsAgent,
+    mocks.indexer as unknown as VeranaIndexerService,
+    { mode: 'standalone', trustedEcosystemId: 1, ...options },
+    logger as never,
+  )
+}
+
+describe('EcsBootstrapService standalone', () => {
+  it.each([
+    ['TRUSTED_ECS_ECOSYSTEM_ID is not set', {}, { trustedEcosystemId: undefined }],
+    ['no OperatorAuthorization', { oas: [] }, {}],
+    ['no balance', { balance: '0' }, {}],
+    ['ecosystem unknown', { ecosystem: undefined }, {}],
+  ])('skips without starting anything when %s', async (_name, mockTweaks, optionTweaks) => {
+    const mocks = makeMocks()
+    if ('oas' in mockTweaks) mocks.chain.listOperatorAuthorizations.mockResolvedValue([])
+    if ('balance' in mockTweaks) mocks.chain.getBalance.mockResolvedValue({ denom: 'uvna', amount: '0' })
+    if ('ecosystem' in mockTweaks) mocks.indexer.getEcosystem.mockResolvedValue(undefined)
+
+    await makeService(mocks, optionTweaks).run()
+
+    expect(mocks.chain.startParticipantOP).not.toHaveBeenCalled()
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('skipped'))
+  })
+
+  it('starts the HOLDER onboarding and the Service ISSUER onboarding', async () => {
+    const mocks = makeMocks()
+    mocks.indexer.listParticipants.mockImplementation(
+      async (filter: { role?: string; schemaId?: number; did?: string }) => {
+        if (filter.did === 'did:web:agent') return []
+        if (filter.role === ParticipantRole.Issuer && filter.schemaId === 4) {
+          return [{ id: 2, did: 'did:web:validator', participant_state: ParticipantState.Active }]
+        }
+        if (filter.role === ParticipantRole.Ecosystem && filter.schemaId === 5) {
+          return [{ id: 1, did: 'did:example:eco', participant_state: ParticipantState.Active }]
+        }
+        return []
+      },
+    )
+
+    await makeService(mocks).run()
+
+    expect(mocks.chain.startParticipantOP).toHaveBeenCalledTimes(2)
+    const [holderCall, issuerCall] = mocks.chain.startParticipantOP.mock.calls
+    expect(holderCall[0]).toMatchObject({ role: 6, validatorParticipantId: 2, did: 'did:web:agent' })
+    expect(issuerCall[0]).toMatchObject({ role: 1, validatorParticipantId: 1 })
+  })
+
+  it('excludes expired participants from reuse', async () => {
+    const mocks = makeMocks()
+    mocks.indexer.listParticipants.mockImplementation(
+      async (filter: { role?: string; schemaId?: number; did?: string }) => {
+        if (filter.did === 'did:web:agent') {
+          return [
+            {
+              id: 9,
+              participant_state: 'EXPIRED',
+              op_state: 'VALIDATED',
+              revoked: null,
+              slashed: null,
+            },
+          ]
+        }
+        if (filter.role === ParticipantRole.Issuer || filter.role === ParticipantRole.Ecosystem) {
+          return [{ id: 2, did: 'did:web:validator', participant_state: ParticipantState.Active }]
+        }
+        return []
+      },
+    )
+
+    await makeService(mocks).run()
+
+    expect(mocks.chain.startParticipantOP).toHaveBeenCalledTimes(2)
+  })
+
+  it('self-creates the Service ISSUER when the schema mode is OPEN', async () => {
+    const mocks = makeMocks()
+    mocks.chain.listOperatorAuthorizations.mockResolvedValue([{ msgTypes: [START_OP, SELF_CREATE] }])
+    mocks.chain.getCredentialSchema.mockResolvedValue({
+      id: 5,
+      ecosystemId: 1,
+      jsonSchema: serviceSchema.json_schema,
+      issuerOnboardingMode: 1,
+    })
+    mocks.indexer.listParticipants.mockImplementation(
+      async (filter: { role?: string; schemaId?: number; did?: string }) => {
+        if (filter.did === 'did:web:agent') {
+          return filter.role === ParticipantRole.Holder
+            ? [{ id: 9, participant_state: ParticipantState.Active, revoked: null, slashed: null }]
+            : []
+        }
+        if (filter.role === ParticipantRole.Ecosystem) {
+          return [
+            { id: 1, participant_state: ParticipantState.Active, effective_until: '2030-01-01T00:00:00Z' },
+          ]
+        }
+        return []
+      },
+    )
+
+    await makeService(mocks).run()
+
+    expect(mocks.chain.startParticipantOP).not.toHaveBeenCalled()
+    expect(mocks.chain.selfCreateParticipant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 1,
+        validatorParticipantId: 1,
+        effectiveUntil: new Date('2030-01-01T00:00:00Z'),
+      }),
+    )
+  })
+
+  it('fails OPEN self-creation when the operator lacks the MsgSelfCreateParticipant authorization', async () => {
+    const mocks = makeMocks()
+    mocks.chain.getCredentialSchema.mockResolvedValue({
+      id: 5,
+      ecosystemId: 1,
+      jsonSchema: serviceSchema.json_schema,
+      issuerOnboardingMode: 1,
+    })
+    mocks.indexer.listParticipants.mockImplementation(async (filter: { role?: string; did?: string }) => {
+      if (filter.did === 'did:web:agent') {
+        return filter.role === ParticipantRole.Holder
+          ? [{ id: 9, participant_state: ParticipantState.Active, revoked: null, slashed: null }]
+          : []
+      }
+      return []
+    })
+
+    await expect(makeService(mocks).run()).rejects.toThrow('MsgSelfCreateParticipant')
+    expect(mocks.chain.selfCreateParticipant).not.toHaveBeenCalled()
+  })
+
+  it('re-accepts applicant flows left at CRED_OFFERED across a restart', async () => {
+    const mocks = makeMocks()
+    mocks.indexer.listParticipants.mockImplementation(async (filter: { role?: string; did?: string }) => {
+      if (filter.did === 'did:web:agent') {
+        return [{ id: 9, participant_state: ParticipantState.Active, revoked: null, slashed: null }]
+      }
+      return []
+    })
+    mocks.vtFlowApi.findAllByQuery.mockResolvedValue([
+      { id: 'flow-1', credentialExchangeRecordId: 'cred-ex-1' },
+      { id: 'flow-2', credentialExchangeRecordId: undefined },
+    ])
+
+    await makeService(mocks).run()
+
+    expect(mocks.vtFlowApi.findAllByQuery).toHaveBeenCalledWith({
+      flowState: VtFlowState.CredOffered,
+      role: VtFlowRole.Applicant,
+    })
+    expect(mocks.agent.didcomm.credentials.acceptOffer).toHaveBeenCalledTimes(1)
+    expect(mocks.agent.didcomm.credentials.acceptOffer).toHaveBeenCalledWith({
+      credentialExchangeRecordId: 'cred-ex-1',
+    })
+  })
+})
+
+describe('EcsBootstrapService delegated', () => {
+  const delegated = { mode: 'delegated' as const, delegatedParentVsDid: 'did:web:parent' }
+
+  it('fails when peer verification is not configured', async () => {
+    const mocks = makeMocks()
+    const service = makeService(mocks, delegated)
+    await expect(service.run()).rejects.toThrow('verifiable public registries are not configured')
+  })
+
+  it('fails when the parent is not a Verifiable Service', async () => {
+    const mocks = makeMocks()
+    const service = makeService(mocks, { ...delegated, verifyPeer: async () => false })
+    await expect(service.run()).rejects.toThrow('did:web:parent is not a Verifiable Service')
+  })
+
+  it('fails when the parent holds no Service ISSUER participant', async () => {
+    const mocks = makeMocks()
+    mocks.indexer.listParticipants.mockResolvedValue([])
+    const service = makeService(mocks, { ...delegated, verifyPeer: async () => true })
+    await expect(service.run()).rejects.toThrow('no active ISSUER participant for an ECS Service schema')
+  })
+
+  it('fails when the parent is unreachable', async () => {
+    const mocks = makeMocks()
+    mocks.indexer.listParticipants.mockResolvedValue([{ id: 3, schema_id: 5 }])
+    mocks.agent.didcomm.oob.receiveImplicitInvitation.mockRejectedValue(new Error('no endpoint'))
+    const service = makeService(mocks, { ...delegated, verifyPeer: async () => true })
+    await expect(service.run()).rejects.toThrow('did:web:parent is unreachable: no endpoint')
+  })
+
+  it('sends the issuance request and resolves when the flow completes', async () => {
+    const mocks = makeMocks()
+    mocks.indexer.listParticipants.mockResolvedValue([{ id: 3, schema_id: 5 }])
+    const service = makeService(mocks, { ...delegated, verifyPeer: async () => true })
+
+    const outcome = service.run()
+    await vi.waitFor(() => expect(mocks.vtFlowApi.sendIssuanceRequest).toHaveBeenCalled())
+    expect(mocks.vtFlowApi.sendIssuanceRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'conn-1', schemaId: '5' }),
+    )
+    for (const cb of mocks.eventHandlers) {
+      void cb({ payload: { vtFlowRecordId: 'rec-1', state: VtFlowState.Completed } })
+    }
+    await expect(outcome).resolves.toBeUndefined()
+  })
+})

--- a/packages/agent-sdk/tests/e2e/ecs-bootstrap.e2e.test.ts
+++ b/packages/agent-sdk/tests/e2e/ecs-bootstrap.e2e.test.ts
@@ -130,7 +130,7 @@ describeE2E('ECS bootstrap (V4): standalone against a live chain and indexer', (
       const bootstrap = new EcsBootstrapService(
         agent,
         indexer,
-        { mode: 'standalone', trustedEcosystemId: ecosystemId },
+        { mode: 'standalone', trustedEcosystemDids: [`did:example:eco-${RUN_ID}`] },
         new ConsoleLogger(LogLevel.Info),
       )
       await bootstrap.run()

--- a/packages/agent-sdk/tests/e2e/ecs-bootstrap.e2e.test.ts
+++ b/packages/agent-sdk/tests/e2e/ecs-bootstrap.e2e.test.ts
@@ -1,0 +1,157 @@
+import type { VsAgent } from '../../src/agent/VsAgent'
+
+import { ConsoleLogger, LogLevel } from '@credo-ts/core'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import {
+  ParticipantRole,
+  ParticipantState,
+  VeranaChainService,
+  VeranaIndexerService,
+} from '../../src/blockchain'
+import { EcsBootstrapService } from '../../src/bootstrap/EcsBootstrapService'
+
+import { PARTICIPANT_ROLE_ISSUER, VeranaTestChain } from './VeranaTestChain'
+import { COOLUSER_MNEMONIC, SETUP_TIMEOUT_MS, startStack, type StartedStack } from './helpers'
+
+const E2E_ENABLED = process.env.RUN_FLOW_E2E === '1'
+const describeE2E = E2E_ENABLED ? describe : describe.skip
+
+const RUN_ID = String(Date.now())
+const AGENT_DID = `did:example:agent-${RUN_ID}`
+
+const ecsSchema = (title: string) =>
+  JSON.stringify({
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    title,
+    description: `e2e ${title}`,
+    type: 'object',
+    properties: { name: { type: 'string' } },
+    required: ['name'],
+  })
+
+async function until<T>(fn: () => Promise<T | undefined>, timeoutMs = 120_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    const value = await fn().catch(() => undefined)
+    if (value !== undefined) return value
+    await new Promise(r => setTimeout(r, 3_000))
+  }
+  throw new Error('condition did not resolve in time')
+}
+
+describeE2E('ECS bootstrap (V4): standalone against a live chain and indexer', () => {
+  let stack: StartedStack
+  let chainA: VeranaTestChain
+  let agentChain: VeranaChainService
+  let indexer: VeranaIndexerService
+  let ecosystemId: number
+  let orgSchemaId: number
+  let serviceSchemaId: number
+
+  beforeAll(async () => {
+    stack = await startStack()
+    chainA = await VeranaTestChain.connect(stack.rpcUrl, COOLUSER_MNEMONIC)
+
+    const corp = await chainA.createCorporation({ did: `did:example:corp-${RUN_ID}` })
+    await chainA.fundCorporation(corp.policyAddress)
+    await chainA.grantOperatorAuthorization(corp.policyAddress)
+    const eco = await chainA.createEcosystem(corp.policyAddress, { did: `did:example:eco-${RUN_ID}` })
+    ecosystemId = eco.ecosystemId
+
+    const org = await chainA.createCredentialSchema(corp.policyAddress, {
+      ecosystemId,
+      jsonSchema: ecsSchema('OrganizationCredential'),
+    })
+    orgSchemaId = org.schemaId
+    const service = await chainA.createCredentialSchema(corp.policyAddress, {
+      ecosystemId,
+      jsonSchema: ecsSchema('ServiceCredential'),
+    })
+    serviceSchemaId = service.schemaId
+
+    const orgRoot = await chainA.createRootParticipant(corp.policyAddress, {
+      schemaId: orgSchemaId,
+      did: `did:example:org-root-${RUN_ID}`,
+    })
+    await chainA.createRootParticipant(corp.policyAddress, {
+      schemaId: serviceSchemaId,
+      did: `did:example:service-root-${RUN_ID}`,
+    })
+
+    agentChain = new VeranaChainService({
+      rpcUrl: stack.rpcUrl,
+      mnemonic: COOLUSER_MNEMONIC,
+      corporationAddress: corp.policyAddress,
+      logger: new ConsoleLogger(LogLevel.Warn),
+    })
+    await agentChain.start()
+
+    const issuer = await chainA.startParticipantOp(corp.policyAddress, {
+      role: PARTICIPANT_ROLE_ISSUER,
+      validatorParticipantId: orgRoot.participantId,
+      did: `did:example:org-issuer-${RUN_ID}`,
+    })
+    await agentChain.setParticipantOPToValidated({ id: issuer.participantId, opSummaryDigest: 'sha384-x' })
+
+    indexer = new VeranaIndexerService({
+      baseUrl: stack.indexerWsUrl.replace(/^ws/, 'http'),
+      logger: new ConsoleLogger(LogLevel.Warn),
+    })
+  }, SETUP_TIMEOUT_MS)
+
+  afterAll(async () => {
+    chainA?.disconnect()
+    await stack?.stop().catch(() => undefined)
+  })
+
+  it(
+    'discovers the ECS schemas, starts both onboarding OPs, and is idempotent',
+    async () => {
+      await until(async () => {
+        const issuers = await indexer.listParticipants({
+          schemaId: orgSchemaId,
+          role: ParticipantRole.Issuer,
+          participantState: ParticipantState.Active,
+        })
+        return issuers.length > 0 ? issuers : undefined
+      })
+
+      const agent = {
+        did: AGENT_DID,
+        label: 'bootstrap-e2e',
+        publicApiBaseUrl: 'https://agent.example',
+        veranaChain: agentChain,
+        config: { logger: new ConsoleLogger(LogLevel.Warn) },
+        events: { on: () => undefined },
+        dependencyManager: { resolve: () => ({ findAllByQuery: async () => [] }) },
+      } as unknown as VsAgent
+
+      const bootstrap = new EcsBootstrapService(
+        agent,
+        indexer,
+        { mode: 'standalone', trustedEcosystemId: ecosystemId },
+        new ConsoleLogger(LogLevel.Info),
+      )
+      await bootstrap.run()
+
+      const holder = await until(async () => {
+        const list = await indexer.listParticipants({ did: AGENT_DID, role: ParticipantRole.Holder })
+        return list.length > 0 ? list[0] : undefined
+      })
+      expect(Number(holder.schema_id)).toBe(orgSchemaId)
+      expect(holder.op_state).toBe('PENDING')
+
+      const serviceIssuer = await until(async () => {
+        const list = await indexer.listParticipants({ did: AGENT_DID, role: ParticipantRole.Issuer })
+        return list.length > 0 ? list[0] : undefined
+      })
+      expect(Number(serviceIssuer.schema_id)).toBe(serviceSchemaId)
+
+      await bootstrap.run()
+      const all = await indexer.listParticipants({ did: AGENT_DID, role: undefined })
+      expect(all).toHaveLength(2)
+    },
+    SETUP_TIMEOUT_MS,
+  )
+})


### PR DESCRIPTION
Closes #476.

On startup the agent bootstraps its ECS credentials:
- **Standalone:** discovers the trusted ecosystem's ECS schemas via the indexer, then starts the HOLDER onboarding (org/persona) and the Service ISSUER onboarding on chain. Existing participants are reused, so restarts are idempotent. The issuer path follows the schema's `issuerOnboardingMode` (including `selfCreate` for OPEN).
- **Delegated:** verifies the parent VS, then requests the Service credential from it over vt-flow.

Offers are accepted through the vt-flow applicant pipeline (`autoAcceptCredentialOffer` + verify hook, now with retries for indexer lag).

New env: `TRUSTED_ECS_ECOSYSTEM_DIDS`, a comma-separated list of trusted ECS ecosystem DIDs per WL-ECS of the verifiable trust spec.

Validated with unit tests and an e2e against a live chain and indexer.