### PR TITLE
feat(vs-agent): flow management admin routes

### DIFF
--- a/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsController.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsController.ts
@@ -1,13 +1,70 @@
-import { Controller, HttpCode, HttpStatus, Param, Post } from '@nestjs/common'
-import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger'
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Put, Query } from '@nestjs/common'
+import {
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger'
 
 import { VtFlowsService } from './VtFlowsService'
+import {
+  EditClaimsDto,
+  ListFlowsQueryDto,
+  RevokeFlowCredentialDto,
+  SendOobLinkDto,
+} from './dto/flow-requests.dto'
 import { VtFlowRecordDto } from './dto/vt-flow-record.dto'
 
 @ApiTags('vt-flow')
 @Controller({ path: 'vt/flows', version: '1' })
 export class VtFlowsController {
   public constructor(private readonly service: VtFlowsService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List credential-acquisition flows',
+    description: 'Lists flows handled by the agent, with optional role, state, peer, and identifier filters.',
+  })
+  @ApiOkResponse({ type: [VtFlowRecordDto] })
+  public listFlows(@Query() query: ListFlowsQueryDto): Promise<VtFlowRecordDto[]> {
+    return this.service.listFlows(query)
+  }
+
+  @Put(':participantSessionId/claims')
+  @ApiOperation({
+    summary: 'Edit the credential claims of a flow',
+    description:
+      'Validator action. Replaces the credential claims stored on the flow before the credential is offered.',
+  })
+  @ApiParam({ name: 'participantSessionId', type: String })
+  @ApiOkResponse({ type: VtFlowRecordDto })
+  @ApiNotFoundResponse()
+  @ApiBadRequestResponse()
+  public editCredentialClaims(
+    @Param('participantSessionId') participantSessionId: string,
+    @Body() body: EditClaimsDto,
+  ): Promise<VtFlowRecordDto> {
+    return this.service.editCredentialClaims(participantSessionId, body.claims)
+  }
+
+  @Post(':participantSessionId/oob-link')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Send an OOB_LINK message to the applicant',
+    description: 'Validator action. Sends or resends an out-of-band URL for information collection.',
+  })
+  @ApiParam({ name: 'participantSessionId', type: String })
+  @ApiOkResponse({ type: VtFlowRecordDto })
+  @ApiNotFoundResponse()
+  @ApiBadRequestResponse()
+  public sendOobLink(
+    @Param('participantSessionId') participantSessionId: string,
+    @Body() body: SendOobLinkDto,
+  ): Promise<VtFlowRecordDto> {
+    return this.service.sendOobLink(participantSessionId, body.url, body.message)
+  }
 
   @Post(':participantSessionId/validate')
   @HttpCode(HttpStatus.OK)
@@ -21,5 +78,22 @@ export class VtFlowsController {
   @ApiNotFoundResponse()
   public validate(@Param('participantSessionId') participantSessionId: string): Promise<VtFlowRecordDto> {
     return this.service.validateAndOfferCredential(participantSessionId)
+  }
+
+  @Post(':participantSessionId/revoke-credential')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Revoke the credential issued for a flow',
+    description: 'Validator action. Notifies the applicant over DIDComm that the credential is revoked.',
+  })
+  @ApiParam({ name: 'participantSessionId', type: String })
+  @ApiOkResponse({ type: VtFlowRecordDto })
+  @ApiNotFoundResponse()
+  @ApiBadRequestResponse()
+  public revokeCredential(
+    @Param('participantSessionId') participantSessionId: string,
+    @Body() body: RevokeFlowCredentialDto,
+  ): Promise<VtFlowRecordDto> {
+    return this.service.revokeCredential(participantSessionId, body.reason)
   }
 }

--- a/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsService.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsService.ts
@@ -1,5 +1,6 @@
 import type { VsAgent, VeranaChainService } from '@verana-labs/vs-agent-sdk'
 
+import { CredoError } from '@credo-ts/core'
 import {
   BadRequestException,
   HttpException,
@@ -9,11 +10,13 @@ import {
   NotFoundException,
 } from '@nestjs/common'
 import {
+  VtCredentialState,
   VtFlowApi,
   VtFlowRecord,
   VtFlowRole,
   VtFlowState,
   VtFlowVariant,
+  isVtFlowTerminalState,
 } from '@verana-labs/credo-ts-didcomm-vt-flow'
 import { VeranaIndexerService, VtFlowOrchestrator } from '@verana-labs/vs-agent-sdk'
 
@@ -21,6 +24,7 @@ import { ADMIN_LOG_LEVEL, VERANA_INDEXER_BASE_URL } from '../../../config'
 import { VsAgentService } from '../../../services/VsAgentService'
 import { TsLogger } from '../../../utils'
 
+import { ListFlowsQueryDto } from './dto/flow-requests.dto'
 import { VtFlowRecordDto } from './dto/vt-flow-record.dto'
 
 @Injectable()
@@ -28,6 +32,89 @@ export class VtFlowsService {
   private indexerService?: VeranaIndexerService
 
   public constructor(@Inject(VsAgentService) private readonly agentService: VsAgentService) {}
+
+  public async listFlows(query: ListFlowsQueryDto): Promise<VtFlowRecordDto[]> {
+    const agent = await this.agentService.getAgent()
+    const vtFlowApi = this.resolveVtFlowApi(agent)
+    const records = await vtFlowApi.findAllByQuery({
+      ...(query.role && { role: query.role }),
+      ...(query.flowState && { flowState: query.flowState }),
+      ...(query.participant_id && { participantId: query.participant_id }),
+      ...(query.schema_id && { schemaId: query.schema_id }),
+      ...(query.participant_session_id && { participantSessionId: query.participant_session_id }),
+    })
+
+    const connectionIds = [...new Set(records.map(record => record.connectionId))]
+    const connections = new Map(
+      await Promise.all(
+        connectionIds.map(async id => [id, await agent.didcomm.connections.findById(id)] as const),
+      ),
+    )
+
+    const flows: VtFlowRecordDto[] = []
+    for (const record of records) {
+      const connection = connections.get(record.connectionId)
+      const connectionState =
+        isVtFlowTerminalState(record.state) || !connection
+          ? 'TERMINATED'
+          : connection.isReady
+            ? 'ESTABLISHED'
+            : 'NOT_CONNECTED'
+      if (query.peerDID && connection?.theirDid !== query.peerDID) continue
+      if (query.connectionState && connectionState !== query.connectionState) continue
+      flows.push({ ...toDto(record, connection?.theirDid), connectionState })
+    }
+    return flows
+  }
+
+  public editCredentialClaims(
+    participantSessionId: string,
+    claims: Record<string, unknown>,
+  ): Promise<VtFlowRecordDto> {
+    return this.mutateFlow(participantSessionId, async ({ agent, vtFlowApi, record }) => {
+      await this.assertConnectionEstablished(agent, record)
+      return vtFlowApi.updateClaims(record.id, claims)
+    })
+  }
+
+  public sendOobLink(participantSessionId: string, url: string, message?: string): Promise<VtFlowRecordDto> {
+    return this.mutateFlow(participantSessionId, async ({ agent, vtFlowApi, record }) => {
+      await this.assertConnectionEstablished(agent, record)
+      return vtFlowApi.sendOobLink({ vtFlowRecordId: record.id, url, description: message ?? '' })
+    })
+  }
+
+  public revokeCredential(participantSessionId: string, reason?: string): Promise<VtFlowRecordDto> {
+    return this.mutateFlow(participantSessionId, ({ vtFlowApi, record }) =>
+      vtFlowApi.notifyCredentialStateChange({
+        vtFlowRecordId: record.id,
+        state: VtCredentialState.Revoked,
+        reason,
+      }),
+    )
+  }
+
+  private async mutateFlow(
+    participantSessionId: string,
+    action: (ctx: { agent: VsAgent; vtFlowApi: VtFlowApi; record: VtFlowRecord }) => Promise<VtFlowRecord>,
+  ): Promise<VtFlowRecordDto> {
+    const agent = await this.agentService.getAgent()
+    const vtFlowApi = this.resolveVtFlowApi(agent)
+    const record = await this.findRecordBySession(vtFlowApi, participantSessionId)
+    try {
+      return toDto(await action({ agent, vtFlowApi, record }))
+    } catch (error) {
+      if (error instanceof CredoError) throw new BadRequestException(error.message)
+      throw error
+    }
+  }
+
+  private async assertConnectionEstablished(agent: VsAgent, record: VtFlowRecord): Promise<void> {
+    const connection = await agent.didcomm.connections.findById(record.connectionId)
+    if (!connection?.isReady) {
+      throw new BadRequestException('Flow connection is not in ESTABLISHED state')
+    }
+  }
 
   public async validateAndOfferCredential(participantSessionId: string): Promise<VtFlowRecordDto> {
     const agent = await this.agentService.getAgent()
@@ -106,8 +193,10 @@ export class VtFlowsService {
   }
 }
 
-function toDto(record: VtFlowRecord): VtFlowRecordDto {
+function toDto(record: VtFlowRecord, peerDid?: string): VtFlowRecordDto {
   return {
+    peerDid,
+    oobLinkUrl: record.oobLinkUrl,
     id: record.id,
     threadId: record.threadId,
     participantSessionId: record.participantSessionId,

--- a/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsService.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsService.ts
@@ -36,13 +36,17 @@ export class VtFlowsService {
   public async listFlows(query: ListFlowsQueryDto): Promise<VtFlowRecordDto[]> {
     const agent = await this.agentService.getAgent()
     const vtFlowApi = this.resolveVtFlowApi(agent)
-    const records = await vtFlowApi.findAllByQuery({
+    const validatorScope = query.role === VtFlowRole.Applicant && query.participant_id
+    let records = await vtFlowApi.findAllByQuery({
       ...(query.role && { role: query.role }),
       ...(query.flowState && { flowState: query.flowState }),
-      ...(query.participant_id && { participantId: query.participant_id }),
+      ...(query.participant_id && !validatorScope && { participantId: query.participant_id }),
       ...(query.schema_id && { schemaId: query.schema_id }),
       ...(query.participant_session_id && { participantSessionId: query.participant_session_id }),
     })
+    if (validatorScope) {
+      records = await this.filterByValidatorParticipant(agent, records, query.participant_id!)
+    }
 
     const connectionIds = [...new Set(records.map(record => record.connectionId))]
     const connections = new Map(
@@ -92,6 +96,28 @@ export class VtFlowsService {
         reason,
       }),
     )
+  }
+
+  private async filterByValidatorParticipant(
+    agent: VsAgent,
+    records: VtFlowRecord[],
+    validatorParticipantId: string,
+  ): Promise<VtFlowRecord[]> {
+    const chain = this.requireChain(agent)
+    const validatorByApplicant = new Map<string, string | undefined>()
+    const kept: VtFlowRecord[] = []
+    for (const record of records) {
+      if (!record.participantId) continue
+      if (!validatorByApplicant.has(record.participantId)) {
+        const participant = await chain.getParticipant(Number(record.participantId)).catch(() => undefined)
+        validatorByApplicant.set(
+          record.participantId,
+          participant?.validatorParticipantId ? String(participant.validatorParticipantId) : undefined,
+        )
+      }
+      if (validatorByApplicant.get(record.participantId) === validatorParticipantId) kept.push(record)
+    }
+    return kept
   }
 
   private async mutateFlow(
@@ -197,6 +223,8 @@ function toDto(record: VtFlowRecord, peerDid?: string): VtFlowRecordDto {
   return {
     peerDid,
     oobLinkUrl: record.oobLinkUrl,
+    proofs: record.proofsAttach,
+    credentialDigest: record.credentialDigest,
     id: record.id,
     threadId: record.threadId,
     participantSessionId: record.participantSessionId,

--- a/apps/vs-agent/src/controllers/admin/vt-flow/dto/flow-requests.dto.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/dto/flow-requests.dto.ts
@@ -47,7 +47,7 @@ export class EditClaimsDto {
 
 export class SendOobLinkDto {
   @ApiProperty()
-  @IsUrl({ require_tld: false, protocols: ['https'] })
+  @IsUrl({ require_tld: false, protocols: ['https', 'http'] })
   @IsNotEmpty()
   url!: string
 

--- a/apps/vs-agent/src/controllers/admin/vt-flow/dto/flow-requests.dto.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/dto/flow-requests.dto.ts
@@ -1,0 +1,65 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { VtFlowRole, VtFlowState } from '@verana-labs/credo-ts-didcomm-vt-flow'
+import { IsEnum, IsIn, IsNotEmpty, IsObject, IsOptional, IsString, IsUrl } from 'class-validator'
+
+export class ListFlowsQueryDto {
+  @ApiProperty({ required: false, enum: VtFlowRole })
+  @IsOptional()
+  @IsEnum(VtFlowRole)
+  role?: VtFlowRole
+
+  @ApiProperty({ required: false, enum: ['NOT_CONNECTED', 'ESTABLISHED', 'TERMINATED'] })
+  @IsOptional()
+  @IsIn(['NOT_CONNECTED', 'ESTABLISHED', 'TERMINATED'])
+  connectionState?: 'NOT_CONNECTED' | 'ESTABLISHED' | 'TERMINATED'
+
+  @ApiProperty({ required: false, enum: VtFlowState })
+  @IsOptional()
+  @IsEnum(VtFlowState)
+  flowState?: VtFlowState
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  peerDID?: string
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  participant_id?: string
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  schema_id?: string
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  participant_session_id?: string
+}
+
+export class EditClaimsDto {
+  @ApiProperty({ type: Object })
+  @IsObject()
+  claims!: Record<string, unknown>
+}
+
+export class SendOobLinkDto {
+  @ApiProperty()
+  @IsUrl({ require_tld: false, protocols: ['https'] })
+  @IsNotEmpty()
+  url!: string
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  message?: string
+}
+
+export class RevokeFlowCredentialDto {
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  reason?: string
+}

--- a/apps/vs-agent/src/controllers/admin/vt-flow/dto/vt-flow-record.dto.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/dto/vt-flow-record.dto.ts
@@ -16,6 +16,9 @@ export class VtFlowRecordDto {
   @ApiProperty({ required: false, type: Object }) claims?: Record<string, unknown>
   @ApiProperty({ required: false }) credentialExchangeRecordId?: string
   @ApiProperty({ required: false }) subprotocolThid?: string
+  @ApiProperty({ required: false }) oobLinkUrl?: string
+  @ApiProperty({ required: false }) peerDid?: string
+  @ApiProperty({ required: false }) connectionState?: string
   @ApiProperty({ required: false }) errorMessage?: string
   @ApiProperty() createdAt!: Date
   @ApiProperty() updatedAt!: Date

--- a/apps/vs-agent/src/controllers/admin/vt-flow/dto/vt-flow-record.dto.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/dto/vt-flow-record.dto.ts
@@ -17,6 +17,8 @@ export class VtFlowRecordDto {
   @ApiProperty({ required: false }) credentialExchangeRecordId?: string
   @ApiProperty({ required: false }) subprotocolThid?: string
   @ApiProperty({ required: false }) oobLinkUrl?: string
+  @ApiProperty({ required: false, type: [Object] }) proofs?: unknown[]
+  @ApiProperty({ required: false }) credentialDigest?: string
   @ApiProperty({ required: false }) peerDid?: string
   @ApiProperty({ required: false }) connectionState?: string
   @ApiProperty({ required: false }) errorMessage?: string

--- a/apps/vs-agent/tests/flowAdminRoutes.test.ts
+++ b/apps/vs-agent/tests/flowAdminRoutes.test.ts
@@ -1,0 +1,80 @@
+import { CredoError } from '@credo-ts/core'
+import { BadRequestException, NotFoundException } from '@nestjs/common'
+import { VtCredentialState, VtFlowRole, VtFlowState } from '@verana-labs/credo-ts-didcomm-vt-flow'
+import { describe, expect, it, vi } from 'vitest'
+
+import { VtFlowsService } from '../src/controllers/admin/vt-flow/VtFlowsService'
+
+const record = {
+  id: 'rec-1',
+  threadId: 'thid-1',
+  participantSessionId: 'sess-1',
+  connectionId: 'conn-1',
+  role: VtFlowRole.Validator,
+  createdAt: new Date(0),
+}
+
+function makeService(
+  vtFlowApi: Record<string, unknown>,
+  connection: unknown = { isReady: true, theirDid: 'did:web:peer' },
+) {
+  const agent = {
+    dependencyManager: { resolve: () => vtFlowApi },
+    didcomm: { connections: { findById: vi.fn().mockResolvedValue(connection) } },
+  }
+  return new VtFlowsService({ getAgent: async () => agent } as never)
+}
+
+describe('VtFlowsService flow admin routes', () => {
+  it('maps the spec list filters onto record tags and enriches the peer DID', async () => {
+    const findAllByQuery = vi.fn().mockResolvedValue([record])
+    const service = makeService({ findAllByQuery })
+
+    const flows = await service.listFlows({
+      role: VtFlowRole.Validator,
+      flowState: VtFlowState.Validating,
+      participant_id: '42',
+      schema_id: '5',
+      participant_session_id: 'sess-1',
+    })
+
+    expect(findAllByQuery).toHaveBeenCalledWith({
+      role: VtFlowRole.Validator,
+      flowState: VtFlowState.Validating,
+      participantId: '42',
+      schemaId: '5',
+      participantSessionId: 'sess-1',
+    })
+    expect(flows).toHaveLength(1)
+    expect(flows[0].peerDid).toBe('did:web:peer')
+  })
+
+  it('returns 404 when the flow does not exist', async () => {
+    const service = makeService({ findAllByQuery: vi.fn().mockResolvedValue([]) })
+    await expect(service.editCredentialClaims('missing', {})).rejects.toThrow(NotFoundException)
+  })
+
+  it('refuses oob-link and claim edits when the connection is not established', async () => {
+    const service = makeService({ findAllByQuery: vi.fn().mockResolvedValue([record]) }, { isReady: false })
+    await expect(service.sendOobLink('sess-1', 'https://x')).rejects.toThrow(BadRequestException)
+    await expect(service.editCredentialClaims('sess-1', {})).rejects.toThrow(BadRequestException)
+  })
+
+  it('revokes with the REVOKED credential state and maps vt-flow errors to 400', async () => {
+    const notifyCredentialStateChange = vi.fn().mockResolvedValue(record)
+    const service = makeService({
+      findAllByQuery: vi.fn().mockResolvedValue([record]),
+      notifyCredentialStateChange,
+    })
+
+    await service.revokeCredential('sess-1', 'fraud')
+    expect(notifyCredentialStateChange).toHaveBeenCalledWith({
+      vtFlowRecordId: 'rec-1',
+      state: VtCredentialState.Revoked,
+      reason: 'fraud',
+    })
+
+    notifyCredentialStateChange.mockRejectedValue(new CredoError('expected COMPLETED'))
+    await expect(service.revokeCredential('sess-1')).rejects.toThrow(BadRequestException)
+  })
+})

--- a/apps/vs-agent/tests/vtFlow.test.ts
+++ b/apps/vs-agent/tests/vtFlow.test.ts
@@ -174,6 +174,46 @@ describe('vt-flow: two-agent integration', () => {
     expect(updatedApplicant?.state).toBe(VtFlowState.Validating)
   })
 
+  it('admin flow routes: list, edit claims, and send oob-link on a live flow', async () => {
+    const validatingReached = waitForEvent(validatorEvents, isVtFlowStateChangedEvent(VtFlowState.Validating))
+    await applicant.modules.vtFlow.sendIssuanceRequest({
+      connectionId: applicantConnection.id,
+      schemaId: 'https://example.test/schemas/organization.json',
+      agentParticipantId: 'agent-participant-1',
+      walletAgentParticipantId: 'wallet-agent-participant-1',
+      claims: { name: 'Acme', country: 'CH' },
+    })
+    await validatingReached
+
+    const { VtFlowsService } = await import('../src/controllers/admin/vt-flow/VtFlowsService')
+    const flowsService = new VtFlowsService({ getAgent: async () => validator } as never)
+
+    const flows = await flowsService.listFlows({ role: VtFlowRole.Validator })
+    expect(flows).toHaveLength(1)
+    expect(flows[0].peerDid).toBe(applicant.did)
+    expect(flows[0].state).toBe(VtFlowState.Validating)
+
+    const none = await flowsService.listFlows({ role: VtFlowRole.Validator, peerDID: 'did:web:nobody' })
+    expect(none).toHaveLength(0)
+
+    const psid = flows[0].participantSessionId
+    const edited = await flowsService.editCredentialClaims(psid, { name: 'Acme AG', country: 'CH' })
+    expect(edited.claims).toEqual({ name: 'Acme AG', country: 'CH' })
+
+    const applicantOobPending = waitForEvent(
+      applicantEvents,
+      isVtFlowStateChangedEvent(VtFlowState.OobPending),
+    )
+    const sent = await flowsService.sendOobLink(psid, 'https://collect.example/form', 'complete the form')
+    expect(sent.oobLinkUrl).toBe('https://collect.example/form')
+    expect(sent.state).toBe(VtFlowState.OobPending)
+    await applicantOobPending
+
+    const resent = await flowsService.sendOobLink(psid, 'https://collect.example/form-v2')
+    expect(resent.oobLinkUrl).toBe('https://collect.example/form-v2')
+    expect(resent.state).toBe(VtFlowState.OobPending)
+  })
+
   it('threadId lookup on the Validator side matches the Applicant', async () => {
     const validatingReached = waitForEvent(validatorEvents, isVtFlowStateChangedEvent(VtFlowState.Validating))
 

--- a/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
+++ b/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
@@ -184,6 +184,7 @@ export class VtFlowOrchestrator {
 
     const { record: offered } = await vtFlowApi.offerCredentialForSession({
       vtFlowRecordId: record.id,
+      credentialDigest: digest,
       credentialFormats: {
         jsonld: {
           credential: unsignedCredentialJson,

--- a/packages/vt-flow/src/VtFlowApi.ts
+++ b/packages/vt-flow/src/VtFlowApi.ts
@@ -246,6 +246,7 @@ export class VtFlowApi {
       this.agentContext,
       record.id,
       credentialExchangeRecord,
+      options.credentialDigest,
     )
 
     return {

--- a/packages/vt-flow/src/VtFlowApi.ts
+++ b/packages/vt-flow/src/VtFlowApi.ts
@@ -279,6 +279,10 @@ export class VtFlowApi {
     return record
   }
 
+  public updateClaims(vtFlowRecordId: string, claims: Record<string, unknown>): Promise<VtFlowRecord> {
+    return this.vtFlowService.updateClaims(this.agentContext, vtFlowRecordId, claims)
+  }
+
   public getById(vtFlowRecordId: string): Promise<VtFlowRecord> {
     return this.vtFlowService.getById(this.agentContext, vtFlowRecordId)
   }

--- a/packages/vt-flow/src/messages/OobLinkMessage.ts
+++ b/packages/vt-flow/src/messages/OobLinkMessage.ts
@@ -32,7 +32,7 @@ export class OobLinkMessage extends DidCommMessage {
   @IsValidMessageType(OobLinkMessage.type)
   public readonly type = OobLinkMessage.type.messageTypeUri
 
-  @IsUrl({ require_tld: false, protocols: ['https'] })
+  @IsUrl({ require_tld: false, protocols: ['https', 'http'] })
   public url!: string
 
   @IsString()

--- a/packages/vt-flow/src/repository/VtFlowRecord.ts
+++ b/packages/vt-flow/src/repository/VtFlowRecord.ts
@@ -1,4 +1,5 @@
 import type { RecordTags, TagsBase } from '@credo-ts/core'
+import type { DidCommAttachment } from '@credo-ts/didcomm'
 
 import { BaseRecord, CredoError, utils } from '@credo-ts/core'
 
@@ -44,6 +45,8 @@ export interface VtFlowStorageProps {
   subprotocolThid?: string
 
   oobLinkUrl?: string
+  proofsAttach?: DidCommAttachment[]
+  credentialDigest?: string
   errorMessage?: string
 
   tags?: CustomVtFlowTags
@@ -73,6 +76,8 @@ export class VtFlowRecord extends BaseRecord<DefaultVtFlowTags, CustomVtFlowTags
   public subprotocolThid?: string
 
   public oobLinkUrl?: string
+  public proofsAttach?: DidCommAttachment[]
+  public credentialDigest?: string
   public errorMessage?: string
 
   public constructor(props: VtFlowStorageProps) {
@@ -101,6 +106,8 @@ export class VtFlowRecord extends BaseRecord<DefaultVtFlowTags, CustomVtFlowTags
       this.subprotocolThid = props.subprotocolThid
 
       this.oobLinkUrl = props.oobLinkUrl
+      this.proofsAttach = props.proofsAttach
+      this.credentialDigest = props.credentialDigest
       this.errorMessage = props.errorMessage
     }
   }

--- a/packages/vt-flow/src/repository/VtFlowRecord.ts
+++ b/packages/vt-flow/src/repository/VtFlowRecord.ts
@@ -43,6 +43,7 @@ export interface VtFlowStorageProps {
   credentialExchangeRecordId?: string
   subprotocolThid?: string
 
+  oobLinkUrl?: string
   errorMessage?: string
 
   tags?: CustomVtFlowTags
@@ -71,6 +72,7 @@ export class VtFlowRecord extends BaseRecord<DefaultVtFlowTags, CustomVtFlowTags
   public credentialExchangeRecordId?: string
   public subprotocolThid?: string
 
+  public oobLinkUrl?: string
   public errorMessage?: string
 
   public constructor(props: VtFlowStorageProps) {
@@ -98,6 +100,7 @@ export class VtFlowRecord extends BaseRecord<DefaultVtFlowTags, CustomVtFlowTags
       this.credentialExchangeRecordId = props.credentialExchangeRecordId
       this.subprotocolThid = props.subprotocolThid
 
+      this.oobLinkUrl = props.oobLinkUrl
       this.errorMessage = props.errorMessage
     }
   }

--- a/packages/vt-flow/src/services/VtFlowService.ts
+++ b/packages/vt-flow/src/services/VtFlowService.ts
@@ -189,6 +189,7 @@ export class VtFlowService {
       if (message.claims) existing.claims = message.claims
       if (existing.state === VtFlowState.Completed || existing.state === VtFlowState.CredRevoked) {
         // A finished flow re-entered with a new OR is a renewal (VSA-VTI-FLOW-OP-RENEW): re-run it.
+        existing.oobLinkUrl = undefined
         await this.updateState(agentContext, existing, VtFlowState.AwaitingOr)
       } else {
         await this.repository.update(agentContext, existing)
@@ -426,6 +427,7 @@ export class VtFlowService {
       VtFlowState.AwaitingOr,
       VtFlowState.AwaitingIr,
       VtFlowState.Validating,
+      VtFlowState.OobPending,
       VtFlowState.Completed,
     ])
 
@@ -436,8 +438,11 @@ export class VtFlowService {
       expiresTime: params.expiresTime,
     })
 
+    record.oobLinkUrl = params.url
     if (record.state !== VtFlowState.Completed) {
       await this.updateState(agentContext, record, VtFlowState.OobPending)
+    } else {
+      await this.updateRecord(agentContext, record)
     }
 
     return { record, message }
@@ -493,7 +498,7 @@ export class VtFlowService {
     return record
   }
 
-  /** Validator-side `credential-state-change`; `COMPLETED => CRED_REVOKED`. */
+  /** Validator-side `credential-state-change`; `COMPLETED => CRED_REVOKED`, re-notify allowed from `CRED_REVOKED`. */
   public async notifyCredentialStateChange(
     agentContext: AgentContext,
     recordId: string,
@@ -501,7 +506,11 @@ export class VtFlowService {
   ): Promise<{ record: VtFlowRecord; message: CredentialStateChangeMessage }> {
     const record = await this.repository.getById(agentContext, recordId)
     record.assertRole(VtFlowRole.Validator)
-    record.assertState(VtFlowState.Completed)
+    record.assertState(
+      params.state === VtCredentialState.Revoked
+        ? [VtFlowState.Completed, VtFlowState.CredRevoked]
+        : VtFlowState.Completed,
+    )
 
     const message = new CredentialStateChangeMessage({
       threadId: record.threadId,
@@ -515,6 +524,19 @@ export class VtFlowService {
     }
 
     return { record, message }
+  }
+
+  public async updateClaims(
+    agentContext: AgentContext,
+    recordId: string,
+    claims: Record<string, unknown>,
+  ): Promise<VtFlowRecord> {
+    const record = await this.repository.getById(agentContext, recordId)
+    record.assertRole(VtFlowRole.Validator)
+    record.assertState([VtFlowState.Validating, VtFlowState.CredRevoked])
+    record.claims = claims
+    await this.updateRecord(agentContext, record)
+    return record
   }
 
   /** Map a Credo credential-exchange state change onto the vt-flow session via `~thread.pthid`. */

--- a/packages/vt-flow/src/services/VtFlowService.ts
+++ b/packages/vt-flow/src/services/VtFlowService.ts
@@ -187,6 +187,7 @@ export class VtFlowService {
       existing.connectionId = connection.id
       existing.threadId = message.threadId
       if (message.claims) existing.claims = message.claims
+      if (message.proofsAttach) existing.proofsAttach = message.proofsAttach
       if (existing.state === VtFlowState.Completed || existing.state === VtFlowState.CredRevoked) {
         // A finished flow re-entered with a new OR is a renewal (VSA-VTI-FLOW-OP-RENEW): re-run it.
         existing.oobLinkUrl = undefined
@@ -208,6 +209,7 @@ export class VtFlowService {
       walletAgentParticipantId: message.walletAgentParticipantId,
       participantId: message.participantId,
       claims: message.claims,
+      proofsAttach: message.proofsAttach,
     })
 
     await this.repository.save(agentContext, record)
@@ -481,6 +483,7 @@ export class VtFlowService {
     agentContext: AgentContext,
     recordId: string,
     credentialExchangeRecord: DidCommCredentialExchangeRecord,
+    credentialDigest?: string,
   ): Promise<VtFlowRecord> {
     const record = await this.repository.getById(agentContext, recordId)
     record.assertRole(VtFlowRole.Validator)
@@ -492,6 +495,7 @@ export class VtFlowService {
     ])
 
     record.credentialExchangeRecordId = credentialExchangeRecord.id
+    if (credentialDigest) record.credentialDigest = credentialDigest
     record.subprotocolThid = credentialExchangeRecord.threadId
 
     await this.updateState(agentContext, record, VtFlowState.CredOffered)

--- a/packages/vt-flow/src/types.ts
+++ b/packages/vt-flow/src/types.ts
@@ -85,6 +85,7 @@ export interface SendIssuanceRequestOptions {
 export interface OfferCredentialForSessionOptions {
   vtFlowRecordId: string
   credentialFormats: { jsonld: DidCommJsonLdCredentialDetailFormat }
+  credentialDigest?: string
   comment?: string
   goal?: string
   goalCode?: string

--- a/packages/vt-flow/tests/VtFlowMessages.test.ts
+++ b/packages/vt-flow/tests/VtFlowMessages.test.ts
@@ -155,15 +155,17 @@ describe('OobLinkMessage', () => {
     expect(parsed.description).toBe('Complete OOB step')
   })
 
-  it('rejects a non-HTTPS URL', () => {
+  it('accepts http URLs and rejects non-URL values', () => {
     // Constructor itself is permissive; validation runs on serialise/parse.
-    const msg = new OobLinkMessage({
+    const httpMsg = new OobLinkMessage({
       threadId,
       url: 'http://issuer.example/oob/abc',
-      description: 'bad',
+      description: 'test env',
     })
-    const json = JsonTransformer.toJSON(msg)
-    expect(() => JsonTransformer.fromJSON(json, OobLinkMessage)).toThrow()
+    expect(() => JsonTransformer.fromJSON(JsonTransformer.toJSON(httpMsg), OobLinkMessage)).not.toThrow()
+
+    const badMsg = new OobLinkMessage({ threadId, url: 'ftp://issuer.example/oob', description: 'bad' })
+    expect(() => JsonTransformer.fromJSON(JsonTransformer.toJSON(badMsg), OobLinkMessage)).toThrow()
   })
 })
 

--- a/packages/vt-flow/tests/VtFlowService.test.ts
+++ b/packages/vt-flow/tests/VtFlowService.test.ts
@@ -1,7 +1,7 @@
 import { utils } from '@credo-ts/core'
 import { describe, expect, it, vi } from 'vitest'
 
-import { VtFlowRole, VtFlowState, VtFlowVariant } from '../src'
+import { VtCredentialState, VtFlowRole, VtFlowState, VtFlowVariant } from '../src'
 import { OnboardingRequestMessage } from '../src/messages'
 import { VtFlowRecord } from '../src/repository'
 import { VtFlowService } from '../src/services/VtFlowService'
@@ -24,6 +24,7 @@ function makeRecord(overrides: Partial<ConstructorParameters<typeof VtFlowRecord
 function makeService(existing: VtFlowRecord | null, previousConnection: unknown = null) {
   const repository = {
     findByParticipantSessionId: vi.fn().mockResolvedValue(existing),
+    getById: vi.fn().mockResolvedValue(existing),
     save: vi.fn(),
     update: vi.fn(),
   }
@@ -122,5 +123,33 @@ describe('VtFlowService re-attach on same participant_session_id', () => {
     await expect(
       service.processReceiveOnboardingRequest(makeMessageContext(agentContext, 'did:web:attacker') as never),
     ).rejects.toThrow(/peer does not match/)
+  })
+})
+
+describe('VtFlowService.notifyCredentialStateChange', () => {
+  it('allows re-notifying a revocation from CRED_REVOKED', async () => {
+    const revoked = makeRecord({ role: VtFlowRole.Validator, state: VtFlowState.CredRevoked })
+    const { service } = makeService(revoked)
+
+    const { record } = await service.notifyCredentialStateChange({} as never, revoked.id, {
+      state: VtCredentialState.Revoked,
+      subprotocolThid: 'sub-1',
+    })
+    expect(record.state).toBe(VtFlowState.CredRevoked)
+  })
+})
+
+describe('VtFlowService.updateClaims', () => {
+  it('replaces claims while validating and rejects other states', async () => {
+    const validating = makeRecord({ role: VtFlowRole.Validator, state: VtFlowState.Validating })
+    const { service, repository } = makeService(validating)
+
+    const updated = await service.updateClaims({} as never, validating.id, { name: 'Edited' })
+    expect(updated.claims).toEqual({ name: 'Edited' })
+    expect(repository.update).toHaveBeenCalled()
+
+    const completed = makeRecord({ role: VtFlowRole.Validator, state: VtFlowState.Completed })
+    repository.getById.mockResolvedValue(completed)
+    await expect(service.updateClaims({} as never, completed.id, {})).rejects.toThrow()
   })
 })


### PR DESCRIPTION
Closes #497 

Implements the four missing Flow Management admin methods from the spec table (VSA-ADM-FL).

- `GET /v1/vt/flows`: list flows with the spec filters, enriched with peer DID and connection state.
- `PUT /v1/vt/flows/{participantSessionId}/claims`: replace the flow's claims (`VALIDATING` or `CRED_REVOKED`, connection `ESTABLISHED`).
- `POST /v1/vt/flows/{participantSessionId}/oob-link`: send or resend an OOB link (last URL stored on the record).
- `POST /v1/vt/flows/{participantSessionId}/revoke-credential`: `CRED_STATE_CHANGE` to the applicant, retryable from `CRED_REVOKED`.

Known differences: `participant_id` filters on the applicant participant id (the record does not store the validator's), and `listFlows` has no proofs/digest yet (not captured at offer time).