### PR TITLE
fix: validator-side issuance and agent startup bugs

### DIFF
--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -10,8 +10,10 @@ import {
   VsAgentWsInboundTransport,
   type VsAgentNestPlugin,
   VeranaChainService,
+  VeranaIndexerService,
   IndexerWebSocketService,
   buildDefaultIndexerHandlerRegistry,
+  reconcileVtjscPublications,
 } from '@verana-labs/vs-agent-sdk'
 import * as express from 'express'
 import * as fs from 'fs'
@@ -240,13 +242,28 @@ const run = async () => {
     VtFlowNestPlugin,
   ]
 
+  const indexerService = VERANA_INDEXER_BASE_URL
+    ? new VeranaIndexerService({ baseUrl: VERANA_INDEXER_BASE_URL, logger: serverLogger })
+    : undefined
+
   // Connect to Verana blockchain for on-chain transactions
   let veranaChain: VeranaChainService | undefined
   if (VERANA_RPC_ENDPOINT_URL && VERANA_ACCOUNT_MNEMONIC) {
+    let corporationAddress: string | undefined
+    if (VERANA_CORPORATION_ID && indexerService) {
+      const corporation = await indexerService.getCorporation(VERANA_CORPORATION_ID).catch(() => undefined)
+      corporationAddress = corporation?.policy_address ?? undefined
+      if (!corporationAddress) {
+        serverLogger.warn(
+          `Corporation ${VERANA_CORPORATION_ID} not resolvable on the indexer yet; on-chain transactions will sign without a corporation`,
+        )
+      }
+    }
     veranaChain = new VeranaChainService({
       rpcUrl: VERANA_RPC_ENDPOINT_URL,
       chainId: VERANA_CHAIN_ID,
       mnemonic: VERANA_ACCOUNT_MNEMONIC,
+      corporationAddress,
       logger: serverLogger,
       autoTriggerResolver: VERANA_AUTO_TRIGGER_RESOLVER,
     })
@@ -361,13 +378,25 @@ const run = async () => {
       VERANA_INDEXER_SUBSCRIPTION_SCOPE === 'corporation' && VERANA_CORPORATION_ID
         ? Number(VERANA_CORPORATION_ID)
         : undefined
-    const indexerWs = new IndexerWebSocketService({
-      indexerUrl: VERANA_INDEXER_BASE_URL,
-      agent,
-      handlerRegistry,
-      corporationId: indexerCorporationId,
-    })
-    await indexerWs.start()
+    if (agent.did || indexerCorporationId) {
+      const indexerWs = new IndexerWebSocketService({
+        indexerUrl: VERANA_INDEXER_BASE_URL,
+        agent,
+        handlerRegistry,
+        corporationId: indexerCorporationId,
+      })
+      await indexerWs.start()
+    } else {
+      serverLogger.warn(
+        '[IndexerWS] subscription skipped: agent has no public DID and no VERANA_CORPORATION_ID scope',
+      )
+    }
+
+    if (indexerService && VERANA_CORPORATION_ID) {
+      void reconcileVtjscPublications(agent, indexerService, Number(VERANA_CORPORATION_ID)).catch(
+        (error: Error) => serverLogger.error(`[VTJSC] reconciliation failed: ${error.message}`),
+      )
+    }
   }
 
   // Accept incoming DIDComm only after the catch-up, so the agent does not act on stale chain state.

--- a/apps/vs-agent/src/utils/setupAgent.ts
+++ b/apps/vs-agent/src/utils/setupAgent.ts
@@ -117,6 +117,7 @@ export const setupAgent = async ({
         endpoints,
         didcommVersions,
         vtFlow: {
+          autoIssueCredentialOnRequest: true,
           assertVerifiableService: verifiablePublicRegistries
             ? assertVerifiableService({ verifiablePublicRegistries })
             : undefined,

--- a/packages/agent-sdk/src/blockchain/VeranaIndexerService.ts
+++ b/packages/agent-sdk/src/blockchain/VeranaIndexerService.ts
@@ -43,6 +43,24 @@ export class VeranaIndexerService {
     return data.ecosystem
   }
 
+  async listEcosystems(): Promise<EcosystemDto[]> {
+    this.config.logger.debug('[VeranaIndexer] listEcosystems')
+    const data = await fetchJson<{ ecosystems: EcosystemDto[] }>(
+      `${this.baseUrl}/v4/ecosystem/list`,
+      REQUEST_TIMEOUT_MS,
+    )
+    return data.ecosystems ?? []
+  }
+
+  async listCredentialSchemas(ecosystemId: number): Promise<CredentialSchemaDto[]> {
+    this.config.logger.debug(`[VeranaIndexer] listCredentialSchemas ecosystem=${ecosystemId}`)
+    const data = await fetchJson<{ schemas: CredentialSchemaDto[] }>(
+      `${this.baseUrl}/v4/credential-schema/list?ecosystem_id=${ecosystemId}`,
+      REQUEST_TIMEOUT_MS,
+    )
+    return data.schemas
+  }
+
   async getCredentialSchema(id: string | number): Promise<CredentialSchemaDto> {
     this.config.logger.debug(`[VeranaIndexer] getCredentialSchema id=${id}`)
     const data = await fetchJson<{ schema: CredentialSchemaDto }>(

--- a/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
@@ -11,8 +11,9 @@ import { computeSchemaDigest } from '@verana-labs/vs-agent-model'
 
 import { VsAgent } from '../../agent/VsAgent'
 import { getEcsSchemas } from '../../utils/data'
-import { createJsc, removeTrustCredential } from '../../utils/trustCredentialStore'
+import { createJsc, getTrustMetadata, removeTrustCredential } from '../../utils/trustCredentialStore'
 import { VtFlowOrchestrator } from '../../vtFlow'
+import { VeranaIndexerService } from '../VeranaIndexerService'
 import { IndexerActivity, VeranaSyncState } from '../types'
 
 const DEFAULT_CHAIN_ID = 'vna-testnet-1'
@@ -319,6 +320,37 @@ export async function startParticipantOPAutoFlow(agent: VsAgent, activity: Index
     agent.config.logger.error(
       `[IndexerWS] StartParticipantOP auto-flow failed: ${(err as Error).message}\n${(err as Error).stack}`,
     )
+  }
+}
+
+export async function reconcileVtjscPublications(
+  agent: VsAgent,
+  indexer: VeranaIndexerService,
+  corporationId: number,
+): Promise<void> {
+  if (!agent.did || !agent.publicApiBaseUrl) return
+
+  const [didRecord] = await agent.dids.getCreatedDids({ did: agent.did })
+  if (!didRecord) return
+  const chainId = agent.veranaChain?.getChainId ?? DEFAULT_CHAIN_ID
+
+  const ecosystems = await indexer.listEcosystems()
+  for (const ecosystem of ecosystems.filter(entry => Number(entry.corporation_id) === corporationId)) {
+    for (const schema of await indexer.listCredentialSchemas(ecosystem.id)) {
+      if (getTrustMetadata(didRecord, '_vt/jsc', String(schema.id))) continue
+      try {
+        await createJsc(agent, agent.publicApiBaseUrl, getEcsSchemas(agent.publicApiBaseUrl), {
+          schemaBaseId: String(schema.id),
+          jsonSchemaRef: `vpr:verana:${chainId}/cs/v1/js/${schema.id}`,
+          precomputedDigestSRI: await computeSchemaDigest(JSON.parse(schema.json_schema)),
+        })
+        agent.config.logger.info(
+          `[VTJSC] Reconciled missing VTJSC for schema ${schema.id} (ecosystem ${ecosystem.id})`,
+        )
+      } catch (e) {
+        agent.config.logger.error(`[VTJSC] Failed to reconcile VTJSC for schema ${schema.id}`, e as Error)
+      }
+    }
   }
 }
 

--- a/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
@@ -11,7 +11,7 @@ import { computeSchemaDigest } from '@verana-labs/vs-agent-model'
 
 import { VsAgent } from '../../agent/VsAgent'
 import { getEcsSchemas } from '../../utils/data'
-import { createJsc, getTrustMetadata, removeTrustCredential } from '../../utils/trustCredentialStore'
+import { createJsc, findMetadataEntry, removeTrustCredential } from '../../utils/trustCredentialStore'
 import { VtFlowOrchestrator } from '../../vtFlow'
 import { VeranaIndexerService } from '../VeranaIndexerService'
 import { IndexerActivity, VeranaSyncState } from '../types'
@@ -337,11 +337,12 @@ export async function reconcileVtjscPublications(
   const ecosystems = await indexer.listEcosystems()
   for (const ecosystem of ecosystems.filter(entry => Number(entry.corporation_id) === corporationId)) {
     for (const schema of await indexer.listCredentialSchemas(ecosystem.id)) {
-      if (getTrustMetadata(didRecord, '_vt/jsc', String(schema.id))) continue
+      const schemaRef = `vpr:verana:${chainId}/cs/v1/js/${schema.id}`
+      if (findMetadataEntry(didRecord, '_vt/jsc', '', schemaRef)) continue
       try {
         await createJsc(agent, agent.publicApiBaseUrl, getEcsSchemas(agent.publicApiBaseUrl), {
           schemaBaseId: String(schema.id),
-          jsonSchemaRef: `vpr:verana:${chainId}/cs/v1/js/${schema.id}`,
+          jsonSchemaRef: schemaRef,
           precomputedDigestSRI: await computeSchemaDigest(JSON.parse(schema.json_schema)),
         })
         agent.config.logger.info(

--- a/packages/agent-sdk/src/blockchain/types.ts
+++ b/packages/agent-sdk/src/blockchain/types.ts
@@ -195,6 +195,7 @@ export interface ParticipantDto {
 export interface CorporationDto {
   id: number
   did?: string | null
+  policy_address?: string | null
 }
 
 export interface ParticipantSessionRecordDto {
@@ -329,7 +330,7 @@ export interface SetParticipantOPToValidatedParams {
   validationFees?: number
   issuanceFees?: number
   verificationFees?: number
-  opSummaryDigest: string
+  opSummaryDigest?: string
   issuanceFeeDiscount?: number
   verificationFeeDiscount?: number
   corporation?: string

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -29,3 +29,4 @@ export interface VsAgentNestPlugin {
 }
 
 export const ISSUER_PARTICIPANT_TYPE = 1
+export const HOLDER_PARTICIPANT_TYPE = 6

--- a/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
+++ b/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
@@ -14,7 +14,7 @@ import {
 import { BaseAgentModules, VsAgent } from '../agent'
 import { VeranaIndexerService } from '../blockchain/VeranaIndexerService'
 import { ParticipantRole, ParticipantState } from '../blockchain/types'
-import { ISSUER_PARTICIPANT_TYPE } from '../types'
+import { HOLDER_PARTICIPANT_TYPE, ISSUER_PARTICIPANT_TYPE } from '../types'
 import { createCredential, createVtc, findMetadataEntry } from '../utils'
 
 import { credentialContentDigest } from './credentialDigest'
@@ -166,14 +166,15 @@ export class VtFlowOrchestrator {
 
     const digest = credentialContentDigest(unsignedCredentialJson)
 
+    // The chain requires a null op_summary_digest for HOLDER participants (MOD-PP-MSG-3).
     await chain.setParticipantOPToValidated({
       id: holderParticipantId,
-      opSummaryDigest: digest,
+      opSummaryDigest: holderParticipant.role === HOLDER_PARTICIPANT_TYPE ? undefined : digest,
       corporation: holderParticipant.corporation,
     })
     await chain.createOrUpdateParticipantSession({
       id: record.participantSessionId,
-      issuerParticipantId: holderParticipantId,
+      issuerParticipantId: Number(holderParticipant.validatorParticipantId),
       agentParticipantId: input.agentParticipantId ?? 0,
       walletAgentParticipantId: input.walletAgentParticipantId ?? 0,
       digest,


### PR DESCRIPTION
Closes https://github.com/verana-labs/vs-agent/issues/499

- `op_summary_digest` is now omitted for HOLDER participants (MOD-PP-MSG-3) and the session is anchored with the validator participant as `issuer_participant_id`.
- `setupAgent` wires `autoIssueCredentialOnRequest`, so validators actually issue after the holder's request instead of stalling at `RequestReceived`.
- `VERANA_CORPORATION_ID` now resolves the corporation policy address from the indexer at startup and feeds it to the transaction signer.
- `indexerWs.start()` is guarded, so an agent with the indexer configured but no public DID and no corporation scope logs a warning instead of crashing.
- New `reconcileVtjscPublications` runs at startup and publishes any VTJSC missed while the agent was down or not yet subscribed.

All six were found and verified by running the full lifecycle against a live chain and indexer.