### PR TITLE
fix(vt-flow): credential cleanup on revocation and cancel-aware flow reconciliation

### DIFF
--- a/apps/vs-agent/src/utils/setupAgent.ts
+++ b/apps/vs-agent/src/utils/setupAgent.ts
@@ -149,6 +149,14 @@ export const setupAgent = async ({
               logger.error(`[vt-flow] onCompleted failed: ${(error as Error).message}`)
             }
           },
+          onCredentialRevoked: async ({ record }) => {
+            if (!orchestrator) return
+            try {
+              await orchestrator.onCredentialRevoked(record.id)
+            } catch (error) {
+              logger.error(`[vt-flow] onCredentialRevoked failed: ${(error as Error).message}`)
+            }
+          },
         },
       }),
       ...(chatSetup ? [chatSetup.setupChatProtocols()] : []),

--- a/packages/agent-sdk/src/blockchain/handlers/defaultHandlers.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/defaultHandlers.ts
@@ -6,7 +6,7 @@ import {
   setVtFlowRecordsParticipantRevoked,
   setVtFlowRecordsParticipantSlashed,
   startParticipantOPAutoFlow,
-  terminateVtFlowRecordsByApplicant,
+  reconcileVtFlowRecordsOnCancel,
 } from './stateMutations'
 
 /**
@@ -142,7 +142,7 @@ export const defaultHandlers: IndexerEventHandler[] = [
       ctx.agent.config.logger.info(
         `[IndexerWS] CancelParticipantOPLastRequest participant=${activity.entity_id} block=${ctx.blockHeight}`,
       )
-      await terminateVtFlowRecordsByApplicant(ctx.agent, String(activity.entity_id))
+      await reconcileVtFlowRecordsOnCancel(ctx.agent, String(activity.entity_id))
     },
   },
   {

--- a/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
@@ -6,15 +6,16 @@ import {
   VtFlowRole,
   VtFlowService,
   VtFlowState,
+  isVtFlowTerminalState,
 } from '@verana-labs/credo-ts-didcomm-vt-flow'
 import { computeSchemaDigest } from '@verana-labs/vs-agent-model'
 
 import { VsAgent } from '../../agent/VsAgent'
 import { getEcsSchemas } from '../../utils/data'
-import { createJsc, findMetadataEntry, removeTrustCredential } from '../../utils/trustCredentialStore'
+import { createJsc, findMetadataEntry, removeStoredTrustCredential } from '../../utils/trustCredentialStore'
 import { VtFlowOrchestrator } from '../../vtFlow'
 import { VeranaIndexerService } from '../VeranaIndexerService'
-import { IndexerActivity, VeranaSyncState } from '../types'
+import { IndexerActivity, ValidationState, VeranaSyncState } from '../types'
 
 const DEFAULT_CHAIN_ID = 'vna-testnet-1'
 const PARTICIPANT_ROLE_HOLDER = 6
@@ -265,21 +266,14 @@ export async function removeHolderTrustCredentialIfRevoked(
   for (const record of records) {
     if (record.role !== VtFlowRole.Applicant || !record.credentialExchangeRecordId) continue
     try {
-      const formatData = await agent.didcomm.credentials.getFormatData(record.credentialExchangeRecordId)
-      const credentialId = (
-        (formatData.credential as { jsonld?: { id?: string } } | undefined)?.jsonld as
-          | { id?: string }
-          | undefined
-      )?.id
-      if (!credentialId) continue
-      const removed = await removeTrustCredential(agent, agent.publicApiBaseUrl, credentialId, '_vt/vtc')
-      if (removed) {
+      const credentialId = await removeStoredTrustCredential(
+        agent,
+        agent.publicApiBaseUrl,
+        record.credentialExchangeRecordId,
+      )
+      if (credentialId) {
         agent.config.logger.info(
           `[IndexerWS] Removed linked VP and stored credential ${credentialId} (participant=${participantId})`,
-        )
-      } else {
-        agent.config.logger.debug(
-          `[IndexerWS] No stored trust credential matched ${credentialId} (participant=${participantId})`,
         )
       }
     } catch (e) {
@@ -291,18 +285,17 @@ export async function removeHolderTrustCredentialIfRevoked(
   }
 }
 
-const ONBOARDING_STATE_VALIDATED = 2
-
 export async function reconcileVtFlowRecordsOnCancel(agent: VsAgent, participantId: string): Promise<void> {
   const participant = await agent.veranaChain?.getParticipant(Number(participantId)).catch(() => undefined)
-  const stillValidated = Number(participant?.opState) === ONBOARDING_STATE_VALIDATED
+  const stillValidated = Number(participant?.opState) === ValidationState.VALIDATED
 
   await reconcileVtFlowRecordsForParticipant(
     agent,
     participantId,
     async (record, service, agentContext) => {
-      const renewalState = record.state === VtFlowState.AwaitingOr || record.state === VtFlowState.OrSent
-      if (stillValidated && renewalState && record.credentialExchangeRecordId) {
+      if (isVtFlowTerminalState(record.state)) return null
+      if (stillValidated && record.credentialExchangeRecordId) {
+        if (record.state === VtFlowState.Completed) return null
         await service.updateState(agentContext, record, VtFlowState.Completed)
         return 'COMPLETED'
       }

--- a/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
@@ -291,18 +291,25 @@ export async function removeHolderTrustCredentialIfRevoked(
   }
 }
 
-export async function terminateVtFlowRecordsByApplicant(
-  agent: VsAgent,
-  participantId: string,
-): Promise<void> {
+const ONBOARDING_STATE_VALIDATED = 2
+
+export async function reconcileVtFlowRecordsOnCancel(agent: VsAgent, participantId: string): Promise<void> {
+  const participant = await agent.veranaChain?.getParticipant(Number(participantId)).catch(() => undefined)
+  const stillValidated = Number(participant?.opState) === ONBOARDING_STATE_VALIDATED
+
   await reconcileVtFlowRecordsForParticipant(
     agent,
     participantId,
     async (record, service, agentContext) => {
+      const renewalState = record.state === VtFlowState.AwaitingOr || record.state === VtFlowState.OrSent
+      if (stillValidated && renewalState && record.credentialExchangeRecordId) {
+        await service.updateState(agentContext, record, VtFlowState.Completed)
+        return 'COMPLETED'
+      }
       await service.updateState(agentContext, record, VtFlowState.TerminatedByApplicant)
       return 'TERMINATED_BY_APPLICANT'
     },
-    'Failed to terminate record',
+    'Failed to reconcile record after cancel',
   )
 }
 

--- a/packages/agent-sdk/src/utils/trustCredentialStore.ts
+++ b/packages/agent-sdk/src/utils/trustCredentialStore.ts
@@ -297,6 +297,26 @@ export async function removeTrustCredential(
   return await deleteMetadataEntry(agent, schemaId, didRecord, key, publicApiBaseUrl)
 }
 
+export async function removeStoredTrustCredential(
+  agent: VsAgent,
+  publicApiBaseUrl: string,
+  credentialExchangeRecordId: string,
+): Promise<string | undefined> {
+  const formatData = await agent.didcomm.credentials.getFormatData(credentialExchangeRecordId)
+  const credentialId = (formatData.credential as { jsonld?: { id?: string } } | undefined)?.jsonld?.id
+  if (!credentialId) return undefined
+
+  await removeTrustCredential(agent, publicApiBaseUrl, credentialId, '_vt/vtc')
+
+  const stored = await agent.w3cCredentials.getAll()
+  for (const storedRecord of stored) {
+    if (storedRecord.getTags().givenId === credentialId) {
+      await agent.w3cCredentials.deleteById(storedRecord.id)
+    }
+  }
+  return credentialId
+}
+
 export function getTrustMetadata(didRecord: DidRecord, key: '_vt/vtc' | '_vt/jsc', schemaId?: string) {
   return findMetadataEntry(didRecord, key, schemaId)
 }

--- a/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
+++ b/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
@@ -15,7 +15,7 @@ import { BaseAgentModules, VsAgent } from '../agent'
 import { VeranaIndexerService } from '../blockchain/VeranaIndexerService'
 import { ParticipantRole, ParticipantState } from '../blockchain/types'
 import { HOLDER_PARTICIPANT_TYPE, ISSUER_PARTICIPANT_TYPE } from '../types'
-import { createCredential, createVtc, findMetadataEntry, removeTrustCredential } from '../utils'
+import { createCredential, createVtc, findMetadataEntry, removeStoredTrustCredential } from '../utils'
 
 import { credentialContentDigest } from './credentialDigest'
 
@@ -262,19 +262,16 @@ export class VtFlowOrchestrator {
     if (!record || record.role !== VtFlowRole.Applicant) return
     if (!this.options.publicApiBaseUrl || !record.credentialExchangeRecordId) return
 
-    const formatData = await this.agent.didcomm.credentials.getFormatData(record.credentialExchangeRecordId)
-    const credentialId = (formatData.credential as { jsonld?: { id?: string } } | undefined)?.jsonld?.id
-    if (!credentialId) return
-
-    await removeTrustCredential(this.agent, this.options.publicApiBaseUrl, credentialId, '_vt/vtc')
-
-    const stored = await this.agent.w3cCredentials.getAll()
-    for (const storedRecord of stored) {
-      if (storedRecord.getTags().givenId === credentialId) {
-        await this.agent.w3cCredentials.deleteById(storedRecord.id)
-      }
+    const credentialId = await removeStoredTrustCredential(
+      this.agent,
+      this.options.publicApiBaseUrl,
+      record.credentialExchangeRecordId,
+    )
+    if (credentialId) {
+      this.agent.config.logger.info(
+        `[vt-flow] removed revoked credential and its linked VP (${credentialId})`,
+      )
     }
-    this.agent.config.logger.info(`[vt-flow] removed revoked credential and its linked VP (${credentialId})`)
   }
 
   async onCredentialCompleted(vtFlowRecordId: string): Promise<void> {

--- a/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
+++ b/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
@@ -15,7 +15,7 @@ import { BaseAgentModules, VsAgent } from '../agent'
 import { VeranaIndexerService } from '../blockchain/VeranaIndexerService'
 import { ParticipantRole, ParticipantState } from '../blockchain/types'
 import { HOLDER_PARTICIPANT_TYPE, ISSUER_PARTICIPANT_TYPE } from '../types'
-import { createCredential, createVtc, findMetadataEntry } from '../utils'
+import { createCredential, createVtc, findMetadataEntry, removeTrustCredential } from '../utils'
 
 import { credentialContentDigest } from './credentialDigest'
 
@@ -254,6 +254,27 @@ export class VtFlowOrchestrator {
     if (!anchored) {
       throw new Error(`Credential digest ${digest} is not anchored on-chain`)
     }
+  }
+
+  async onCredentialRevoked(vtFlowRecordId: string): Promise<void> {
+    const vtFlowApi = this.resolveVtFlowApi()
+    const record = await vtFlowApi.findById(vtFlowRecordId)
+    if (!record || record.role !== VtFlowRole.Applicant) return
+    if (!this.options.publicApiBaseUrl || !record.credentialExchangeRecordId) return
+
+    const formatData = await this.agent.didcomm.credentials.getFormatData(record.credentialExchangeRecordId)
+    const credentialId = (formatData.credential as { jsonld?: { id?: string } } | undefined)?.jsonld?.id
+    if (!credentialId) return
+
+    await removeTrustCredential(this.agent, this.options.publicApiBaseUrl, credentialId, '_vt/vtc')
+
+    const stored = await this.agent.w3cCredentials.getAll()
+    for (const storedRecord of stored) {
+      if (storedRecord.getTags().givenId === credentialId) {
+        await this.agent.w3cCredentials.deleteById(storedRecord.id)
+      }
+    }
+    this.agent.config.logger.info(`[vt-flow] removed revoked credential and its linked VP (${credentialId})`)
   }
 
   async onCredentialCompleted(vtFlowRecordId: string): Promise<void> {

--- a/packages/agent-sdk/tests/indexerHandlers.test.ts
+++ b/packages/agent-sdk/tests/indexerHandlers.test.ts
@@ -1,4 +1,4 @@
-import { VtFlowRole, VtFlowService } from '@verana-labs/credo-ts-didcomm-vt-flow'
+import { VtFlowRole, VtFlowService, VtFlowState } from '@verana-labs/credo-ts-didcomm-vt-flow'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -12,6 +12,7 @@ import {
 } from '../src/blockchain/handlers/defaultHandlers'
 import {
   applyStateMutation,
+  reconcileVtFlowRecordsOnCancel,
   removeHolderTrustCredentialIfRevoked,
 } from '../src/blockchain/handlers/stateMutations'
 import { IndexerActivity, VeranaSyncState } from '../src/blockchain/types'
@@ -196,5 +197,74 @@ describe('applyStateMutation', () => {
     )
     expect(state.participants['12']).toMatchObject({ id: 12, schemaId: 4, did: 'did:web:self' })
     expect(state.participants['13']).toMatchObject({ id: 13, schemaId: 4, did: 'did:web:root' })
+  })
+})
+
+describe('reconcileVtFlowRecordsOnCancel', () => {
+  function makeCancelAgent(opState: number | undefined, records: Record<string, unknown>[]) {
+    const updateState = vi.fn().mockResolvedValue(undefined)
+    const agent = {
+      veranaChain: {
+        getParticipant:
+          opState === undefined
+            ? vi.fn().mockRejectedValue(new Error('participant not found'))
+            : vi.fn().mockResolvedValue({ opState }),
+      },
+      context: {
+        dependencyManager: {
+          resolve: () => ({ findAllByQuery: vi.fn().mockResolvedValue(records), updateState }),
+        },
+      },
+      config: { logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+    }
+    return { agent, updateState }
+  }
+
+  it('restores renewal-reset records to COMPLETED when the participant is still VALIDATED', async () => {
+    for (const state of [
+      VtFlowState.AwaitingOr,
+      VtFlowState.OrSent,
+      VtFlowState.OobPending,
+      VtFlowState.Validating,
+    ]) {
+      const record = { state, credentialExchangeRecordId: 'cx-1' }
+      const { agent, updateState } = makeCancelAgent(2, [record])
+
+      await reconcileVtFlowRecordsOnCancel(agent as never, '7')
+
+      expect(updateState).toHaveBeenCalledWith(expect.anything(), record, VtFlowState.Completed)
+    }
+  })
+
+  it('leaves completed and terminal records untouched', async () => {
+    const records = [
+      { state: VtFlowState.Completed, credentialExchangeRecordId: 'cx-1' },
+      { state: VtFlowState.TerminatedByApplicant, credentialExchangeRecordId: 'cx-1' },
+    ]
+    const { agent, updateState } = makeCancelAgent(2, records)
+
+    await reconcileVtFlowRecordsOnCancel(agent as never, '7')
+
+    expect(updateState).not.toHaveBeenCalled()
+  })
+
+  it('terminates records when the participant is no longer validated', async () => {
+    for (const opState of [1, undefined]) {
+      const record = { state: VtFlowState.AwaitingOr, credentialExchangeRecordId: 'cx-1' }
+      const { agent, updateState } = makeCancelAgent(opState, [record])
+
+      await reconcileVtFlowRecordsOnCancel(agent as never, '7')
+
+      expect(updateState).toHaveBeenCalledWith(expect.anything(), record, VtFlowState.TerminatedByApplicant)
+    }
+  })
+
+  it('terminates a validated participant record that has no prior credential exchange', async () => {
+    const record = { state: VtFlowState.AwaitingOr }
+    const { agent, updateState } = makeCancelAgent(2, [record])
+
+    await reconcileVtFlowRecordsOnCancel(agent as never, '7')
+
+    expect(updateState).toHaveBeenCalledWith(expect.anything(), record, VtFlowState.TerminatedByApplicant)
   })
 })

--- a/packages/vt-flow/src/VtFlowModule.ts
+++ b/packages/vt-flow/src/VtFlowModule.ts
@@ -153,6 +153,25 @@ export class VtFlowModule implements Module {
     })
 
     eventEmitter.on<VtFlowStateChangedEvent>(VtFlowEventTypes.VtFlowStateChanged, async ({ payload }) => {
+      if (payload.state !== VtFlowState.CredRevoked) return
+      if (payload.previousState === VtFlowState.CredRevoked) return
+
+      const config = service.getModuleConfig()
+      if (!config.onCredentialRevoked) return
+
+      const record = await service.findById(agentContext, payload.vtFlowRecordId)
+      if (!record || record.role !== VtFlowRole.Applicant) return
+
+      try {
+        await config.onCredentialRevoked({ agentContext, record })
+      } catch (error) {
+        service
+          .getLogger()
+          .error('[vt-flow] onCredentialRevoked hook threw', error as Record<string, unknown>)
+      }
+    })
+
+    eventEmitter.on<VtFlowStateChangedEvent>(VtFlowEventTypes.VtFlowStateChanged, async ({ payload }) => {
       const config = service.getModuleConfig()
 
       const record = await service.findById(agentContext, payload.vtFlowRecordId)

--- a/packages/vt-flow/src/VtFlowModuleConfig.ts
+++ b/packages/vt-flow/src/VtFlowModuleConfig.ts
@@ -14,6 +14,11 @@ export type VtFlowVerifyCredentialHook = (ctx: VtFlowCredentialLifecycleContext)
 /** Fired on COMPLETED on both sides; typical applicant use is to link the credential to its DID Document. */
 export type VtFlowOnCompletedHook = (ctx: VtFlowCredentialLifecycleContext) => Promise<void>
 
+export type VtFlowOnCredentialRevokedHook = (ctx: {
+  agentContext: AgentContext
+  record: VtFlowRecord
+}) => Promise<void>
+
 export interface VtFlowBuildCredentialOfferContext {
   agentContext: AgentContext
   record: VtFlowRecord
@@ -50,6 +55,7 @@ export interface VtFlowModuleConfigOptions {
   autoAcceptIssuanceRequest?: boolean
   verifyCredential?: VtFlowVerifyCredentialHook
   onCompleted?: VtFlowOnCompletedHook
+  onCredentialRevoked?: VtFlowOnCredentialRevokedHook
   autoMarkValidated?: boolean
   autoOfferCredential?: boolean
   buildCredentialOffer?: VtFlowBuildCredentialOfferHook
@@ -88,6 +94,10 @@ export class VtFlowModuleConfig {
 
   public get onCompleted(): VtFlowOnCompletedHook | undefined {
     return this.options.onCompleted
+  }
+
+  public get onCredentialRevoked(): VtFlowOnCredentialRevokedHook | undefined {
+    return this.options.onCredentialRevoked
   }
 
   public get autoMarkValidated(): boolean {


### PR DESCRIPTION
Closes https://github.com/verana-labs/vs-agent/issues/503

- New `onCredentialRevoked` hook: when an applicant flow enters `CRED_REVOKED`, the agent removes the credential's LinkedVerifiablePresentation entry from its DID Document and deletes the credential from the wallet, as the spec requires.
- `CancelParticipantOPLastRequest` no longer terminates every flow: if the participant is still VALIDATED on chain (a renewal was cancelled), flows reset by that renewal restore to `COMPLETED`. Cancelling a first request still terminates.