### PR TITLE
fix: deploy only two vs-agent flavours

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,9 +31,6 @@ jobs:
           - image: vs-agent
             dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent
-          - image: vs-agent-chat
-            dockerfile: ./apps/vs-agent/Dockerfile
-            target: vs-agent-chat
           - image: vs-agent-mrtd
             dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent-mrtd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
           - dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent
           - dockerfile: ./apps/vs-agent/Dockerfile
-            target: vs-agent-chat
-          - dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent-mrtd
           - dockerfile: ./examples/chatbot/Dockerfile
           - dockerfile: ./examples/verifier/Dockerfile

--- a/apps/vs-agent/Dockerfile
+++ b/apps/vs-agent/Dockerfile
@@ -2,43 +2,8 @@ FROM node:22.19-slim AS base
 ENV COREPACK_INTEGRITY_KEYS=0
 RUN corepack enable && corepack prepare pnpm@9.15.3 --activate
 
-# Build: base agent (no plugins)
-FROM base AS build-base
-WORKDIR /www
-ENV RUN_MODE="docker"
-
-COPY patches ./patches
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
-COPY packages/model/package.json packages/model/package.json
-COPY packages/agent-sdk/package.json packages/agent-sdk/package.json
-COPY packages/vt-flow/package.json packages/vt-flow/package.json
-COPY apps/vs-agent/package.json apps/vs-agent/package.json
-COPY apps/vs-agent-ui/package.json apps/vs-agent-ui/package.json
-
-# plugin-chat and plugin-mrtd package.json intentionally absent — pnpm skips optional workspace:* deps
-RUN pnpm install --no-frozen-lockfile
-
-COPY packages/model/src packages/model/src
-COPY packages/model/tsconfig.json packages/model/tsconfig.build.json packages/model/
-COPY packages/agent-sdk/src packages/agent-sdk/src
-COPY packages/agent-sdk/tsconfig.json packages/agent-sdk/tsconfig.build.json packages/agent-sdk/
-COPY packages/vt-flow/src packages/vt-flow/src
-COPY packages/vt-flow/tsconfig.json packages/vt-flow/tsconfig.build.json packages/vt-flow/
-COPY apps/vs-agent/src apps/vs-agent/src
-COPY apps/vs-agent/discovery.json apps/vs-agent/tsconfig.json apps/vs-agent/tsconfig.build.json apps/vs-agent/nest-cli.json apps/vs-agent/
-COPY apps/vs-agent-ui/src apps/vs-agent-ui/src
-COPY apps/vs-agent-ui/index.html apps/vs-agent-ui/vite.config.js apps/vs-agent-ui/tsconfig.json apps/vs-agent-ui/
-
-RUN pnpm --filter @verana-labs/vs-agent-model build && \
-    pnpm --filter @verana-labs/credo-ts-didcomm-vt-flow build && \
-    pnpm --filter @verana-labs/vs-agent-sdk build && \
-    pnpm --filter @verana-labs/vs-agent-ui build && \
-    pnpm --filter @verana-labs/vs-agent build
-
-RUN --mount=type=bind,source=scripts/docker-cleanup.sh,target=/tmp/cleanup.sh sh /tmp/cleanup.sh
-
-# Build: chat plugin
-FROM base AS build-chat
+# Build: vs-agent (messaging + chat)
+FROM base AS build-vs-agent
 WORKDIR /www
 ENV RUN_MODE="docker"
 
@@ -118,49 +83,27 @@ RUN pnpm --filter @verana-labs/vs-agent-model build && \
 
 RUN --mount=type=bind,source=scripts/docker-cleanup.sh,target=/tmp/cleanup.sh sh /tmp/cleanup.sh
 
-# Final: vs-agent (no plugins)
+# Final: vs-agent (messaging + chat)
 FROM node:22.19-slim AS vs-agent
-WORKDIR /www
-ENV RUN_MODE="docker"
-ENV VS_AGENT_PLUGINS=messaging
-
-COPY --from=build-base /www/node_modules ./node_modules
-COPY --from=build-base /www/packages/model/package.json ./packages/model/package.json
-COPY --from=build-base /www/packages/model/build ./packages/model/build
-COPY --from=build-base /www/packages/agent-sdk/package.json ./packages/agent-sdk/package.json
-COPY --from=build-base /www/packages/agent-sdk/build ./packages/agent-sdk/build
-COPY --from=build-base /www/packages/agent-sdk/node_modules ./packages/agent-sdk/node_modules
-COPY --from=build-base /www/packages/vt-flow/package.json ./packages/vt-flow/package.json
-COPY --from=build-base /www/packages/vt-flow/build ./packages/vt-flow/build
-COPY --from=build-base /www/apps/vs-agent/node_modules ./apps/vs-agent/node_modules
-COPY apps/vs-agent/package.json ./apps/vs-agent/package.json
-COPY --from=build-base /www/apps/vs-agent/build ./apps/vs-agent/build
-COPY --from=build-base /www/apps/vs-agent/public ./apps/vs-agent/public
-COPY apps/vs-agent/discovery.json ./apps/vs-agent/discovery.json
-
-CMD ["node", "apps/vs-agent/build/src/main"]
-
-# Final: vs-agent-chat (chat plugin)
-FROM node:22.19-slim AS vs-agent-chat
 WORKDIR /www
 ENV RUN_MODE="docker"
 ENV VS_AGENT_PLUGINS=messaging,chat
 
-COPY --from=build-chat /www/node_modules ./node_modules
-COPY --from=build-chat /www/packages/model/package.json ./packages/model/package.json
-COPY --from=build-chat /www/packages/model/build ./packages/model/build
-COPY --from=build-chat /www/packages/agent-sdk/package.json ./packages/agent-sdk/package.json
-COPY --from=build-chat /www/packages/agent-sdk/build ./packages/agent-sdk/build
-COPY --from=build-chat /www/packages/agent-sdk/node_modules ./packages/agent-sdk/node_modules
-COPY --from=build-chat /www/packages/plugin-chat/package.json ./packages/plugin-chat/package.json
-COPY --from=build-chat /www/packages/plugin-chat/build ./packages/plugin-chat/build
-COPY --from=build-chat /www/packages/plugin-chat/node_modules ./packages/plugin-chat/node_modules
-COPY --from=build-chat /www/packages/vt-flow/package.json ./packages/vt-flow/package.json
-COPY --from=build-chat /www/packages/vt-flow/build ./packages/vt-flow/build
-COPY --from=build-chat /www/apps/vs-agent/node_modules ./apps/vs-agent/node_modules
+COPY --from=build-vs-agent /www/node_modules ./node_modules
+COPY --from=build-vs-agent /www/packages/model/package.json ./packages/model/package.json
+COPY --from=build-vs-agent /www/packages/model/build ./packages/model/build
+COPY --from=build-vs-agent /www/packages/agent-sdk/package.json ./packages/agent-sdk/package.json
+COPY --from=build-vs-agent /www/packages/agent-sdk/build ./packages/agent-sdk/build
+COPY --from=build-vs-agent /www/packages/agent-sdk/node_modules ./packages/agent-sdk/node_modules
+COPY --from=build-vs-agent /www/packages/plugin-chat/package.json ./packages/plugin-chat/package.json
+COPY --from=build-vs-agent /www/packages/plugin-chat/build ./packages/plugin-chat/build
+COPY --from=build-vs-agent /www/packages/plugin-chat/node_modules ./packages/plugin-chat/node_modules
+COPY --from=build-vs-agent /www/packages/vt-flow/package.json ./packages/vt-flow/package.json
+COPY --from=build-vs-agent /www/packages/vt-flow/build ./packages/vt-flow/build
+COPY --from=build-vs-agent /www/apps/vs-agent/node_modules ./apps/vs-agent/node_modules
 COPY apps/vs-agent/package.json ./apps/vs-agent/package.json
-COPY --from=build-chat /www/apps/vs-agent/build ./apps/vs-agent/build
-COPY --from=build-chat /www/apps/vs-agent/public ./apps/vs-agent/public
+COPY --from=build-vs-agent /www/apps/vs-agent/build ./apps/vs-agent/build
+COPY --from=build-vs-agent /www/apps/vs-agent/public ./apps/vs-agent/public
 COPY apps/vs-agent/discovery.json ./apps/vs-agent/discovery.json
 
 CMD ["node", "apps/vs-agent/build/src/main"]

--- a/apps/vs-agent/README.md
+++ b/apps/vs-agent/README.md
@@ -273,12 +273,11 @@ This means that VS-A is up and running!
 
 First
 
-The Dockerfile produces three images of different sizes depending on which plugins are included. Choose the one that matches your needs:
+The Dockerfile produces two images of different sizes depending on which plugins are included. Choose the one that matches your needs:
 
 | Target | Image | Plugins included |
 |--------|-------|-----------------|
-| `vs-agent` | `2060io/vs-agent` | messaging only |
-| `vs-agent-chat` | `2060io/vs-agent-chat` | messaging + chat |
+| `vs-agent` | `2060io/vs-agent` | messaging + chat |
 | `vs-agent-mrtd` | `2060io/vs-agent-mrtd` | messaging + chat + mrtd |
 
 #### Building locally
@@ -287,8 +286,7 @@ The build context must be the **monorepo root**, not the `apps/vs-agent` directo
 
 ```bash
 # From the repository root
-docker build --target vs-agent     -t vs-agent     -f apps/vs-agent/Dockerfile .
-docker build --target vs-agent-chat -t vs-agent-chat -f apps/vs-agent/Dockerfile .
+docker build --target vs-agent      -t vs-agent      -f apps/vs-agent/Dockerfile .
 docker build --target vs-agent-mrtd -t vs-agent-mrtd -f apps/vs-agent/Dockerfile .
 ```
 
@@ -299,7 +297,7 @@ docker run \
   -e AGENT_PUBLIC_DID=did:web:myagent.example.com \
   -e EVENTS_BASE_URL=http://my-backend:5000 \
   -p 3000:3000 -p 3001:3001 \
-  vs-agent-chat
+  vs-agent
 ```
 
 #### Using Docker Compose
@@ -312,7 +310,7 @@ services:
     build:
       context: ../..                          # repository root
       dockerfile: ./apps/vs-agent/Dockerfile
-      target: vs-agent-chat                   # choose the appropriate target
+      target: vs-agent                        # choose the appropriate target (vs-agent or vs-agent-mrtd)
     environment:
       - AGENT_PUBLIC_DID=did:web:myagent.example.com
       - EVENTS_BASE_URL=http://my-backend:5000


### PR DESCRIPTION
Creating now only 2 different vs-agent container flavors, to maximize backwards compatibility (99% of existing services) and not make things more complicate than needed for now:

- veranalabs/vs-agent: keep all functionality except eMRTD
- veranalabs/vs-agent-mrtd: add eMRTD (used in passport demos)