### PR TITLE
feat(chart): configurable redis image, maxmemory and extra args

### DIFF
--- a/charts/vs-agent/README.md
+++ b/charts/vs-agent/README.md
@@ -92,7 +92,7 @@ extraEnv:
 | `redis.host`               | Redis host                                       | `your-redis-host`               |
 | `redis.password`           | Redis password                                   | `myRedisPass123`                |
 | `redis.image`              | Redis container image (pin a tag for reproducible deploys) | `redis:alpine`       |
-| `redis.maxmemory`          | Redis `maxmemory` (e.g. `80mb`); empty = unlimited | `""`                          |
+| `redis.maxmemory`          | Redis `maxmemory`; set `""` for unlimited        | `80mb`                          |
 | `redis.maxmemoryPolicy`    | Redis `maxmemory-policy` (applied only when `maxmemory` is set) | `noeviction`     |
 | `redis.extraArgs`          | Additional `redis-server` flags (list)          | `[]`                            |
 

--- a/charts/vs-agent/README.md
+++ b/charts/vs-agent/README.md
@@ -91,6 +91,10 @@ extraEnv:
 | `redis.enabled`            | Enable Redis                                     | `false`                         |
 | `redis.host`               | Redis host                                       | `your-redis-host`               |
 | `redis.password`           | Redis password                                   | `myRedisPass123`                |
+| `redis.image`              | Redis container image (pin a tag for reproducible deploys) | `redis:alpine`       |
+| `redis.maxmemory`          | Redis `maxmemory` (e.g. `80mb`); empty = unlimited | `""`                          |
+| `redis.maxmemoryPolicy`    | Redis `maxmemory-policy` (applied only when `maxmemory` is set) | `noeviction`     |
+| `redis.extraArgs`          | Additional `redis-server` flags (list)          | `[]`                            |
 
 ### Persistent Storage
 

--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -240,8 +240,20 @@ spec:
         {{- end }}
         {{- if .Values.redis.enabled }}
          -  name: {{ .Values.name }}-redis-container
-            image: redis:alpine
+            image: {{ .Values.redis.image | default "redis:alpine" }}
             imagePullPolicy: Always
+            {{- if or .Values.redis.maxmemory .Values.redis.extraArgs }}
+            args:
+            {{- if .Values.redis.maxmemory }}
+            -  --maxmemory
+            -  {{ .Values.redis.maxmemory | quote }}
+            -  --maxmemory-policy
+            -  {{ .Values.redis.maxmemoryPolicy | default "noeviction" }}
+            {{- end }}
+            {{- range .Values.redis.extraArgs }}
+            -  {{ . | quote }}
+            {{- end }}
+            {{- end }}
             ports:
             -  containerPort: 6379
             resources:

--- a/charts/vs-agent/values.yaml
+++ b/charts/vs-agent/values.yaml
@@ -42,8 +42,12 @@ database:
       cpu: 500m
       memory: 512Mi
 
-redis: 
+redis:
   enabled: false
+  image: "redis:alpine"      # Redis container image (pin a tag for reproducible deploys)
+  maxmemory: ""              # e.g. "80mb"; empty = unlimited (Redis default)
+  maxmemoryPolicy: noeviction # applied only when maxmemory is set
+  extraArgs: []              # additional redis-server flags, e.g. ["--save", ""]
   resources:
     requests:
       cpu: 25m

--- a/charts/vs-agent/values.yaml
+++ b/charts/vs-agent/values.yaml
@@ -45,7 +45,7 @@ database:
 redis:
   enabled: false
   image: "redis:alpine"      # Redis container image (pin a tag for reproducible deploys)
-  maxmemory: ""              # e.g. "80mb"; empty = unlimited (Redis default)
+  maxmemory: "80mb"          # Redis memory cap; set "" for unlimited (Redis default)
   maxmemoryPolicy: noeviction # applied only when maxmemory is set
   extraArgs: []              # additional redis-server flags, e.g. ["--save", ""]
   resources:


### PR DESCRIPTION
## Overview

The vs-agent-chart's Redis container was fully hardcoded: floating `redis:alpine` image, no way to pass any Redis configuration. In particular `maxmemory` could not be set, so Redis defaults to unlimited memory and only discovers the pod's cgroup limit when the kernel OOM-kills it.

New values:

| Value | Description | Default |
|---|---|---|
| `redis.image` | Redis container image (pinnable) | `redis:alpine` |
| `redis.maxmemory` | Redis `maxmemory`; set `""` for unlimited | **`80mb`** |
| `redis.maxmemoryPolicy` | `maxmemory-policy`, applied only when `maxmemory` is set | `noeviction` |
| `redis.extraArgs` | Additional `redis-server` flags (list) | `[]` |

**Behavior change**: the default is now a **capped Redis (80mb, noeviction)** instead of unlimited — sized for the queue-only role this Redis plays in vs-agent (Bull `message` queue), and a fit for the current deployments (avatar/passport run well under 80 MB). Deployments needing more can raise `redis.maxmemory` or set `""` to restore the old unlimited behavior. `noeviction` is deliberate: a job queue must fail loudly rather than have keys silently evicted.

Rendered args go through the official redis image entrypoint (flag-style args are prepended with `redis-server` automatically):

```yaml
args: ["--maxmemory", "80mb", "--maxmemory-policy", "noeviction"]
```

Verified with helm 3.16: `helm lint` clean; default values render the 80mb cap; `maxmemory: ""` renders no args (identical to previous behavior); `redis.enabled=false` unaffected.

Related: #515 fixes the Redis PVC mount path so persistence actually works.

Context: the AI agents' Redis OOM crash-loops in hologram-verifiable-services (see 2060-io/hologram-verifiable-services#63) — this chart change is the prerequisite for capping the standalone vs-agent Redis instances (avatar/passport) at a small `maxmemory`.