### PR TITLE
fix(chart): mount redis data volume at /data so persistence works

### DIFF
--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -248,7 +248,7 @@ spec:
 {{- toYaml .Values.redis.resources | nindent 14 }}
             volumeMounts:
             - name: {{ .Values.name }}-redis-main
-              mountPath: /home/data
+              mountPath: /data
         {{- end }}
 
          volumes:


### PR DESCRIPTION
## Overview

The vs-agent-chart mounts the Redis PVC at `/home/data`, but the official redis image's working directory is `/data` — RDB snapshots are written to `/data/dump.rdb` on the container's ephemeral filesystem. Net effect: the PVC (`<name>-redis-main`) has been provisioned and bound but **never used**; Redis data is lost on every container restart.

Fix: mount the volume at `/data`, where Redis actually writes.

## Rollout notes

- StatefulSet pod-template changes are allowed; the pod restarts on upgrade.
- There is no data to migrate — nothing was ever persisted to the PVC, so the newly-mounted volume simply starts receiving snapshots from now on.
- Independent of #514 (configurable image/maxmemory); both touch the same template but different lines.