### PR TITLE
feat(chart): let a deployment enable the openid4vc plugin

### DIFF
--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -154,6 +154,17 @@ spec:
     requests:
       storage: 1Gi
 {{- end }}
+{{- if .Values.openid4vc.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+   name: {{ .Values.name }}-openid4vc
+   namespace: {{ .Release.Namespace }}
+data:
+   openid4vc.json: |
+{{ .Values.openid4vc.config | toPrettyJson | indent 5 }}
+{{- end }}
 ---
 # StatefulSet description for the VS Agent
 # This StatefulSet manages the deployment of the VS Agent service
@@ -205,6 +216,12 @@ spec:
             - name: ADMIN_API_CORPORATION_ALLOWED_ACCOUNTS
               value: {{ .Values.adminApiCorporationAllowedAccounts | quote }}
             {{- end }}
+            {{- if .Values.openid4vc.enabled }}
+            - name: VS_AGENT_PLUGINS
+              value: {{ .Values.openid4vc.plugins | quote }}
+            - name: OID4VC_CONFIG_FILE
+              value: {{ printf "%s/openid4vc.json" .Values.openid4vc.mountPath | quote }}
+            {{- end }}
 {{- with .Values.extraEnv }}
 {{ toYaml . | nindent 12 }}
 {{- end }}
@@ -254,6 +271,11 @@ spec:
             volumeMounts:
             - name: {{ .Values.name }}-vsa-pv
               mountPath: /root/.afj
+            {{- if .Values.openid4vc.enabled }}
+            - name: {{ .Values.name }}-openid4vc
+              mountPath: {{ .Values.openid4vc.mountPath | quote }}
+              readOnly: true
+            {{- end }}
         {{- if .Values.database.enabled }}
          -  name: postgres
             image: postgres:15.2
@@ -305,6 +327,11 @@ spec:
          - name: {{ .Values.name }}-vsa-pv
            persistentVolumeClaim:
              claimName: {{ .Values.name }}-vsa-pv
+        {{- if .Values.openid4vc.enabled }}
+         - name: {{ .Values.name }}-openid4vc
+           configMap:
+             name: {{ .Values.name }}-openid4vc
+        {{- end }}
         {{- if .Values.database.enabled }}
          - name: {{ .Values.name }}-pg-pv-main
            persistentVolumeClaim:

--- a/charts/vs-agent/values.yaml
+++ b/charts/vs-agent/values.yaml
@@ -77,6 +77,16 @@ ingress:
 # Extra environment variables (extensible)
 extraEnv: []
 
+# OpenID4VC plugin. The agent reads its plugin options from a JSON file, so there is
+# no way to enable OpenID4VC through environment variables alone: turning this on
+# renders `config` into a ConfigMap, mounts it, and points OID4VC_CONFIG_FILE at it.
+# Left disabled the agent serves DIDComm only.
+openid4vc:
+  enabled: false
+  plugins: "messaging,openid4vc"
+  mountPath: "/run/config"
+  config: {}
+
 # Persistent volume configuration for app
 storage:
   size: 1Gi


### PR DESCRIPTION
The chart can set environment variables but cannot deliver files, and the agent reads its OpenID4VC options from a JSON file pointed at by `OID4VC_CONFIG_FILE`. So there is currently no way to turn the plugin on in a deployed agent at all, whatever image it runs.

That is not hypothetical. The playground demo cast already runs the oidc4vc image and its deployment template says the DemoCredential is served over both rails, DIDComm and OpenID4VC. It is not: the plugin is never enabled, so those services expose DIDComm only and every OpenID4VC wallet gets a 404 on `/.well-known/openid-credential-issuer`. Five of the six personal wallets on the playground cannot reach a demo service because of it.

This adds an `openid4vc` block. When enabled it renders `config` into a ConfigMap, mounts it read-only, and sets `VS_AGENT_PLUGINS` and `OID4VC_CONFIG_FILE`. One switch rather than three, since enabling the file without the plugin name is a silent no-op. Default is off.

Verified with `helm template` both ways: disabled renders zero openid4vc references and parses clean, enabled renders a ConfigMap whose embedded JSON round-trips through a YAML load, the two env vars, and the mount and volume wired to it.