### PR TITLE
feat(oid4vc): publish the openid4vc image, chart config support, certificates route

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,6 +124,9 @@ jobs:
           - image: vs-agent
             dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent
+          - image: vs-agent-openid4vc
+            dockerfile: ./apps/vs-agent/Dockerfile
+            target: vs-agent-openid4vc
           - image: vs-agent-mrtd
             dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent-mrtd

--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -205,6 +205,14 @@ spec:
             - name: ADMIN_API_CORPORATION_ALLOWED_ACCOUNTS
               value: {{ .Values.adminApiCorporationAllowedAccounts | quote }}
             {{- end }}
+            {{- if .Values.oid4vc.config }}
+            - name: OID4VC_CONFIG_FILE
+              value: "/run/config/oid4vc/openid4vc.json"
+            {{- end }}
+            {{- if .Values.oid4vc.plugins }}
+            - name: VS_AGENT_PLUGINS
+              value: {{ .Values.oid4vc.plugins | quote }}
+            {{- end }}
 {{- with .Values.extraEnv }}
 {{ toYaml . | nindent 12 }}
 {{- end }}
@@ -254,6 +262,11 @@ spec:
             volumeMounts:
             - name: {{ .Values.name }}-vsa-pv
               mountPath: /root/.afj
+            {{- if .Values.oid4vc.config }}
+            - name: {{ .Values.name }}-oid4vc-config
+              mountPath: /run/config/oid4vc
+              readOnly: true
+            {{- end }}
         {{- if .Values.database.enabled }}
          -  name: postgres
             image: postgres:15.2
@@ -305,6 +318,11 @@ spec:
          - name: {{ .Values.name }}-vsa-pv
            persistentVolumeClaim:
              claimName: {{ .Values.name }}-vsa-pv
+        {{- if .Values.oid4vc.config }}
+         - name: {{ .Values.name }}-oid4vc-config
+           configMap:
+             name: {{ .Values.name }}-oid4vc-config
+        {{- end }}
         {{- if .Values.database.enabled }}
          - name: {{ .Values.name }}-pg-pv-main
            persistentVolumeClaim:

--- a/charts/vs-agent/templates/oid4vc-configmap.yaml
+++ b/charts/vs-agent/templates/oid4vc-configmap.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.oid4vc.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}-oid4vc-config
+  namespace: {{ .Release.Namespace }}
+data:
+  openid4vc.json: |-
+{{ tpl .Values.oid4vc.config . | indent 4 }}
+{{- end }}

--- a/charts/vs-agent/values.yaml
+++ b/charts/vs-agent/values.yaml
@@ -48,6 +48,14 @@ database:
       cpu: 500m
       memory: 512Mi
 
+# OpenID4VC plugin configuration (requires the vs-agent-openid4vc image).
+# When config is non-empty it is rendered into a ConfigMap, mounted read-only,
+# and OID4VC_CONFIG_FILE points at it. The JSON must NOT contain
+# publicApiBaseUrl (injected by VS Agent from PUBLIC_API_BASE_URL).
+oid4vc:
+  config: "" # openid4vc.json content as a string
+  plugins: "" # optional VS_AGENT_PLUGINS override, e.g. "messaging,chat,openid4vc" (the openid4vc image already defaults to it)
+
 redis:
   enabled: false
   image: "redis:alpine"      # Redis container image (pin a tag for reproducible deploys)

--- a/packages/plugin-openid4vc/README.md
+++ b/packages/plugin-openid4vc/README.md
@@ -162,12 +162,13 @@ The control and protocol surfaces are intentionally separate.
 | Internal admin | `GET /v1/oid4vc/offers/:id`                                                               | Plugin controller. Returns safe issuance state only.                                                                                                                         |
 | Internal admin | `POST /v1/oid4vc/verifier/requests`                                                       | Plugin controller. Creates a request from `policyId`.                                                                                                                        |
 | Internal admin | `GET /v1/oid4vc/verifier/sessions/:id`                                                    | Plugin controller. Returns protocol state and the bounded trust result.                                                                                                      |
+| Internal admin | `GET /v1/oid4vc/certificates`                                                             | Plugin controller. Returns the configured roles' public signing certificates: leaf fingerprint (`SHA256:` pin format) and base64 chain. Never returns private keys.          |
 | Public         | `GET /oid4vc/vct/:configurationId`                                                        | Plugin route. Returns configured SD-JWT VC type metadata.                                                                                                                    |
 | Public         | dynamic paths below `/.well-known/*`, `/oid4vci/:issuerId/*`, and `/oid4vp/:verifierId/*` | Pinned Credo router. Serves issuer/OAuth metadata, returned offer and request URIs, and wallet token, credential, authorization-request, and authorization-response traffic. |
 
 Credo derives protocol paths from its current route configuration and record IDs. Wallets should follow the URIs returned by the admin API and metadata rather than constructing undocumented paths.
 
-The four admin routes have the default `INTERNAL` access mode. They are absent from the public listener and unavailable through the corporation bearer-authenticated listener. The internal listener is network-trusted by default, so production deployments must isolate it or place it behind an authenticated reverse proxy. Credential offers are bearer capabilities and must not be logged or exposed through a public convenience endpoint.
+The admin routes have the default `INTERNAL` access mode. They are absent from the public listener and unavailable through the corporation bearer-authenticated listener. The internal listener is network-trusted by default, so production deployments must isolate it or place it behind an authenticated reverse proxy. Credential offers are bearer capabilities and must not be logged or exposed through a public convenience endpoint.
 
 ## Trust decision
 

--- a/packages/plugin-openid4vc/src/nestjs/CertificatesController.ts
+++ b/packages/plugin-openid4vc/src/nestjs/CertificatesController.ts
@@ -1,0 +1,33 @@
+import type { SigningCertificateInfo } from '../services/CertificateService'
+
+import { Controller, Get, Inject, Optional } from '@nestjs/common'
+
+import { IssuerService } from '../services/IssuerService'
+import { VerifierService } from '../services/VerifierService'
+
+// Internal admin route exposing the plugin's PUBLIC signing-certificate
+// material: the leaf fingerprint (the exact pin format verifiers configure
+// in trust.developmentCertificateFingerprints) and the base64 chain. Lets
+// operators wire verifier pins without reaching into agent storage. Never
+// returns private keys.
+@Controller({ path: 'oid4vc/certificates', version: '1' })
+export class CertificatesController {
+  public constructor(
+    @Optional() @Inject(IssuerService) private readonly issuerService?: IssuerService,
+    @Optional() @Inject(VerifierService) private readonly verifierService?: VerifierService,
+  ) {}
+
+  @Get()
+  public async list(): Promise<{ certificates: SigningCertificateInfo[] }> {
+    const certificates: SigningCertificateInfo[] = []
+    if (this.issuerService) {
+      await this.issuerService.ensureInitialized()
+      certificates.push(this.issuerService.getCertificateInfo())
+    }
+    if (this.verifierService) {
+      await this.verifierService.ensureInitialized()
+      certificates.push(this.verifierService.getCertificateInfo())
+    }
+    return { certificates }
+  }
+}

--- a/packages/plugin-openid4vc/src/nestjs/OpenId4VcPlugin.ts
+++ b/packages/plugin-openid4vc/src/nestjs/OpenId4VcPlugin.ts
@@ -7,6 +7,7 @@ import { setupOpenId4Vc } from '../sdk/setupOpenId4Vc'
 import { IssuerService, type OpenId4VcIssuerAgent } from '../services/IssuerService'
 import { VerifierService, type OpenId4VcVerifierAgent } from '../services/VerifierService'
 
+import { CertificatesController } from './CertificatesController'
 import { IssuerController } from './IssuerController'
 import { VerifierController } from './VerifierController'
 
@@ -41,6 +42,7 @@ export function OpenId4VcPlugin(options: OpenId4VcPluginOptions): VsAgentNestPlu
     controllers: [
       ...(options.issuer ? [IssuerController] : []),
       ...(options.verifier ? [VerifierController] : []),
+      CertificatesController,
     ],
     providers: [
       ...(options.issuer

--- a/packages/plugin-openid4vc/src/services/CertificateService.ts
+++ b/packages/plugin-openid4vc/src/services/CertificateService.ts
@@ -25,6 +25,28 @@ interface DevelopmentCertificateRecord {
   keyId: string
 }
 
+export interface SigningCertificateInfo {
+  role: SigningRole
+  development: boolean
+  /** SHA256:<hex> of the leaf, the pin format of trust.developmentCertificateFingerprints. */
+  fingerprint: string
+  /** Base64 DER, leaf first. */
+  certificateChain: string[]
+}
+
+export function signingCertificateInfo(
+  role: SigningRole,
+  handle: SigningCertificateHandle,
+): SigningCertificateInfo {
+  const digest = createHash('sha256').update(handle.certificate.rawCertificate).digest('hex')
+  return {
+    role,
+    development: handle.development,
+    fingerprint: `SHA256:${digest}`,
+    certificateChain: handle.chain.map(certificate => certificate.toString('base64')),
+  }
+}
+
 export interface SigningCertificateHandle {
   certificate: X509Certificate
   chain: X509Certificate[]

--- a/packages/plugin-openid4vc/src/services/IssuerService.ts
+++ b/packages/plugin-openid4vc/src/services/IssuerService.ts
@@ -16,7 +16,9 @@ import {
   didFromValidatedCertificate,
   loadSigningCertificate,
   publishDevelopmentSigningKey,
+  signingCertificateInfo,
   type SigningCertificateHandle,
+  type SigningCertificateInfo,
 } from './CertificateService'
 
 type IssuerApi = Pick<
@@ -113,6 +115,13 @@ export class IssuerService {
       createdAt: session.createdAt,
       ...(session.expiresAt ? { expiresAt: session.expiresAt } : {}),
     }
+  }
+
+  /** Public signing-certificate material, for operators wiring verifier
+   *  fingerprint pins (never includes private keys). */
+  public getCertificateInfo(): SigningCertificateInfo {
+    this.assertInitialized()
+    return signingCertificateInfo('issuer', this.signingCertificateHandle())
   }
 
   public getVctMetadata(configurationId: string): SdJwtVcTypeMetadata | undefined {

--- a/packages/plugin-openid4vc/src/services/VerifierService.ts
+++ b/packages/plugin-openid4vc/src/services/VerifierService.ts
@@ -18,7 +18,9 @@ import {
   didFromValidatedCertificate,
   loadSigningCertificate,
   publishDevelopmentSigningKey,
+  signingCertificateInfo,
   type SigningCertificateHandle,
+  type SigningCertificateInfo,
 } from './CertificateService'
 
 type VerifierApi = Pick<
@@ -123,6 +125,12 @@ export class VerifierService {
       authorizationRequest,
       verificationSessionId: verificationSession.id,
     }
+  }
+
+  /** Public signing-certificate material, for operators wiring verifier
+   *  fingerprint pins (never includes private keys). */
+  public getCertificateInfo(): SigningCertificateInfo {
+    return signingCertificateInfo('verifier', this.signingCertificateHandle())
   }
 
   public async getResult(sessionId: string): Promise<OpenId4VcVerificationResult> {

--- a/packages/plugin-openid4vc/tests/OpenId4VcPlugin.test.ts
+++ b/packages/plugin-openid4vc/tests/OpenId4VcPlugin.test.ts
@@ -133,14 +133,20 @@ describe('OpenId4VcPlugin', () => {
     delete issuerOptions.trust
     const issuer = OpenId4VcPlugin(issuerOptions)
 
-    expect(issuer.controllers?.map(controller => controller.name)).toEqual(['IssuerController'])
+    expect(issuer.controllers?.map(controller => controller.name)).toEqual([
+      'IssuerController',
+      'CertificatesController',
+    ])
     expect((issuer.providers as FactoryProvider[]).map(item => item.provide.name)).toEqual(['IssuerService'])
 
     const verifierOptions = validOptions()
     delete verifierOptions.issuer
     const verifier = OpenId4VcPlugin(verifierOptions)
 
-    expect(verifier.controllers?.map(controller => controller.name)).toEqual(['VerifierController'])
+    expect(verifier.controllers?.map(controller => controller.name)).toEqual([
+      'VerifierController',
+      'CertificatesController',
+    ])
     expect((verifier.providers as FactoryProvider[]).map(item => item.provide.name)).toEqual([
       'VerifierService',
     ])


### PR DESCRIPTION
Groundwork for running the OpenID4VC rail on the Playground demo cast (and any shared deployment). **Targets the `oidc4vc` branch** — no merge to main; the next manual publish from this branch ships everything.

## 1. Publish the `vs-agent-openid4vc` image
`cd.yml`'s docker matrix gains the `vs-agent-openid4vc` target (CI already built it; it was never published). A manual branch publish (e.g. `v1.12.0-oidc4vc.3`) now produces `veranalabs/vs-agent-openid4vc:<version>` alongside the plain image — with the usual manual-release isolation (exact tag only, no floating pointers).

## 2. Chart: deliver `openid4vc.json`
New `oid4vc` values block: when `oid4vc.config` is set, the chart renders it into a ConfigMap, mounts it read-only at `/run/config/oid4vc/openid4vc.json`, and sets `OID4VC_CONFIG_FILE`. Optional `oid4vc.plugins` overrides `VS_AGENT_PLUGINS` (the openid4vc image already defaults to `messaging,chat,openid4vc`). Verified with `helm lint` + `helm template`.

## 3. `GET /v1/oid4vc/certificates` (internal admin)
Returns each configured role's **public** signing-certificate material: the leaf fingerprint in the exact `SHA256:` pin format of `trust.developmentCertificateFingerprints`, `development` flag, and the base64 chain. This closes the dev-signing bootstrap gap: operators (or cast provisioning) read an issuer's fingerprint from the issuer itself and wire it into verifier configs — no reaching into agent storage, no synthetic issuance. Never returns private keys. Registered for whichever roles are configured (`@Optional` injection), documented in the README route table.

Tests: plugin suite 203/203 (one expectation updated for the new controller); `vt-flow` → `agent-sdk` → `plugin-openid4vc` all compile.

## After merge
Dispatch the CD workflow on `oidc4vc` with version `v1.12.0-oidc4vc.3`; then the playground demo cast switches to `image.repository: veranalabs/vs-agent-openid4vc` + chart `v1.12.0-oidc4vc.3` and gets per-service `openid4vc.json` (companion playground PR to follow).