### PR TITLE
fix(openid4vc): dev-mode robustness - self-heal stale signing records, retry failed initialization

### DIFF
--- a/packages/plugin-openid4vc/src/services/CertificateService.ts
+++ b/packages/plugin-openid4vc/src/services/CertificateService.ts
@@ -239,23 +239,36 @@ async function loadDevelopmentSigningCertificate(
   const recordId = developmentRecordId(agent.did, hostname, development.commonName, role)
   const existing = await agent.genericRecords.findById(recordId)
   if (existing) {
-    const stored = parseDevelopmentRecord(existing.content)
-    const certificate = X509Certificate.fromEncodedCertificate(stored.certificate)
-    assertCertificateChainUsable([certificate])
-    assertDevelopmentCertificateIdentity(certificate, agent.did, hostname)
+    try {
+      const stored = parseDevelopmentRecord(existing.content)
+      const certificate = X509Certificate.fromEncodedCertificate(stored.certificate)
+      assertCertificateChainUsable([certificate])
+      assertDevelopmentCertificateIdentity(certificate, agent.did, hostname)
 
-    const storedPublicJwk = await agent.kms.getPublicKey({ keyId: stored.keyId })
-    if (
-      !equalPublicJwk(
-        canonicalP256PublicJwk(storedPublicJwk),
-        canonicalP256PublicJwk(certificate.publicJwk.toJson()),
-      )
-    ) {
-      throw new Error('stored development KMS key does not match its certificate')
+      const storedPublicJwk = await agent.kms.getPublicKey({ keyId: stored.keyId })
+      if (
+        !equalPublicJwk(
+          canonicalP256PublicJwk(storedPublicJwk),
+          canonicalP256PublicJwk(certificate.publicJwk.toJson()),
+        )
+      ) {
+        throw new Error('stored development KMS key does not match its certificate')
+      }
+
+      certificate.keyId = stored.keyId
+      return { certificate, chain: [certificate], keyId: stored.keyId, development: true }
+    } catch (error) {
+      // A KMS backend fault is not stale state: recreating on it would rotate a
+      // healthy certificate and break fingerprints pinned by verifiers.
+      if (error instanceof Kms.KeyManagementError && !(error instanceof Kms.KeyManagementKeyNotFoundError)) {
+        throw error
+      }
+      // Development certificates are disposable. An expired certificate, an
+      // identity that no longer matches the DID or host, or a key id no KMS
+      // backend holds (records written by older builds) must not wedge the
+      // agent: drop the record and mint a fresh certificate below.
+      await agent.genericRecords.deleteById(recordId)
     }
-
-    certificate.keyId = stored.keyId
-    return { certificate, chain: [certificate], keyId: stored.keyId, development: true }
   }
 
   const { keyId, publicJwk } = await agent.kms.createKey({ type: { kty: 'EC', crv: 'P-256' } })

--- a/packages/plugin-openid4vc/src/services/IssuerService.ts
+++ b/packages/plugin-openid4vc/src/services/IssuerService.ts
@@ -74,7 +74,13 @@ export class IssuerService {
   ) {}
 
   public ensureInitialized(): Promise<void> {
-    this.initialization ??= this.initialize()
+    // A rejected initialization must not be cached: a transient boot-time
+    // failure (KMS or storage not ready yet) would otherwise wedge the
+    // process until restart. Reset so the next call retries.
+    this.initialization ??= this.initialize().catch(error => {
+      this.initialization = undefined
+      throw error
+    })
     return this.initialization
   }
 

--- a/packages/plugin-openid4vc/src/services/VerifierService.ts
+++ b/packages/plugin-openid4vc/src/services/VerifierService.ts
@@ -84,7 +84,13 @@ export class VerifierService {
   }
 
   public ensureInitialized(): Promise<void> {
-    this.initialization ??= this.initialize()
+    // A rejected initialization must not be cached: a transient boot-time
+    // failure (KMS or storage not ready yet) would otherwise wedge the
+    // process until restart. Reset so the next call retries.
+    this.initialization ??= this.initialize().catch(error => {
+      this.initialization = undefined
+      throw error
+    })
     return this.initialization
   }
 

--- a/packages/plugin-openid4vc/tests/CertificateService.test.ts
+++ b/packages/plugin-openid4vc/tests/CertificateService.test.ts
@@ -232,16 +232,57 @@ describe('CertificateService', () => {
     expect(new Set(savedRecordIds)).toHaveLength(2)
   })
 
-  it('rejects an expired persisted development certificate', async () => {
-    const agent = createAgent({ persistedDevelopmentCertificate: fixtures.expiredAttacker })
+  it('replaces an expired persisted development certificate with a fresh one', async () => {
+    const agent = createAgent({
+      developmentCertificate: fixtures.attacker,
+      persistedDevelopmentCertificate: fixtures.expiredAttacker,
+    })
     agent.did = 'did:web:attacker.example'
     agent.publicApiBaseUrl = 'https://attacker.example/agent'
+
+    const handle = await loadSigningCertificate(agent, {
+      development: { enabled: true, commonName: 'Development Agent' },
+    })
+
+    expect(handle.certificate.equal(fixtures.attacker)).toBe(true)
+    expect(agent.genericRecords.deleteById).toHaveBeenCalledTimes(1)
+    expect(agent.kms.createKey).toHaveBeenCalledTimes(1)
+    expect(agent.genericRecords.save).toHaveBeenCalledTimes(1)
+  })
+
+  it('replaces a persisted development record whose key no KMS backend holds', async () => {
+    const agent = createAgent({
+      developmentCertificate: fixtures.attacker,
+      persistedDevelopmentCertificate: fixtures.attacker,
+    })
+    agent.did = 'did:web:attacker.example'
+    agent.publicApiBaseUrl = 'https://attacker.example/agent'
+    agent.keys.clear()
+
+    const handle = await loadSigningCertificate(agent, {
+      development: { enabled: true, commonName: 'Development Agent' },
+    })
+
+    expect(handle.development).toBe(true)
+    expect(agent.genericRecords.deleteById).toHaveBeenCalledTimes(1)
+    expect(agent.kms.createKey).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not replace a persisted development certificate on a KMS backend fault', async () => {
+    const agent = createAgent({
+      developmentCertificate: fixtures.attacker,
+      persistedDevelopmentCertificate: fixtures.attacker,
+    })
+    agent.did = 'did:web:attacker.example'
+    agent.publicApiBaseUrl = 'https://attacker.example/agent'
+    agent.kms.getPublicKey.mockRejectedValueOnce(new Kms.KeyManagementError('backend unavailable'))
 
     await expect(
       loadSigningCertificate(agent, {
         development: { enabled: true, commonName: 'Development Agent' },
       }),
-    ).rejects.toThrow('expired')
+    ).rejects.toThrow('backend unavailable')
+    expect(agent.genericRecords.deleteById).not.toHaveBeenCalled()
     expect(agent.kms.createKey).not.toHaveBeenCalled()
   })
 })
@@ -303,21 +344,27 @@ function createAgent({
       return { keyId, publicJwk: publicKey }
     }),
   }
+  const deletedIds = new Set<string>()
   const genericRecords = {
-    findById: vi.fn(async (id: string) =>
-      persistedDevelopmentCertificate
-        ? {
-            id,
-            content: {
-              certificate: persistedDevelopmentCertificate.toString('base64'),
-              keyId: 'development-key',
-            },
-          }
-        : (records.get(id) ?? null),
-    ),
+    findById: vi.fn(async (id: string) => {
+      if (persistedDevelopmentCertificate && !deletedIds.has(id) && !records.has(id)) {
+        return {
+          id,
+          content: {
+            certificate: persistedDevelopmentCertificate.toString('base64'),
+            keyId: 'development-key',
+          },
+        }
+      }
+      return records.get(id) ?? null
+    }),
     save: vi.fn(async (record: { id: string; content: Record<string, unknown> }) => {
       records.set(record.id, record)
       return record
+    }),
+    deleteById: vi.fn(async (id: string) => {
+      deletedIds.add(id)
+      records.delete(id)
     }),
   }
   const x509 = {

--- a/packages/plugin-openid4vc/tests/IssuerService.test.ts
+++ b/packages/plugin-openid4vc/tests/IssuerService.test.ts
@@ -217,6 +217,18 @@ describe('IssuerService', () => {
     expect(api.createIssuer).not.toHaveBeenCalled()
   })
 
+  it('retries initialization after a failed first attempt', async () => {
+    const api = issuerApi()
+    api.getIssuerByIssuerId.mockResolvedValue({ issuerId: 'issuer' })
+    const service = new IssuerService(agent(api) as never, options())
+    loadSigningCertificate.mockRejectedValueOnce(new Error('storage not ready'))
+
+    await expect(service.ensureInitialized()).rejects.toThrow('storage not ready')
+    await service.ensureInitialized()
+
+    expect(loadSigningCertificate).toHaveBeenCalledTimes(2)
+  })
+
   it('requires an agent DID before loading signing material', async () => {
     const agentWithoutDid = { ...agent(), did: undefined }
     const service = new IssuerService(agentWithoutDid as never, options())

--- a/packages/plugin-openid4vc/tests/VerifierService.test.ts
+++ b/packages/plugin-openid4vc/tests/VerifierService.test.ts
@@ -226,6 +226,18 @@ describe('VerifierService', () => {
     expect(api.createVerifier).not.toHaveBeenCalled()
   })
 
+  it('retries initialization after a failed first attempt', async () => {
+    const api = verifierApi()
+    api.getVerifierByVerifierId.mockResolvedValue({ verifierId: 'verifier' })
+    const service = new VerifierService(agent(api) as never, options())
+    loadSigningCertificate.mockRejectedValueOnce(new Error('storage not ready'))
+
+    await expect(service.ensureInitialized()).rejects.toThrow('storage not ready')
+    await service.ensureInitialized()
+
+    expect(loadSigningCertificate).toHaveBeenCalledTimes(2)
+  })
+
   it('requires an agent DID before loading verifier signing material', async () => {
     const agentWithoutDid = { ...agent(), did: undefined }
     const service = new VerifierService(agentWithoutDid as never, options())


### PR DESCRIPTION
## What we saw on the playground cast

After the `.5` rollout, the two verifiers with pre-existing wallets (`demo-verifier-accredited`/`-unaccredited`) could not mint OID4VP requests: every attempt failed with

```
KeyManagementKeyNotFoundError: Key with key id 'k3Vhbc7WS2ZNt83ZsLiPHs3Zdt2ZBhRNMjSoxVPdyjiW' not found in backend 'askar'
```

where the "missing" key id is the **legacy base58 id** (base58 of the leaf P-256 compressed public key) of the service's own development certificate - Askar stores keys by uuid. The two fresh services (`demo-issuer-untrusted`/`demo-verifier-untrusted`, first boot ever) were unaffected. **A pod restart healed both broken verifiers**: the failure is a boot-time condition on wallets with prior state, and once it happens the process never recovers on its own because `ensureInitialized()` caches the rejected promise - one verifier kept replaying its original boot error on every request for an hour, which is what made a transient condition look like a permanently corrupt record.

## Fixes

**1. Failed initialization retries (`IssuerService`/`VerifierService`).** A rejected `initialization` promise is no longer cached: reset on rejection so the next request re-runs `initialize()`. One unlucky boot no longer wedges the process until restart.

**2. Stale development signing records self-heal (`CertificateService`).** Development certificates are disposable. If the persisted record is genuinely unusable - expired certificate, identity drift after a DID/host change, malformed record, cert/key mismatch, or a key id no KMS backend holds (records written by older builds) - delete the record and fall through to the existing creation path (which republishes the dev key to the DID document with the correct kid). KMS backend *faults* (`KeyManagementError` other than key-not-found) still propagate: recreating on a transient outage would rotate a healthy certificate and silently break the fingerprints verifiers pinned at deploy time.

## Tests

- failed first init → second `ensureInitialized()` retries and succeeds (issuer + verifier)
- expired persisted dev record → replaced (was: rejected; wedging was the old asserted behavior)
- persisted dev record with a key no backend holds → replaced
- KMS backend fault → propagated, record untouched, no rotation

207/207 plugin tests pass, `tsc` clean.