### PR TITLE
fix(chart): roll the pod when only the oid4vc config changes

### DIFF
--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -208,6 +208,10 @@ spec:
             {{- if .Values.oid4vc.config }}
             - name: OID4VC_CONFIG_FILE
               value: "/run/config/oid4vc/openid4vc.json"
+            # The agent reads the config file once at boot; baking its hash
+            # into the pod template makes a config-only change roll the pod.
+            - name: OID4VC_CONFIG_CHECKSUM
+              value: {{ sha256sum .Values.oid4vc.config | quote }}
             {{- end }}
             {{- if .Values.oid4vc.plugins }}
             - name: VS_AGENT_PLUGINS


### PR DESCRIPTION
Found on the playground cast: the agent reads `OID4VC_CONFIG_FILE` once at boot, but a config-only `helm upgrade` changes just the ConfigMap - the pod template stays identical, so the StatefulSet does not roll and the running agent keeps the old configuration until someone restarts the pod by hand (playground#60's claim-rules change silently did not take effect until a manual pod delete).

Standard checksum pattern, applied as an env var since the pod template has no annotations block: bake `sha256sum .Values.oid4vc.config` into the template as `OID4VC_CONFIG_CHECKSUM`, so any config change rolls the StatefulSet by itself.

Verified with `helm template` (checksum renders, changes with the config) and `helm lint`. The playground workflows carry an explicit `kubectl rollout restart` as a stopgap that works with the already-published `.5` chart (playground#62); once a chart with this fix is pinned, that restart becomes redundant and can be dropped.