### PR TITLE
feat(vs-agent-ui): service profile as default public page

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,6 +79,8 @@ jobs:
           fi
 
           if [ -z "$MANUAL_VERSION" ]; then
+            echo "::warning::No publish_version input received; nothing will be published. If you filled the field, note that switching the branch in the Run workflow form resets the inputs: select the branch first, then enter the version."
+            echo "Nothing published: the \`publish_version\` input was empty." >> "$GITHUB_STEP_SUMMARY"
             echo "publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -116,7 +116,9 @@ jobs:
 
   docker:
     needs: version
-    if: needs.version.outputs.publish == 'true'
+    # !cancelled() keeps the skipped resolve-version (dispatch runs) from propagating a skip
+    # through the version job down to here.
+    if: ${{ !cancelled() && needs.version.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -200,7 +202,9 @@ jobs:
 
   helm:
     needs: [version, docker]
-    if: needs.version.outputs.publish == 'true'
+    # The explicit docker result check is what a bare !cancelled() would throw away: without it
+    # this would publish charts pointing at images that were never built.
+    if: ${{ !cancelled() && needs.docker.result == 'success' && needs.version.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     env:
       RELEASE_TYPE: ${{ needs.version.outputs.release-type }}
@@ -256,7 +260,7 @@ jobs:
 
   npm-publish:
     needs: [version]
-    if: needs.version.outputs.publish == 'true'
+    if: ${{ !cancelled() && needs.version.outputs.publish == 'true' }}
     runs-on: ubuntu-latest
     env:
       RELEASE_TYPE: ${{ needs.version.outputs.release-type }}
@@ -311,7 +315,7 @@ jobs:
 
   discord-notify:
     needs: [version, docker, helm]
-    if: needs.version.outputs.publish == 'true' && needs.version.outputs.release-type == 'stable'
+    if: ${{ !cancelled() && needs.docker.result == 'success' && needs.helm.result == 'success' && needs.version.outputs.publish == 'true' && needs.version.outputs.release-type == 'stable' }}
     permissions:
       contents: read
     uses: 2060-io/organization/.github/workflows/discord-release-notify-call.yml@251db2251120e805474da6528dfafd9693379b6e # main

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -885,13 +885,6 @@ a.meta-chip:hover {
   font-weight: 700;
 }
 
-.profile-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 264px;
-  gap: 20px;
-  align-items: start;
-}
-
 .profile-main {
   display: flex;
   flex-direction: column;
@@ -1153,41 +1146,62 @@ a.meta-chip:hover {
   color: var(--color-danger);
 }
 
-/* Connect column */
-.connect-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-rule);
-  border-radius: 1rem;
-  padding: 20px;
-  text-align: center;
-  position: sticky;
-  top: 76px;
-  box-shadow: 0 10px 32px -24px rgb(0 0 0 / 0.55);
+/* Service endpoints */
+.ep-type {
+  flex-shrink: 0;
+  min-width: 104px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
 }
 
-[data-theme='light'] .connect-card {
-  box-shadow: 0 10px 28px -24px rgb(11 11 18 / 0.28);
+.ep-uri {
+  flex: 1;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-ink);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: 1px solid var(--color-rule);
+  border-radius: 6px;
+  padding: 4px 6px;
+  color: var(--color-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.icon-btn:hover {
+  background: var(--color-surface-2);
+  color: var(--color-ink);
+  border-color: var(--color-primary);
+}
+
+.icon-btn-active {
+  color: var(--color-primary-bright);
+  border-color: var(--color-primary);
+}
+
+.ep-qr {
+  padding: 14px 0 6px;
+  text-align: center;
+  border-top: 1px solid var(--color-rule);
 }
 
 .qr-tile-sm img {
   width: 180px;
   height: 180px;
-}
-
-.connect-did {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--color-muted);
-  word-break: break-all;
-  margin-top: 12px;
-}
-
-.connect-endpoints {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  color: var(--color-muted);
-  word-break: break-all;
-  margin-top: 8px;
 }
 
 /* ─── Utilities ──────────────────────────────────────────── */
@@ -1253,14 +1267,6 @@ a.meta-chip:hover {
 
   .cred-cards {
     align-items: stretch;
-  }
-
-  .profile-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .connect-card {
-    position: static;
   }
 
   .svc-hero {

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -272,6 +272,7 @@ body {
 .content {
   padding: 28px;
   min-width: 0;
+  flex: 1;
 }
 
 /* Welcome headline */
@@ -1243,6 +1244,103 @@ a.meta-chip:hover {
 .qr-tile-sm img {
   width: 180px;
   height: 180px;
+}
+
+/* ─── Footer ─────────────────────────────────────────────── */
+.footer {
+  border-top: 1px solid var(--color-rule);
+  background: var(--color-surface);
+  margin-top: 48px;
+}
+
+.footer-inner {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 40px 28px 24px;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr 1fr;
+  gap: 32px;
+}
+
+.footer-tagline {
+  color: var(--color-muted);
+  font-size: var(--text-base);
+  max-width: 34ch;
+  margin-top: 14px;
+}
+
+.footer-socials {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.footer-social-link {
+  color: var(--color-muted);
+  transition: color 0.15s ease;
+  display: inline-flex;
+}
+
+.footer-social-link:hover {
+  color: var(--color-ink);
+}
+
+.footer-col-title {
+  margin-bottom: 12px;
+}
+
+.footer-links {
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.footer-links a {
+  color: var(--color-muted);
+  font-size: var(--text-base);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.footer-links a:hover {
+  color: var(--color-ink);
+}
+
+.footer-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  border-top: 1px solid var(--color-rule);
+  margin-top: 32px;
+  padding-top: 18px;
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+}
+
+.footer-build {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.footer-legal a {
+  color: var(--color-muted);
+  text-decoration: none;
+}
+
+.footer-legal a:hover {
+  color: var(--color-ink);
+}
+
+@media (max-width: 640px) {
+  .footer-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* ─── Utilities ──────────────────────────────────────────── */

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -1121,12 +1121,15 @@ a.meta-chip:hover {
 
 .acc-perm-type {
   flex-shrink: 0;
-  width: 104px;
+  width: 150px;
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .acc-state {
@@ -1149,12 +1152,15 @@ a.meta-chip:hover {
 /* Service endpoints */
 .ep-type {
   flex-shrink: 0;
-  min-width: 104px;
+  width: 150px;
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--color-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ep-uri {

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -213,6 +213,41 @@ body {
   color: var(--color-muted);
 }
 
+/* Network chip (header) */
+.net-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--color-rule);
+  border-radius: 999px;
+  background: var(--color-surface);
+  padding: 4px 12px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  flex-shrink: 0;
+}
+
+.net-chip .led {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--color-rule);
+}
+
+.net-chip .led-ok {
+  background: var(--color-success);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--color-success) 80%, transparent);
+}
+
+.net-chip .led-down {
+  background: var(--color-danger);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--color-danger) 80%, transparent);
+}
+
 /* Theme toggle */
 .theme-toggle {
   display: inline-flex;

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -268,6 +268,20 @@ body {
   border-color: var(--color-primary);
 }
 
+/* ─── Notice band ────────────────────────────────────────── */
+.notice-band {
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-primary) 18%, var(--color-bg)),
+    color-mix(in srgb, var(--color-accent) 16%, var(--color-bg))
+  );
+  border-bottom: 1px solid var(--color-rule);
+  color: var(--color-ink);
+  font-size: var(--text-sm);
+  text-align: center;
+  padding: 7px 16px;
+}
+
 /* ─── Content ────────────────────────────────────────────── */
 .content {
   padding: 28px;

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -1084,31 +1084,33 @@ a.meta-chip:hover {
 }
 
 /* Accreditations */
-.acc-group + .acc-group {
-  margin-top: 12px;
-  border-top: 1px solid var(--color-rule);
-  padding-top: 10px;
-}
-
-.acc-title {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+.acc-schema {
+  flex: 1;
+  min-width: 0;
   font-size: var(--text-sm);
   font-weight: var(--fw-semibold);
-  margin-bottom: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
-.acc-anchor {
-  flex: 1;
+.acc-anchor-inline {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   font-weight: var(--fw-normal);
   color: var(--color-muted);
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  margin-left: 10px;
+}
+
+.acc-entry-link {
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-muted);
+  flex-shrink: 0;
+}
+
+.acc-entry-link:hover {
+  color: var(--color-accent);
 }
 
 .acc-none {

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -1083,6 +1083,67 @@ a.meta-chip:hover {
   border-color: var(--color-primary);
 }
 
+/* Accreditations */
+.acc-group + .acc-group {
+  margin-top: 12px;
+  border-top: 1px solid var(--color-rule);
+  padding-top: 10px;
+}
+
+.acc-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: var(--text-sm);
+  font-weight: var(--fw-semibold);
+  margin-bottom: 2px;
+}
+
+.acc-anchor {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--fw-normal);
+  color: var(--color-muted);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.acc-none {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  padding: 4px 0;
+}
+
+.acc-perm-type {
+  flex-shrink: 0;
+  width: 104px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.acc-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  font-weight: var(--fw-semibold);
+}
+
+.acc-state-ok {
+  color: var(--color-success-ink);
+}
+
+.acc-state-warn {
+  color: var(--color-danger);
+}
+
 /* Connect column */
 .connect-card {
   background: var(--color-surface);

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -1000,6 +1000,13 @@ a.meta-chip:hover {
   color: var(--color-muted);
 }
 
+.pot-pill-net {
+  background: color-mix(in srgb, var(--color-primary) 14%, transparent);
+  color: var(--color-primary-bright);
+  font-family: var(--font-mono);
+  font-weight: 500;
+}
+
 .pot-section {
   padding: 14px 20px;
 }

--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -800,6 +800,326 @@ body {
   line-height: var(--lh-normal);
 }
 
+/* ─── Service profile (ECS-Service credential presented) ── */
+.profile {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.svc-hero {
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.svc-logo {
+  width: 64px;
+  height: 64px;
+  border-radius: 14px;
+  object-fit: cover;
+  background: var(--color-surface-2);
+  flex-shrink: 0;
+}
+
+.svc-logo-fallback {
+  display: grid;
+  place-items: center;
+  background: linear-gradient(140deg, var(--color-accent), var(--color-primary));
+  color: #ffffff;
+  font-family: var(--font-display);
+  font-size: 26px;
+  font-weight: var(--fw-semibold);
+}
+
+.svc-title-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.svc-name {
+  font-size: 28px;
+  line-height: var(--lh-tight);
+}
+
+.svc-desc {
+  color: var(--color-muted);
+  font-size: var(--text-base);
+  max-width: 62ch;
+  margin-top: 8px;
+}
+
+.svc-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 16px 0 26px;
+}
+
+.meta-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--color-rule);
+  border-radius: 8px;
+  background: var(--color-surface);
+  padding: 5px 12px;
+  font-size: var(--text-sm);
+  color: var(--color-ink);
+  text-decoration: none;
+  line-height: var(--lh-normal);
+  transition: border-color 0.15s ease;
+}
+
+a.meta-chip:hover {
+  border-color: var(--color-primary);
+}
+
+.meta-chip svg {
+  color: var(--color-muted);
+}
+
+.meta-chip-age b {
+  color: var(--color-primary-bright);
+  font-weight: 700;
+}
+
+.profile-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 264px;
+  gap: 20px;
+  align-items: start;
+}
+
+.profile-main {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  min-width: 0;
+}
+
+/* Operated by */
+.op-card {
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
+  padding: 18px 20px;
+  box-shadow: 0 10px 32px -24px rgb(0 0 0 / 0.55);
+}
+
+[data-theme='light'] .op-card {
+  box-shadow: 0 10px 28px -24px rgb(11 11 18 / 0.28);
+}
+
+.op-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.op-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  object-fit: cover;
+  background: var(--color-surface-2);
+  flex-shrink: 0;
+}
+
+.op-logo-fallback {
+  display: grid;
+  place-items: center;
+  color: var(--color-primary-bright);
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: var(--fw-semibold);
+}
+
+.op-name {
+  font-weight: var(--fw-semibold);
+  font-size: var(--text-md);
+}
+
+.op-sub {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  margin-top: 2px;
+  word-break: break-all;
+}
+
+.op-details {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  margin-top: 10px;
+}
+
+/* Proof of Trust */
+.pot-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
+  overflow: hidden;
+  box-shadow: 0 10px 32px -24px rgb(0 0 0 / 0.55);
+}
+
+[data-theme='light'] .pot-card {
+  box-shadow: 0 10px 28px -24px rgb(11 11 18 / 0.28);
+}
+
+.pot-band {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  padding: 10px 20px;
+  border-bottom: 1px solid var(--color-rule);
+  background: var(--color-bg);
+}
+
+.pot-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border-radius: 999px;
+  padding: 3px 10px;
+  font-size: var(--text-xs);
+  font-weight: var(--fw-semibold);
+  line-height: var(--lh-normal);
+}
+
+.pot-pill-trust {
+  background: color-mix(in srgb, var(--color-success) 16%, transparent);
+  color: var(--color-success-ink);
+}
+
+.pot-pill-neutral {
+  background: var(--color-surface-2);
+  color: var(--color-muted);
+}
+
+.pot-section {
+  padding: 14px 20px;
+}
+
+.pot-section + .pot-section {
+  border-top: 1px solid var(--color-rule);
+}
+
+.pot-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--color-muted);
+  margin-bottom: 8px;
+}
+
+.pot-did {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-ink);
+  word-break: break-all;
+}
+
+.pot-note {
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  margin-top: 6px;
+}
+
+.pot-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 7px 0;
+  font-size: var(--text-sm);
+}
+
+.pot-row + .pot-row {
+  border-top: 1px solid var(--color-rule);
+}
+
+.pot-row-name {
+  font-weight: var(--fw-semibold);
+  flex-shrink: 0;
+}
+
+.pot-row-issuer {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pot-row-btn {
+  background: none;
+  border: 1px solid var(--color-rule);
+  border-radius: 6px;
+  padding: 1px 6px;
+  font-size: var(--text-xs);
+  font-family: var(--font-mono);
+  color: var(--color-muted);
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: 1.6;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.pot-row-btn:hover {
+  background: var(--color-surface-2);
+  color: var(--color-ink);
+  border-color: var(--color-primary);
+}
+
+/* Connect column */
+.connect-card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-rule);
+  border-radius: 1rem;
+  padding: 20px;
+  text-align: center;
+  position: sticky;
+  top: 76px;
+  box-shadow: 0 10px 32px -24px rgb(0 0 0 / 0.55);
+}
+
+[data-theme='light'] .connect-card {
+  box-shadow: 0 10px 28px -24px rgb(11 11 18 / 0.28);
+}
+
+.qr-tile-sm img {
+  width: 180px;
+  height: 180px;
+}
+
+.connect-did {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  word-break: break-all;
+  margin-top: 12px;
+}
+
+.connect-endpoints {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  word-break: break-all;
+  margin-top: 8px;
+}
+
 /* ─── Utilities ──────────────────────────────────────────── */
 .loading {
   color: var(--color-muted);
@@ -863,6 +1183,27 @@ body {
 
   .cred-cards {
     align-items: stretch;
+  }
+
+  .profile-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .connect-card {
+    position: static;
+  }
+
+  .svc-hero {
+    gap: 14px;
+  }
+
+  .svc-logo {
+    width: 52px;
+    height: 52px;
+  }
+
+  .svc-name {
+    font-size: 24px;
   }
 
   .cred-card {

--- a/apps/vs-agent-ui/src/App.jsx
+++ b/apps/vs-agent-ui/src/App.jsx
@@ -1,5 +1,6 @@
 import Header from './components/Header'
 import Dashboard from './components/Dashboard'
+import Footer from './components/Footer'
 export default function App() {
   return (
     <div className="layout">
@@ -7,6 +8,7 @@ export default function App() {
       <div className="content">
         <Dashboard />
       </div>
+      <Footer />
     </div>
   )
 }

--- a/apps/vs-agent-ui/src/App.jsx
+++ b/apps/vs-agent-ui/src/App.jsx
@@ -1,13 +1,17 @@
 import Header from './components/Header'
 import Dashboard from './components/Dashboard'
 import Footer from './components/Footer'
+import { getAgentConfig } from './api'
 export default function App() {
+  const { showPlaceholderMessage } = getAgentConfig()
   return (
     <div className="layout">
       <Header />
-      <div className="notice-band">
-        This page is the placeholder of your Verana business wallet.
-      </div>
+      {showPlaceholderMessage !== false && (
+        <div className="notice-band">
+          This page is the placeholder of your Verana business wallet.
+        </div>
+      )}
       <div className="content">
         <Dashboard />
       </div>

--- a/apps/vs-agent-ui/src/App.jsx
+++ b/apps/vs-agent-ui/src/App.jsx
@@ -5,6 +5,9 @@ export default function App() {
   return (
     <div className="layout">
       <Header />
+      <div className="notice-band">
+        This page is the placeholder of your Verana business wallet.
+      </div>
       <div className="content">
         <Dashboard />
       </div>

--- a/apps/vs-agent-ui/src/api.js
+++ b/apps/vs-agent-ui/src/api.js
@@ -5,7 +5,7 @@ export async function getDidDocument() {
 }
 
 export function getAgentConfig() {
-  return window.__VS_AGENT__ ?? { label: 'VS Agent', welcomeMessage: null }
+  return window.__VS_AGENT__ ?? { label: 'VS Agent', welcomeMessage: null, network: null }
 }
 
 export const qrUrl = '/qr'

--- a/apps/vs-agent-ui/src/api.js
+++ b/apps/vs-agent-ui/src/api.js
@@ -5,7 +5,7 @@ export async function getDidDocument() {
 }
 
 export function getAgentConfig() {
-  return window.__VS_AGENT__ ?? { label: 'VS Agent', welcomeMessage: null, network: null }
+  return window.__VS_AGENT__ ?? { label: 'VS Agent', welcomeMessage: null, network: null, showPlaceholderMessage: true }
 }
 
 export const qrUrl = '/qr'

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -184,7 +184,7 @@ function credentialDisplayName(vc, type) {
   return types[types.length - 1] ?? 'Credential'
 }
 
-/* ─── Accreditations (on-ledger permission chain, queried from the VPR index) ── */
+/* ─── Accreditations (on-ledger entries of this DID, from the VPR index) ── */
 
 const SCHEMA_REF_RE = /^(vpr:[a-z0-9-]+:[^:/]+)(?::cs:(\d+)|\/cs\/v1\/js\/(\d+))$/
 
@@ -192,6 +192,16 @@ const PERM_TYPE_LABELS = {
   ECOSYSTEM: 'Ecosystem',
   ISSUER_GRANTOR: 'Issuer grantor',
   ISSUER: 'Issuer',
+  VERIFIER_GRANTOR: 'Verifier grantor',
+  VERIFIER: 'Verifier',
+  HOLDER: 'Holder',
+}
+
+// Verana app base URL per VPR network, for schema / participant deep links.
+const APP_URLS = {
+  'vna-mainnet-1': 'https://app.verana.network',
+  'vna-testnet-1': 'https://app.testnet.verana.network',
+  'vna-devnet-1': 'https://app.devnet.verana.network',
 }
 
 async function fetchJson(url) {
@@ -203,53 +213,71 @@ async function fetchJson(url) {
   }
 }
 
-function permIsActive(perm) {
-  return (perm.perm_state ? perm.perm_state === 'ACTIVE' : true) && !perm.revoked && !perm.slashed
+function entryState(entry) {
+  return entry.perm_state ?? entry.pp_state ?? entry.state ?? 'ACTIVE'
 }
 
-/**
- * Resolves the on-ledger accreditation chain for a credential: the issuer
- * permission for the credential schema, its validator permissions up to the
- * ECOSYSTEM permission, and the trust registry anchoring the schema. Returns
- * null when the schema is not anchored in a known VPR network.
- */
-async function resolveAccreditation(vc) {
-  const schemaUrl = vc?.credentialSchema?.id
-  const issuer = credentialIssuer(vc)
-  if (!schemaUrl || !issuer) return null
+function entryIsActive(entry) {
+  return entryState(entry) === 'ACTIVE' && !entry.revoked && !entry.slashed
+}
 
+/** Extracts the VPR network a credential schema is anchored in, or null. */
+async function credentialNetwork(vc) {
+  const schemaUrl = vc?.credentialSchema?.id
+  if (!schemaUrl) return null
   const w3c = await fetchJson(schemaUrl)
   const ref = w3c?.credentialSubject?.jsonSchema?.$ref
   const match = typeof ref === 'string' ? ref.match(SCHEMA_REF_RE) : null
   if (!match) return null
   const prefix = match[1]
-  const schemaId = match[2] ?? match[3]
   const base = mapToEcosystem(prefix)
   if (base === prefix) return null
-  const network = prefix.split(':').pop()
+  return { prefix, base, network: prefix.split(':').pop() }
+}
 
-  const permList = await fetchJson(
-    `${base}/perm/v1/list?did=${encodeURIComponent(issuer)}&type=ISSUER&schema_id=${schemaId}&response_max_size=1`,
-  )
-  const issuerPerm = permList?.permissions?.[0]
-  if (!issuerPerm) return { network, schemaId, registry: null, chain: [] }
+/**
+ * Lists the on-ledger accreditations of a DID: its permission entries
+ * (VPR v3, /perm/v1) or participant entries (VPR v4, /pp/v1) for credential
+ * schemas, with the schema title resolved for display.
+ */
+async function resolveDidAccreditations(did, networks) {
+  const entries = []
+  for (const { base, network } of networks) {
+    const q = `did=${encodeURIComponent(did)}&response_max_size=64`
+    const v3 = await fetchJson(`${base}/perm/v1/list?${q}`)
+    const raw = v3?.permissions ?? (await fetchJson(`${base}/pp/v1/list?${q}`))?.participants ?? []
 
-  const chain = [issuerPerm]
-  let nextId = issuerPerm.validator_perm_id
-  for (let hops = 0; nextId && hops < 6; hops++) {
-    const perm = (await fetchJson(`${base}/perm/v1/get/${nextId}`))?.permission
-    if (!perm) break
-    chain.push(perm)
-    nextId = perm.validator_perm_id
+    const schemaCache = new Map()
+    for (const entry of raw) {
+      const schemaId = entry.schema_id
+      let schemaTitle = null
+      if (schemaId != null) {
+        if (!schemaCache.has(schemaId)) {
+          const cs = await fetchJson(`${base}/cs/v1/get/${schemaId}`)
+          try {
+            schemaTitle = JSON.parse((cs?.schema ?? cs)?.json_schema)?.title ?? null
+          } catch {
+            schemaTitle = null
+          }
+          schemaCache.set(schemaId, schemaTitle)
+        }
+        schemaTitle = schemaCache.get(schemaId)
+      }
+      const appUrl = APP_URLS[network]
+      entries.push({
+        type: entry.type ?? entry.role,
+        state: entryState(entry),
+        active: entryIsActive(entry),
+        schemaId,
+        schemaTitle,
+        network,
+        schemaUrl: appUrl && schemaId != null ? `${appUrl}/tr/cs/${schemaId}` : null,
+        entryUrl: appUrl && schemaId != null ? `${appUrl}/participants/${schemaId}` : null,
+        raw: entry,
+      })
+    }
   }
-  chain.reverse() // ecosystem first, issuer last
-
-  const cs = await fetchJson(`${base}/cs/v1/get/${schemaId}`)
-  const trId = cs?.schema?.tr_id ?? cs?.tr_id
-  const tr = trId ? await fetchJson(`${base}/tr/v1/get/${trId}`) : null
-  const registry = tr?.trust_registry ?? null
-
-  return { network, schemaId, registry, chain }
+  return entries
 }
 
 /** ISO 3166-1 alpha-2 country code as an emoji flag (e.g. "CH"). */
@@ -325,6 +353,16 @@ function BuildingIcon(props) {
       <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
       <path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" />
       <path d="M10 6h4M10 10h4M10 14h4M10 18h4" />
+    </Icon>
+  )
+}
+
+function ExternalLinkIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
     </Icon>
   )
 }
@@ -435,52 +473,50 @@ function ControllerCard({ item, onSelect }) {
   )
 }
 
-function AccreditationGroup({ label, acc, onSelect }) {
-  const anchor = [`cs/${acc.schemaId}`, acc.registry?.id != null ? `registry ${acc.registry.id}` : null, acc.network]
-    .filter(Boolean)
-    .join(' · ')
+function AccreditationRow({ entry, onSelect }) {
+  const anchor = [`cs/${entry.schemaId}`, entry.network].filter(Boolean).join(' · ')
+  const title = entry.schemaTitle ?? (entry.schemaId != null ? `Schema ${entry.schemaId}` : 'Unknown schema')
 
   return (
-    <div className="acc-group">
-      <div className="acc-title">
-        <span>{label}</span>
-        <span className="acc-anchor">{anchor}</span>
-        <button className="pot-row-btn" onClick={() => onSelect(acc)} title="View details">{'{ }'}</button>
-      </div>
-      {acc.chain.length === 0 ? (
-        <p className="acc-none">No active issuer permission found in the trust registry.</p>
+    <div className="pot-row">
+      <span className="acc-perm-type">{PERM_TYPE_LABELS[entry.type] ?? entry.type}</span>
+      <span className="acc-schema">
+        {entry.schemaUrl ? (
+          <a className="subtle-link" href={entry.schemaUrl} target="_blank" rel="noopener noreferrer" title="View credential schema in the Verana app">
+            {title}
+          </a>
+        ) : (
+          title
+        )}
+        <span className="acc-anchor-inline">{anchor}</span>
+      </span>
+      {entry.entryUrl && (
+        <a
+          className="acc-entry-link"
+          href={entry.entryUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="View participant entries in the Verana app"
+        >
+          <ExternalLinkIcon size={11} />
+        </a>
+      )}
+      <button className="pot-row-btn" onClick={() => onSelect(entry.raw)} title="View details">{'{ }'}</button>
+      {entry.active ? (
+        <span className="acc-state acc-state-ok" title="Entry active in the trust registry">
+          <CircleCheckIcon size={12} />
+          active
+        </span>
       ) : (
-        acc.chain.map(perm => (
-          <div className="pot-row" key={perm.id}>
-            <span className="acc-perm-type">{PERM_TYPE_LABELS[perm.type] ?? perm.type}</span>
-            <span className="pot-row-issuer">
-              {perm.type === 'ECOSYSTEM' && acc.registry?.aka
-                ? <><LinkOrText text={acc.registry.aka} />{' · '}<LinkOrText text={perm.did ?? ''} /></>
-                : <LinkOrText text={perm.did ?? ''} />}
-            </span>
-            {permIsActive(perm) ? (
-              <span className="acc-state acc-state-ok" title="Permission active in the trust registry">
-                <CircleCheckIcon size={12} />
-                active
-              </span>
-            ) : (
-              <span className="acc-state acc-state-warn">{String(perm.perm_state ?? 'inactive').toLowerCase()}</span>
-            )}
-          </div>
-        ))
+        <span className="acc-state acc-state-warn">{String(entry.state).toLowerCase()}</span>
       )}
     </div>
   )
 }
 
-function TrustCard({ webDid, cvpItems, jscItems, accMap, onSelect }) {
+function TrustCard({ webDid, cvpItems, jscItems, acc, onSelect }) {
   const rows = cvpItems
     .flatMap(item => item.credentials.map(vc => ({ item, vc })))
-    .sort((a, b) => potRowRank(a.item.type) - potRowRank(b.item.type))
-
-  const accEntries = cvpItems
-    .map((item, i) => ({ item, acc: accMap?.[i] }))
-    .filter(e => e.acc)
     .sort((a, b) => potRowRank(a.item.type) - potRowRank(b.item.type))
 
   return (
@@ -496,8 +532,8 @@ function TrustCard({ webDid, cvpItems, jscItems, accMap, onSelect }) {
       <div className="pot-section">
         {webDid && <div className="pot-did"><LinkOrText text={webDid} /></div>}
         <p className="pot-note">
-          {accEntries.length > 0
-            ? 'Credentials presented by this service. Issuer accreditations are read live from the trust registry; credential signatures are not verified from this page.'
+          {(acc?.length ?? 0) > 0
+            ? 'Credentials presented by this service. Accreditations are read live from the trust registry; credential signatures are not verified from this page.'
             : 'Credentials presented by this service. They have not been verified against a Verana resolver from this page.'}
         </p>
       </div>
@@ -518,7 +554,7 @@ function TrustCard({ webDid, cvpItems, jscItems, accMap, onSelect }) {
           ))}
         </div>
       )}
-      {accMap === null ? (
+      {acc === null ? (
         <div className="pot-section">
           <p className="pot-label">
             <ShieldIcon size={11} />
@@ -526,19 +562,14 @@ function TrustCard({ webDid, cvpItems, jscItems, accMap, onSelect }) {
           </p>
           <p className="acc-none">Resolving accreditations from the trust registry...</p>
         </div>
-      ) : accEntries.length > 0 ? (
+      ) : acc.length > 0 ? (
         <div className="pot-section">
           <p className="pot-label">
             <ShieldIcon size={11} />
             Accreditations
           </p>
-          {accEntries.map(({ item, acc }, i) => (
-            <AccreditationGroup
-              key={i}
-              label={ECS_LABELS[item.type] ?? credentialDisplayName(item.credentials[0], item.type)}
-              acc={acc}
-              onSelect={onSelect}
-            />
+          {acc.map((entry, i) => (
+            <AccreditationRow key={i} entry={entry} onSelect={onSelect} />
           ))}
         </div>
       ) : null}
@@ -581,7 +612,7 @@ function ConnectCard({ webDid, endpoints }) {
   )
 }
 
-function ServiceProfile({ serviceItem, cvpItems, jscItems, accMap, webDid, endpoints, onSelect }) {
+function ServiceProfile({ serviceItem, cvpItems, jscItems, acc, webDid, endpoints, onSelect }) {
   const subject = serviceItem.credentials[0]?.credentialSubject ?? {}
   const controllerItem =
     cvpItems.find(i => i.type === 'ecs-org' && i.credentials.length > 0) ??
@@ -597,7 +628,7 @@ function ServiceProfile({ serviceItem, cvpItems, jscItems, accMap, webDid, endpo
       <div className="profile-grid">
         <div className="profile-main">
           <ControllerCard item={controllerItem} onSelect={() => onSelect(controllerItem?.vp)} />
-          <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} accMap={accMap} onSelect={onSelect} />
+          <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} acc={acc} onSelect={onSelect} />
         </div>
         <ConnectCard webDid={webDid} endpoints={endpoints} />
       </div>
@@ -701,8 +732,8 @@ export default function Dashboard() {
   const [credsLoading, setCredsLoading] = useState(true)
   const [error, setError] = useState(null)
   const [selected, setSelected] = useState(null)
-  // null = still resolving, {} onward = resolved (possibly empty)
-  const [accMap, setAccMap] = useState(null)
+  // null = still resolving, array afterward (possibly empty)
+  const [acc, setAcc] = useState(null)
 
   useEffect(() => {
     getDidDocument()
@@ -721,25 +752,32 @@ export default function Dashboard() {
   }, [])
 
   useEffect(() => {
-    if (credsLoading) return
-    if (cvpItems.length === 0) {
-      setAccMap({})
+    if (credsLoading || !doc) return
+    const did = (doc.alsoKnownAs ?? []).find(d => d.startsWith('did:webvh:')) ?? doc.id
+    const ecsItems = cvpItems.filter(i => i.type !== 'other' && i.credentials.length > 0)
+    if (!did || ecsItems.length === 0) {
+      setAcc([])
       return
     }
     let alive = true
-    Promise.all(
-      cvpItems.map(async (item, i) => {
-        const vc = item.credentials[0]
-        if (!vc || item.type === 'other') return [i, null]
-        return [i, await resolveAccreditation(vc)]
-      }),
-    ).then(entries => {
-      if (alive) setAccMap(Object.fromEntries(entries.filter(([, acc]) => acc)))
-    })
+    Promise.all(ecsItems.map(i => credentialNetwork(i.credentials[0])))
+      .then(nets => {
+        const byPrefix = new Map()
+        for (const net of nets) {
+          if (net && !byPrefix.has(net.prefix)) byPrefix.set(net.prefix, net)
+        }
+        return resolveDidAccreditations(did, [...byPrefix.values()])
+      })
+      .then(entries => {
+        if (alive) setAcc(entries)
+      })
+      .catch(() => {
+        if (alive) setAcc([])
+      })
     return () => {
       alive = false
     }
-  }, [credsLoading, cvpItems])
+  }, [credsLoading, cvpItems, doc])
 
   if (error) return <p className="error-msg">{error}</p>
   if (!doc || credsLoading) return <p className="loading">Loading...</p>
@@ -760,7 +798,7 @@ export default function Dashboard() {
           serviceItem={serviceItem}
           cvpItems={cvpItems}
           jscItems={jscItems}
-          accMap={accMap}
+          acc={acc}
           webDid={webDid}
           endpoints={endpoints}
           onSelect={setSelected}

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -447,7 +447,6 @@ function ServiceHero({ subject }) {
         <div style={{ minWidth: 0 }}>
           <div className="svc-title-row">
             <h1 className="svc-name display">{subject.name ?? 'Unnamed service'}</h1>
-            {subject.type && <span className="chip">{subject.type}</span>}
           </div>
           {subject.description && <p className="svc-desc">{subject.description}</p>}
         </div>
@@ -762,6 +761,19 @@ function ServiceProfile({ serviceItem, cvpItems, jscItems, acc, network, webDid,
   useEffect(() => {
     if (typeof subject.name === 'string' && subject.name) document.title = subject.name
   }, [subject.name])
+
+  // Use the service logo from the ECS-Service credential as the favicon.
+  useEffect(() => {
+    if (typeof subject.logoUri !== 'string' || !subject.logoUri) return
+    let link = document.querySelector('link[rel="icon"]')
+    if (!link) {
+      link = document.createElement('link')
+      link.rel = 'icon'
+      document.head.appendChild(link)
+    }
+    link.removeAttribute('type')
+    link.href = subject.logoUri
+  }, [subject.logoUri])
 
   return (
     <div className="profile">

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { resolveVTCType, resolveJSCType } from '@verana-labs/vs-agent-model/ecs'
+import { resolveVTCType, resolveJSCType, mapToEcosystem } from '@verana-labs/vs-agent-model/ecs'
 import { getAgentConfig, getDidDocument, qrUrl } from '../api'
 
 function JsonModal({ data, onClose }) {
@@ -184,6 +184,74 @@ function credentialDisplayName(vc, type) {
   return types[types.length - 1] ?? 'Credential'
 }
 
+/* ─── Accreditations (on-ledger permission chain, queried from the VPR index) ── */
+
+const SCHEMA_REF_RE = /^(vpr:[a-z0-9-]+:[^:/]+)(?::cs:(\d+)|\/cs\/v1\/js\/(\d+))$/
+
+const PERM_TYPE_LABELS = {
+  ECOSYSTEM: 'Ecosystem',
+  ISSUER_GRANTOR: 'Issuer grantor',
+  ISSUER: 'Issuer',
+}
+
+async function fetchJson(url) {
+  try {
+    const r = await fetch(url)
+    return r.ok ? await r.json() : null
+  } catch {
+    return null
+  }
+}
+
+function permIsActive(perm) {
+  return (perm.perm_state ? perm.perm_state === 'ACTIVE' : true) && !perm.revoked && !perm.slashed
+}
+
+/**
+ * Resolves the on-ledger accreditation chain for a credential: the issuer
+ * permission for the credential schema, its validator permissions up to the
+ * ECOSYSTEM permission, and the trust registry anchoring the schema. Returns
+ * null when the schema is not anchored in a known VPR network.
+ */
+async function resolveAccreditation(vc) {
+  const schemaUrl = vc?.credentialSchema?.id
+  const issuer = credentialIssuer(vc)
+  if (!schemaUrl || !issuer) return null
+
+  const w3c = await fetchJson(schemaUrl)
+  const ref = w3c?.credentialSubject?.jsonSchema?.$ref
+  const match = typeof ref === 'string' ? ref.match(SCHEMA_REF_RE) : null
+  if (!match) return null
+  const prefix = match[1]
+  const schemaId = match[2] ?? match[3]
+  const base = mapToEcosystem(prefix)
+  if (base === prefix) return null
+  const network = prefix.split(':').pop()
+
+  const permList = await fetchJson(
+    `${base}/perm/v1/list?did=${encodeURIComponent(issuer)}&type=ISSUER&schema_id=${schemaId}&response_max_size=1`,
+  )
+  const issuerPerm = permList?.permissions?.[0]
+  if (!issuerPerm) return { network, schemaId, registry: null, chain: [] }
+
+  const chain = [issuerPerm]
+  let nextId = issuerPerm.validator_perm_id
+  for (let hops = 0; nextId && hops < 6; hops++) {
+    const perm = (await fetchJson(`${base}/perm/v1/get/${nextId}`))?.permission
+    if (!perm) break
+    chain.push(perm)
+    nextId = perm.validator_perm_id
+  }
+  chain.reverse() // ecosystem first, issuer last
+
+  const cs = await fetchJson(`${base}/cs/v1/get/${schemaId}`)
+  const trId = cs?.schema?.tr_id ?? cs?.tr_id
+  const tr = trId ? await fetchJson(`${base}/tr/v1/get/${trId}`) : null
+  const registry = tr?.trust_registry ?? null
+
+  return { network, schemaId, registry, chain }
+}
+
 /** ISO 3166-1 alpha-2 country code as an emoji flag (e.g. "CH"). */
 function countryFlag(code) {
   if (typeof code !== 'string' || !/^[A-Za-z]{2}$/.test(code)) return null
@@ -257,6 +325,15 @@ function BuildingIcon(props) {
       <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
       <path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" />
       <path d="M10 6h4M10 10h4M10 14h4M10 18h4" />
+    </Icon>
+  )
+}
+
+function CircleCheckIcon(props) {
+  return (
+    <Icon {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="m9 12 2 2 4-4" />
     </Icon>
   )
 }
@@ -358,9 +435,52 @@ function ControllerCard({ item, onSelect }) {
   )
 }
 
-function TrustCard({ webDid, cvpItems, jscItems, onSelect }) {
+function AccreditationGroup({ label, acc, onSelect }) {
+  const anchor = [`cs/${acc.schemaId}`, acc.registry?.id != null ? `registry ${acc.registry.id}` : null, acc.network]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <div className="acc-group">
+      <div className="acc-title">
+        <span>{label}</span>
+        <span className="acc-anchor">{anchor}</span>
+        <button className="pot-row-btn" onClick={() => onSelect(acc)} title="View details">{'{ }'}</button>
+      </div>
+      {acc.chain.length === 0 ? (
+        <p className="acc-none">No active issuer permission found in the trust registry.</p>
+      ) : (
+        acc.chain.map(perm => (
+          <div className="pot-row" key={perm.id}>
+            <span className="acc-perm-type">{PERM_TYPE_LABELS[perm.type] ?? perm.type}</span>
+            <span className="pot-row-issuer">
+              {perm.type === 'ECOSYSTEM' && acc.registry?.aka
+                ? <><LinkOrText text={acc.registry.aka} />{' · '}<LinkOrText text={perm.did ?? ''} /></>
+                : <LinkOrText text={perm.did ?? ''} />}
+            </span>
+            {permIsActive(perm) ? (
+              <span className="acc-state acc-state-ok" title="Permission active in the trust registry">
+                <CircleCheckIcon size={12} />
+                active
+              </span>
+            ) : (
+              <span className="acc-state acc-state-warn">{String(perm.perm_state ?? 'inactive').toLowerCase()}</span>
+            )}
+          </div>
+        ))
+      )}
+    </div>
+  )
+}
+
+function TrustCard({ webDid, cvpItems, jscItems, accMap, onSelect }) {
   const rows = cvpItems
     .flatMap(item => item.credentials.map(vc => ({ item, vc })))
+    .sort((a, b) => potRowRank(a.item.type) - potRowRank(b.item.type))
+
+  const accEntries = cvpItems
+    .map((item, i) => ({ item, acc: accMap?.[i] }))
+    .filter(e => e.acc)
     .sort((a, b) => potRowRank(a.item.type) - potRowRank(b.item.type))
 
   return (
@@ -376,7 +496,9 @@ function TrustCard({ webDid, cvpItems, jscItems, onSelect }) {
       <div className="pot-section">
         {webDid && <div className="pot-did"><LinkOrText text={webDid} /></div>}
         <p className="pot-note">
-          Credentials presented by this service. They have not been verified against a Verana resolver from this page.
+          {accEntries.length > 0
+            ? 'Credentials presented by this service. Issuer accreditations are read live from the trust registry; credential signatures are not verified from this page.'
+            : 'Credentials presented by this service. They have not been verified against a Verana resolver from this page.'}
         </p>
       </div>
       {rows.length > 0 && (
@@ -396,6 +518,30 @@ function TrustCard({ webDid, cvpItems, jscItems, onSelect }) {
           ))}
         </div>
       )}
+      {accMap === null ? (
+        <div className="pot-section">
+          <p className="pot-label">
+            <ShieldIcon size={11} />
+            Accreditations
+          </p>
+          <p className="acc-none">Resolving accreditations from the trust registry...</p>
+        </div>
+      ) : accEntries.length > 0 ? (
+        <div className="pot-section">
+          <p className="pot-label">
+            <ShieldIcon size={11} />
+            Accreditations
+          </p>
+          {accEntries.map(({ item, acc }, i) => (
+            <AccreditationGroup
+              key={i}
+              label={ECS_LABELS[item.type] ?? credentialDisplayName(item.credentials[0], item.type)}
+              acc={acc}
+              onSelect={onSelect}
+            />
+          ))}
+        </div>
+      ) : null}
       {jscItems.length > 0 && (
         <div className="pot-section">
           <p className="pot-label">
@@ -435,7 +581,7 @@ function ConnectCard({ webDid, endpoints }) {
   )
 }
 
-function ServiceProfile({ serviceItem, cvpItems, jscItems, webDid, endpoints, onSelect }) {
+function ServiceProfile({ serviceItem, cvpItems, jscItems, accMap, webDid, endpoints, onSelect }) {
   const subject = serviceItem.credentials[0]?.credentialSubject ?? {}
   const controllerItem =
     cvpItems.find(i => i.type === 'ecs-org' && i.credentials.length > 0) ??
@@ -451,7 +597,7 @@ function ServiceProfile({ serviceItem, cvpItems, jscItems, webDid, endpoints, on
       <div className="profile-grid">
         <div className="profile-main">
           <ControllerCard item={controllerItem} onSelect={() => onSelect(controllerItem?.vp)} />
-          <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} onSelect={onSelect} />
+          <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} accMap={accMap} onSelect={onSelect} />
         </div>
         <ConnectCard webDid={webDid} endpoints={endpoints} />
       </div>
@@ -555,6 +701,8 @@ export default function Dashboard() {
   const [credsLoading, setCredsLoading] = useState(true)
   const [error, setError] = useState(null)
   const [selected, setSelected] = useState(null)
+  // null = still resolving, {} onward = resolved (possibly empty)
+  const [accMap, setAccMap] = useState(null)
 
   useEffect(() => {
     getDidDocument()
@@ -571,6 +719,27 @@ export default function Dashboard() {
       })
       .catch(err => setError(err.message))
   }, [])
+
+  useEffect(() => {
+    if (credsLoading) return
+    if (cvpItems.length === 0) {
+      setAccMap({})
+      return
+    }
+    let alive = true
+    Promise.all(
+      cvpItems.map(async (item, i) => {
+        const vc = item.credentials[0]
+        if (!vc || item.type === 'other') return [i, null]
+        return [i, await resolveAccreditation(vc)]
+      }),
+    ).then(entries => {
+      if (alive) setAccMap(Object.fromEntries(entries.filter(([, acc]) => acc)))
+    })
+    return () => {
+      alive = false
+    }
+  }, [credsLoading, cvpItems])
 
   if (error) return <p className="error-msg">{error}</p>
   if (!doc || credsLoading) return <p className="loading">Loading...</p>
@@ -591,6 +760,7 @@ export default function Dashboard() {
           serviceItem={serviceItem}
           cvpItems={cvpItems}
           jscItems={jscItems}
+          accMap={accMap}
           webDid={webDid}
           endpoints={endpoints}
           onSelect={setSelected}

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { resolveVTCType, resolveJSCType, mapToEcosystem } from '@verana-labs/vs-agent-model/ecs'
+import { resolveVTCType, resolveJSCType } from '@verana-labs/vs-agent-model/ecs'
 import { getAgentConfig, getDidDocument, qrUrl } from '../api'
 
 function JsonModal({ data, onClose }) {
@@ -184,9 +184,12 @@ function credentialDisplayName(vc, type) {
   return types[types.length - 1] ?? 'Credential'
 }
 
-/* ─── Accreditations (on-ledger entries of this DID, from the VPR index) ── */
-
-const SCHEMA_REF_RE = /^(vpr:[a-z0-9-]+:[^:/]+)(?::cs:(\d+)|\/cs\/v1\/js\/(\d+))$/
+/* ─── Accreditations (on-ledger entries of this DID, from the VPR index) ──
+   The page is bound to the network declared in the agent's env
+   (VERANA_CHAIN_ID + VERANA_INDEXER_BASE_URL, exposed via
+   window.__VS_AGENT__.network). Networks are never derived from the
+   presented credentials, so credentials anchored elsewhere cannot mix
+   another network into this page. */
 
 const PERM_TYPE_LABELS = {
   ECOSYSTEM: 'Ecosystem',
@@ -229,69 +232,55 @@ function entryStatus(entry) {
   return { state: 'ACTIVE', active: true }
 }
 
-/** Extracts the VPR network a credential schema is anchored in, or null. */
-async function credentialNetwork(vc) {
-  const schemaUrl = vc?.credentialSchema?.id
-  if (!schemaUrl) return null
-  const w3c = await fetchJson(schemaUrl)
-  const ref = w3c?.credentialSubject?.jsonSchema?.$ref
-  const match = typeof ref === 'string' ? ref.match(SCHEMA_REF_RE) : null
-  if (!match) return null
-  const prefix = match[1]
-  const base = mapToEcosystem(prefix)
-  if (base === prefix) return null
-  return { prefix, base, network: prefix.split(':').pop() }
-}
-
 /**
- * Lists the on-ledger accreditations of a DID: its permission entries
- * (VPR v3, /perm/v1) or participant entries (VPR v4, /pp/v1) for credential
- * schemas, with the schema title resolved for display.
+ * Lists the on-ledger accreditations of a DID from the declared network's
+ * indexer: its permission entries (VPR v3, /verana/perm/v1) or participant
+ * entries (VPR v4, /v4/participant) for credential schemas, with the schema
+ * title resolved for display.
  */
-async function resolveDidAccreditations(did, networks) {
+async function resolveDidAccreditations(did, network) {
+  const origin = network.indexerBaseUrl.replace(/\/+$/, '')
+  const v3Base = `${origin}/verana`
+  const v4Base = `${origin}/v4`
+  const q = `did=${encodeURIComponent(did)}&response_max_size=64`
+
+  let raw
+  const v3 = await fetchJson(`${v3Base}/perm/v1/list?${q}`)
+  if (v3?.permissions) {
+    raw = v3.permissions.map(entry => ({ entry, jsUrl: `${v3Base}/cs/v1/js/${entry.schema_id}` }))
+  } else {
+    const v4 = await fetchJson(`${v4Base}/participant/list?${q}`)
+    raw = (v4?.participants ?? []).map(entry => ({
+      entry,
+      jsUrl: `${v4Base}/credential-schema/js/${entry.schema_id}`,
+    }))
+  }
+
   const entries = []
-  for (const { base, network } of networks) {
-    const q = `did=${encodeURIComponent(did)}&response_max_size=64`
-    // v4 indexers serve /v4/* on the same host and drop the v3 paths.
-    const v4Base = `${new URL(base).origin}/v4`
-
-    let raw
-    const v3 = await fetchJson(`${base}/perm/v1/list?${q}`)
-    if (v3?.permissions) {
-      raw = v3.permissions.map(entry => ({ entry, jsUrl: `${base}/cs/v1/js/${entry.schema_id}` }))
-    } else {
-      const v4 = await fetchJson(`${v4Base}/participant/list?${q}`)
-      raw = (v4?.participants ?? []).map(entry => ({
-        entry,
-        jsUrl: `${v4Base}/credential-schema/js/${entry.schema_id}`,
-      }))
-    }
-
-    const schemaCache = new Map()
-    for (const { entry, jsUrl } of raw) {
-      const schemaId = entry.schema_id
-      let schemaTitle = null
-      if (schemaId != null) {
-        if (!schemaCache.has(schemaId)) {
-          const js = await fetchJson(jsUrl)
-          schemaCache.set(schemaId, typeof js?.title === 'string' ? js.title : null)
-        }
-        schemaTitle = schemaCache.get(schemaId)
+  const schemaCache = new Map()
+  const appUrl = APP_URLS[network.chainId]
+  for (const { entry, jsUrl } of raw) {
+    const schemaId = entry.schema_id
+    let schemaTitle = null
+    if (schemaId != null) {
+      if (!schemaCache.has(schemaId)) {
+        const js = await fetchJson(jsUrl)
+        schemaCache.set(schemaId, typeof js?.title === 'string' ? js.title : null)
       }
-      const appUrl = APP_URLS[network]
-      const { state, active } = entryStatus(entry)
-      entries.push({
-        type: entry.type ?? entry.role,
-        state,
-        active,
-        schemaId,
-        schemaTitle,
-        network,
-        schemaUrl: appUrl && schemaId != null ? `${appUrl}/tr/cs/${schemaId}` : null,
-        entryUrl: appUrl && schemaId != null ? `${appUrl}/participants/${schemaId}` : null,
-        raw: entry,
-      })
+      schemaTitle = schemaCache.get(schemaId)
     }
+    const { state, active } = entryStatus(entry)
+    entries.push({
+      type: entry.type ?? entry.role,
+      state,
+      active,
+      schemaId,
+      schemaTitle,
+      network: network.chainId,
+      schemaUrl: appUrl && schemaId != null ? `${appUrl}/tr/cs/${schemaId}` : null,
+      entryUrl: appUrl && schemaId != null ? `${appUrl}/participants/${schemaId}` : null,
+      raw: entry,
+    })
   }
   return entries
 }
@@ -530,7 +519,7 @@ function AccreditationRow({ entry, onSelect }) {
   )
 }
 
-function TrustCard({ webDid, cvpItems, jscItems, acc, onSelect }) {
+function TrustCard({ webDid, cvpItems, jscItems, acc, network, onSelect }) {
   const rows = cvpItems
     .flatMap(item => item.credentials.map(vc => ({ item, vc })))
     .sort((a, b) => potRowRank(a.item.type) - potRowRank(b.item.type))
@@ -543,6 +532,7 @@ function TrustCard({ webDid, cvpItems, jscItems, acc, onSelect }) {
           Proof of Trust
         </span>
         <span style={{ flex: 1 }} />
+        {network?.chainId && <span className="pot-pill pot-pill-net">{network.chainId}</span>}
         <span className="pot-pill pot-pill-neutral">Self-declared</span>
       </div>
       <div className="pot-section">
@@ -628,7 +618,7 @@ function ConnectCard({ webDid, endpoints }) {
   )
 }
 
-function ServiceProfile({ serviceItem, cvpItems, jscItems, acc, webDid, endpoints, onSelect }) {
+function ServiceProfile({ serviceItem, cvpItems, jscItems, acc, network, webDid, endpoints, onSelect }) {
   const subject = serviceItem.credentials[0]?.credentialSubject ?? {}
   const controllerItem =
     cvpItems.find(i => i.type === 'ecs-org' && i.credentials.length > 0) ??
@@ -644,7 +634,7 @@ function ServiceProfile({ serviceItem, cvpItems, jscItems, acc, webDid, endpoint
       <div className="profile-grid">
         <div className="profile-main">
           <ControllerCard item={controllerItem} onSelect={() => onSelect(controllerItem?.vp)} />
-          <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} acc={acc} onSelect={onSelect} />
+          <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} acc={acc} network={network} onSelect={onSelect} />
         </div>
         <ConnectCard webDid={webDid} endpoints={endpoints} />
       </div>
@@ -770,20 +760,14 @@ export default function Dashboard() {
   useEffect(() => {
     if (credsLoading || !doc) return
     const did = (doc.alsoKnownAs ?? []).find(d => d.startsWith('did:webvh:')) ?? doc.id
-    const ecsItems = cvpItems.filter(i => i.type !== 'other' && i.credentials.length > 0)
-    if (!did || ecsItems.length === 0) {
+    const network = agentConfig.network
+    const hasProfile = cvpItems.some(i => i.type === 'ecs-service' && i.credentials.length > 0)
+    if (!did || !network?.indexerBaseUrl || !hasProfile) {
       setAcc([])
       return
     }
     let alive = true
-    Promise.all(ecsItems.map(i => credentialNetwork(i.credentials[0])))
-      .then(nets => {
-        const byPrefix = new Map()
-        for (const net of nets) {
-          if (net && !byPrefix.has(net.prefix)) byPrefix.set(net.prefix, net)
-        }
-        return resolveDidAccreditations(did, [...byPrefix.values()])
-      })
+    resolveDidAccreditations(did, network)
       .then(entries => {
         if (alive) setAcc(entries)
       })
@@ -793,7 +777,7 @@ export default function Dashboard() {
     return () => {
       alive = false
     }
-  }, [credsLoading, cvpItems, doc])
+  }, [credsLoading, cvpItems, doc, agentConfig.network])
 
   if (error) return <p className="error-msg">{error}</p>
   if (!doc || credsLoading) return <p className="loading">Loading...</p>
@@ -815,6 +799,7 @@ export default function Dashboard() {
           cvpItems={cvpItems}
           jscItems={jscItems}
           acc={acc}
+          network={agentConfig.network}
           webDid={webDid}
           endpoints={endpoints}
           onSelect={setSelected}

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -381,6 +381,44 @@ function CircleCheckIcon(props) {
   )
 }
 
+function CopyIcon(props) {
+  return (
+    <Icon {...props}>
+      <rect x="8" y="8" width="14" height="14" rx="2" />
+      <path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2" />
+    </Icon>
+  )
+}
+
+function QrCodeIcon(props) {
+  return (
+    <Icon {...props}>
+      <rect x="3" y="3" width="5" height="5" rx="1" />
+      <rect x="16" y="3" width="5" height="5" rx="1" />
+      <rect x="3" y="16" width="5" height="5" rx="1" />
+      <path d="M21 16h-3a2 2 0 0 0-2 2v3" />
+      <path d="M21 21v.01" />
+      <path d="M12 7v3a2 2 0 0 1-2 2H7" />
+      <path d="M3 12h.01" />
+      <path d="M12 3h.01" />
+      <path d="M12 16v.01" />
+      <path d="M16 12h1" />
+      <path d="M21 12v.01" />
+      <path d="M12 21v-1" />
+    </Icon>
+  )
+}
+
+function GlobeIcon(props) {
+  return (
+    <Icon {...props}>
+      <circle cx="12" cy="12" r="10" />
+      <path d="M2 12h20" />
+      <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+    </Icon>
+  )
+}
+
 function LayersIcon(props) {
   return (
     <Icon {...props}>
@@ -600,25 +638,122 @@ function TrustCard({ webDid, cvpItems, jscItems, acc, network, onSelect }) {
   )
 }
 
-function ConnectCard({ webDid, endpoints }) {
+/* ─── Service endpoints (from the DID document service entries) ──────── */
+
+const DIDCOMM_SERVICE_TYPES = ['did-communication', 'DIDCommMessaging', 'IndyAgent']
+
+function serviceTypesOf(service) {
+  return (Array.isArray(service.type) ? service.type : [service.type]).filter(Boolean)
+}
+
+/** Absolute endpoint URIs of a service entry; relativeRef entries are skipped. */
+function endpointUris(serviceEndpoint) {
+  const out = []
+  const visit = ep => {
+    if (typeof ep === 'string') {
+      out.push(ep)
+      return
+    }
+    if (Array.isArray(ep)) {
+      ep.forEach(visit)
+      return
+    }
+    if (ep && typeof ep === 'object' && typeof ep.uri === 'string') out.push(ep.uri)
+  }
+  visit(serviceEndpoint)
+  return out.filter(uri => /^[a-z][a-z0-9+.-]*:/i.test(uri))
+}
+
+function CopyButton({ text }) {
+  const [copied, setCopied] = useState(false)
+
+  function copy() {
+    try {
+      navigator.clipboard.writeText(text)
+    } catch {
+      return
+    }
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
   return (
-    <aside className="connect-card">
-      <div className="qr-desktop">
-        <span className="qr-tile qr-tile-sm">
-          <img src={qrUrl} alt="Invitation QR" />
-        </span>
-        <p className="qr-label">Scan to connect</p>
-      </div>
-      <div className="qr-mobile">
-        <a href="/invitation" className="btn btn-primary">Connect</a>
-      </div>
-      {webDid && <div className="connect-did">{webDid}</div>}
-      {endpoints.length > 0 && <div className="connect-endpoints">{endpoints.join(', ')}</div>}
-    </aside>
+    <button className="icon-btn" onClick={copy} title="Copy endpoint">
+      {copied ? <CircleCheckIcon size={12} /> : <CopyIcon size={12} />}
+    </button>
   )
 }
 
-function ServiceProfile({ serviceItem, cvpItems, jscItems, acc, network, webDid, endpoints, onSelect }) {
+function ServiceEndpointsCard({ services }) {
+  const [qrOpenFor, setQrOpenFor] = useState(null)
+
+  const rows = (services ?? [])
+    .map(service => ({ service, types: serviceTypesOf(service), uris: endpointUris(service.serviceEndpoint) }))
+    .filter(row => !row.types.includes('LinkedVerifiablePresentation') && row.uris.length > 0)
+
+  if (rows.length === 0) return null
+
+  return (
+    <div className="pot-card">
+      <div className="pot-section">
+        <p className="pot-label">
+          <GlobeIcon size={11} />
+          Service endpoints
+        </p>
+        {rows.map(row => {
+          const isDidComm = row.types.some(t => DIDCOMM_SERVICE_TYPES.includes(t))
+          const qrOpen = qrOpenFor === row.service.id
+          return (
+            <div key={row.service.id}>
+              {row.uris.map((uri, i) => (
+                <div className="pot-row" key={uri}>
+                  <span className="ep-type">{i === 0 ? row.types.join(', ') : ''}</span>
+                  <span className="ep-uri" title={uri}>{uri}</span>
+                  {isDidComm && i === 0 && (
+                    <button
+                      className={`icon-btn${qrOpen ? ' icon-btn-active' : ''}`}
+                      onClick={() => setQrOpenFor(qrOpen ? null : row.service.id)}
+                      title="Show connection QR code"
+                    >
+                      <QrCodeIcon size={12} />
+                    </button>
+                  )}
+                  <CopyButton text={uri} />
+                  {/^https?:/.test(uri) && (
+                    <a
+                      className="icon-btn"
+                      href={uri}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title="Open endpoint in a new window"
+                    >
+                      <ExternalLinkIcon size={12} />
+                    </a>
+                  )}
+                </div>
+              ))}
+              {isDidComm && qrOpen && (
+                <div className="ep-qr">
+                  <div className="qr-desktop">
+                    <span className="qr-tile qr-tile-sm">
+                      <img src={qrUrl} alt="Invitation QR" />
+                    </span>
+                    <p className="qr-label">Scan to connect</p>
+                  </div>
+                  <div className="qr-mobile">
+                    <a href="/invitation" className="btn btn-primary">Connect</a>
+                  </div>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function ServiceProfile({ serviceItem, cvpItems, jscItems, acc, network, webDid, services, onSelect }) {
   const subject = serviceItem.credentials[0]?.credentialSubject ?? {}
   const controllerItem =
     cvpItems.find(i => i.type === 'ecs-org' && i.credentials.length > 0) ??
@@ -631,12 +766,10 @@ function ServiceProfile({ serviceItem, cvpItems, jscItems, acc, network, webDid,
   return (
     <div className="profile">
       <ServiceHero subject={subject} />
-      <div className="profile-grid">
-        <div className="profile-main">
-          <ControllerCard item={controllerItem} onSelect={() => onSelect(controllerItem?.vp)} />
-          <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} acc={acc} network={network} onSelect={onSelect} />
-        </div>
-        <ConnectCard webDid={webDid} endpoints={endpoints} />
+      <div className="profile-main">
+        <ControllerCard item={controllerItem} onSelect={() => onSelect(controllerItem?.vp)} />
+        <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} acc={acc} network={network} onSelect={onSelect} />
+        <ServiceEndpointsCard services={services} />
       </div>
     </div>
   )
@@ -801,7 +934,7 @@ export default function Dashboard() {
           acc={acc}
           network={agentConfig.network}
           webDid={webDid}
-          endpoints={endpoints}
+          services={doc.service ?? []}
           onSelect={setSelected}
         />
       ) : (

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -159,6 +159,37 @@ function typeRank(type) {
   return i === -1 ? Infinity : i
 }
 
+const POT_ROW_ORDER = ['ecs-service', 'ecs-org', 'ecs-persona', 'ecs-user-agent']
+function potRowRank(type) {
+  const i = POT_ROW_ORDER.indexOf(type)
+  return i === -1 ? Infinity : i
+}
+
+const ECS_LABELS = {
+  'ecs-service': 'Service credential',
+  'ecs-org': 'Organization credential',
+  'ecs-persona': 'Persona credential',
+  'ecs-user-agent': 'User agent credential',
+}
+
+function credentialIssuer(vc) {
+  return typeof vc?.issuer === 'string' ? vc.issuer : (vc?.issuer?.id ?? '')
+}
+
+function credentialDisplayName(vc, type) {
+  if (ECS_LABELS[type]) return ECS_LABELS[type]
+  const subjectName = vc?.credentialSubject?.name
+  if (typeof subjectName === 'string' && subjectName) return subjectName
+  const types = Array.isArray(vc?.type) ? vc.type.filter(t => t !== 'VerifiableCredential') : []
+  return types[types.length - 1] ?? 'Credential'
+}
+
+/** ISO 3166-1 alpha-2 country code as an emoji flag (e.g. "CH"). */
+function countryFlag(code) {
+  if (typeof code !== 'string' || !/^[A-Za-z]{2}$/.test(code)) return null
+  return String.fromCodePoint(...[...code.toUpperCase()].map(c => 127397 + c.charCodeAt(0)))
+}
+
 function CredentialSection({ title, items, renderItem }) {
   if (items.length === 0) return null
   const sorted = [...items].sort((a, b) => typeRank(a.type) - typeRank(b.type))
@@ -172,45 +203,269 @@ function CredentialSection({ title, items, renderItem }) {
   )
 }
 
-export default function Dashboard() {
-  const agentConfig = getAgentConfig()
-  const [doc, setDoc] = useState(null)
-  const [cvpItems, setCvpItems] = useState([])
-  const [jscItems, setJscItems] = useState([])
-  const [credsLoading, setCredsLoading] = useState(true)
-  const [error, setError] = useState(null)
-  const [selected, setSelected] = useState(null)
+/* ─── Icons (stroke style shared with Header) ────────────────────────── */
+
+function Icon({ children, size = 13 }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      style={{ flexShrink: 0 }}
+    >
+      {children}
+    </svg>
+  )
+}
+
+function ShieldIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+    </Icon>
+  )
+}
+
+function FileTextIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7z" />
+      <path d="M14 2v5h5" />
+    </Icon>
+  )
+}
+
+function LockIcon(props) {
+  return (
+    <Icon {...props}>
+      <rect x="3" y="11" width="18" height="11" rx="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </Icon>
+  )
+}
+
+function BuildingIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="M6 22V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v18Z" />
+      <path d="M6 12H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h2" />
+      <path d="M18 9h2a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-2" />
+      <path d="M10 6h4M10 10h4M10 14h4M10 18h4" />
+    </Icon>
+  )
+}
+
+function LayersIcon(props) {
+  return (
+    <Icon {...props}>
+      <path d="m12.83 2.18 8.11 4.06c1.42.7 1.42 2.82 0 3.52l-8.11 4.06a1.87 1.87 0 0 1-1.66 0L3.06 9.76c-1.42-.7-1.42-2.82 0-3.52l8.11-4.06a1.87 1.87 0 0 1 1.66 0Z" />
+      <path d="m22 12.5-9.17 4.59a1.87 1.87 0 0 1-1.66 0L2 12.5" />
+    </Icon>
+  )
+}
+
+/* ─── Service profile (shown when an ECS-Service credential is presented) ── */
+
+function ServiceLogo({ uri, name }) {
+  const [failed, setFailed] = useState(false)
+  if (uri && !failed) {
+    return <img className="svc-logo" src={uri} alt="" onError={() => setFailed(true)} />
+  }
+  return <div className="svc-logo svc-logo-fallback">{(name ?? '?').charAt(0).toUpperCase()}</div>
+}
+
+function ServiceHero({ subject }) {
+  const age = Number(subject.minimumAgeRequired)
+  return (
+    <>
+      <div className="svc-hero">
+        <ServiceLogo uri={subject.logoUri} name={subject.name} />
+        <div style={{ minWidth: 0 }}>
+          <div className="svc-title-row">
+            <h1 className="svc-name display">{subject.name ?? 'Unnamed service'}</h1>
+            {subject.type && <span className="chip">{subject.type}</span>}
+          </div>
+          {subject.description && <p className="svc-desc">{subject.description}</p>}
+        </div>
+      </div>
+      <div className="svc-meta">
+        {Number.isFinite(age) && age > 0 && (
+          <span className="meta-chip meta-chip-age">
+            <b>{age}+</b> minimum age to connect
+          </span>
+        )}
+        {subject.termsAndConditionsUri && (
+          <a className="meta-chip" href={subject.termsAndConditionsUri} target="_blank" rel="noopener noreferrer">
+            <FileTextIcon size={12} />
+            Terms and conditions
+          </a>
+        )}
+        {subject.privacyPolicyUri && (
+          <a className="meta-chip" href={subject.privacyPolicyUri} target="_blank" rel="noopener noreferrer">
+            <LockIcon size={12} />
+            Privacy policy
+          </a>
+        )}
+      </div>
+    </>
+  )
+}
+
+function ControllerLogo({ uri, name }) {
+  const [failed, setFailed] = useState(false)
+  if (uri && !failed) {
+    return <img className="op-logo" src={uri} alt="" onError={() => setFailed(true)} />
+  }
+  return <div className="op-logo op-logo-fallback">{(name ?? '?').charAt(0).toUpperCase()}</div>
+}
+
+function ControllerCard({ item, onSelect }) {
+  if (!item) return null
+  const subject = item.credentials[0]?.credentialSubject ?? {}
+  const isOrg = item.type === 'ecs-org'
+  const flag = countryFlag(isOrg ? subject.countryCode : subject.controllerCountryCode)
+  const idParts = [subject.registryId, subject.lei ? `LEI ${subject.lei}` : null].filter(Boolean)
+  const detailParts = isOrg
+    ? [subject.address, subject.organizationKind, subject.legalJurisdiction ? `Jurisdiction ${subject.legalJurisdiction}` : null]
+    : [subject.description, subject.controllerJurisdiction ? `Jurisdiction ${subject.controllerJurisdiction}` : null]
+  const details = detailParts.filter(Boolean).join(' · ')
+
+  return (
+    <div className="op-card">
+      <button className="cred-card-details-btn" onClick={onSelect} title="View details">{'{ }'}</button>
+      <p className="pot-label">
+        <BuildingIcon size={11} />
+        Operated by
+      </p>
+      <div className="op-head">
+        <ControllerLogo uri={isOrg ? subject.logoUri : subject.avatarUri} name={subject.name} />
+        <div style={{ minWidth: 0 }}>
+          <div className="op-name">
+            {flag && <span role="img" aria-label="Country flag" style={{ marginRight: 6 }}>{flag}</span>}
+            {subject.name ?? (isOrg ? 'Unnamed organization' : 'Unnamed persona')}
+          </div>
+          {idParts.length > 0 && <div className="op-sub">{idParts.join(' · ')}</div>}
+        </div>
+      </div>
+      {details && <p className="op-details">{details}</p>}
+    </div>
+  )
+}
+
+function TrustCard({ webDid, cvpItems, jscItems, onSelect }) {
+  const rows = cvpItems
+    .flatMap(item => item.credentials.map(vc => ({ item, vc })))
+    .sort((a, b) => potRowRank(a.item.type) - potRowRank(b.item.type))
+
+  return (
+    <div className="pot-card">
+      <div className="pot-band">
+        <span className="pot-pill pot-pill-trust">
+          <ShieldIcon size={12} />
+          Proof of Trust
+        </span>
+        <span style={{ flex: 1 }} />
+        <span className="pot-pill pot-pill-neutral">Self-declared</span>
+      </div>
+      <div className="pot-section">
+        {webDid && <div className="pot-did"><LinkOrText text={webDid} /></div>}
+        <p className="pot-note">
+          Credentials presented by this service. They have not been verified against a Verana resolver from this page.
+        </p>
+      </div>
+      {rows.length > 0 && (
+        <div className="pot-section">
+          <p className="pot-label">
+            <LayersIcon size={11} />
+            Credentials
+          </p>
+          {rows.map(({ item, vc }, i) => (
+            <div className="pot-row" key={i}>
+              <span className="pot-row-name">{credentialDisplayName(vc, item.type)}</span>
+              <span className="pot-row-issuer">
+                {credentialIssuer(vc) && <>issued by <LinkOrText text={credentialIssuer(vc)} /></>}
+              </span>
+              <button className="pot-row-btn" onClick={() => onSelect(item.vp ?? vc)} title="View details">{'{ }'}</button>
+            </div>
+          ))}
+        </div>
+      )}
+      {jscItems.length > 0 && (
+        <div className="pot-section">
+          <p className="pot-label">
+            <FileTextIcon size={11} />
+            Schemas
+          </p>
+          {jscItems.map((item, i) => (
+            <div className="pot-row" key={i}>
+              <span className="pot-row-name">{ECS_LABELS[item.type] ? ECS_LABELS[item.type].replace(' credential', ' schema') : item.type}</span>
+              <span className="pot-row-issuer">
+                <LinkOrText text={item.service.serviceEndpoint} />
+              </span>
+              <button className="pot-row-btn" onClick={() => onSelect(item.service)} title="View details">{'{ }'}</button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ConnectCard({ webDid, endpoints }) {
+  return (
+    <aside className="connect-card">
+      <div className="qr-desktop">
+        <span className="qr-tile qr-tile-sm">
+          <img src={qrUrl} alt="Invitation QR" />
+        </span>
+        <p className="qr-label">Scan to connect</p>
+      </div>
+      <div className="qr-mobile">
+        <a href="/invitation" className="btn btn-primary">Connect</a>
+      </div>
+      {webDid && <div className="connect-did">{webDid}</div>}
+      {endpoints.length > 0 && <div className="connect-endpoints">{endpoints.join(', ')}</div>}
+    </aside>
+  )
+}
+
+function ServiceProfile({ serviceItem, cvpItems, jscItems, webDid, endpoints, onSelect }) {
+  const subject = serviceItem.credentials[0]?.credentialSubject ?? {}
+  const controllerItem =
+    cvpItems.find(i => i.type === 'ecs-org' && i.credentials.length > 0) ??
+    cvpItems.find(i => i.type === 'ecs-persona' && i.credentials.length > 0)
 
   useEffect(() => {
-    getDidDocument()
-      .then(d => {
-        setDoc(d)
-        const vprServices = (d.service ?? []).filter(s => (s.id?.split('#')[1] ?? '').startsWith('vpr'))
-        const cvp = vprServices.filter(s => (s.id?.split('#')[1] ?? '').endsWith('-c-vp'))
-        const jsc = vprServices.filter(s => (s.id?.split('#')[1] ?? '').endsWith('-jsc-vp'))
+    if (typeof subject.name === 'string' && subject.name) document.title = subject.name
+  }, [subject.name])
 
-        Promise.all(cvp.map(resolveCVpService)).then(setCvpItems)
-        Promise.all(jsc.map(resolveJscVpService))
-          .then(setJscItems)
-          .finally(() => setCredsLoading(false))
-      })
-      .catch(err => setError(err.message))
-  }, [])
+  return (
+    <div className="profile">
+      <ServiceHero subject={subject} />
+      <div className="profile-grid">
+        <div className="profile-main">
+          <ControllerCard item={controllerItem} onSelect={() => onSelect(controllerItem?.vp)} />
+          <TrustCard webDid={webDid} cvpItems={cvpItems} jscItems={jscItems} onSelect={onSelect} />
+        </div>
+        <ConnectCard webDid={webDid} endpoints={endpoints} />
+      </div>
+    </div>
+  )
+}
 
-  if (error) return <p className="error-msg">{error}</p>
-  if (!doc) return <p className="loading">Loading...</p>
+/* ─── Classic view (no ECS-Service credential presented) ─────────────── */
 
-  const endpoints = (doc.service ?? [])
-    .filter(s => s.type === 'did-communication')
-    .map(s => s.serviceEndpoint)
-  const webDid = (doc.alsoKnownAs ?? []).find(d => d.startsWith('did:webvh:')) ?? doc.id
-
+function ClassicView({ agentConfig, webDid, endpoints, cvpItems, jscItems, credsLoading, onSelect }) {
   const noCredentials = !credsLoading && cvpItems.length === 0 && jscItems.length === 0
 
   return (
     <div>
-      {selected && <JsonModal data={selected} onClose={() => setSelected(null)} />}
-
       {agentConfig.welcomeMessage && (
         <h1 className="welcome display">
           {agentConfig.welcomeMessage}
@@ -270,7 +525,7 @@ export default function Dashboard() {
         items={cvpItems}
         renderItem={(item, i) =>
           item.credentials.map((vc, j) => (
-            <CredentialCard key={`${i}-${j}`} vc={vc} type={item.type} onSelect={() => setSelected(item.vp)} />
+            <CredentialCard key={`${i}-${j}`} vc={vc} type={item.type} onSelect={() => onSelect(item.vp)} />
           ))
         }
       />
@@ -280,7 +535,7 @@ export default function Dashboard() {
         items={jscItems}
         renderItem={(item, i) => (
           <div key={i} className="cred-card">
-            <button className="cred-card-details-btn" onClick={() => setSelected(item.service)} title="View details">{'{ }'}</button>
+            <button className="cred-card-details-btn" onClick={() => onSelect(item.service)} title="View details">{'{ }'}</button>
             <div className="cred-card-type">{item.type}</div>
             <div className="cred-field-value cred-field-mono text-subtle">
               <LinkOrText text={item.service.serviceEndpoint} />
@@ -288,6 +543,69 @@ export default function Dashboard() {
           </div>
         )}
       />
+    </div>
+  )
+}
+
+export default function Dashboard() {
+  const agentConfig = getAgentConfig()
+  const [doc, setDoc] = useState(null)
+  const [cvpItems, setCvpItems] = useState([])
+  const [jscItems, setJscItems] = useState([])
+  const [credsLoading, setCredsLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [selected, setSelected] = useState(null)
+
+  useEffect(() => {
+    getDidDocument()
+      .then(d => {
+        setDoc(d)
+        const vprServices = (d.service ?? []).filter(s => (s.id?.split('#')[1] ?? '').startsWith('vpr'))
+        const cvp = vprServices.filter(s => (s.id?.split('#')[1] ?? '').endsWith('-c-vp'))
+        const jsc = vprServices.filter(s => (s.id?.split('#')[1] ?? '').endsWith('-jsc-vp'))
+
+        Promise.all([
+          Promise.all(cvp.map(resolveCVpService)).then(setCvpItems),
+          Promise.all(jsc.map(resolveJscVpService)).then(setJscItems),
+        ]).finally(() => setCredsLoading(false))
+      })
+      .catch(err => setError(err.message))
+  }, [])
+
+  if (error) return <p className="error-msg">{error}</p>
+  if (!doc || credsLoading) return <p className="loading">Loading...</p>
+
+  const endpoints = (doc.service ?? [])
+    .filter(s => s.type === 'did-communication')
+    .map(s => s.serviceEndpoint)
+  const webDid = (doc.alsoKnownAs ?? []).find(d => d.startsWith('did:webvh:')) ?? doc.id
+
+  const serviceItem = cvpItems.find(i => i.type === 'ecs-service' && i.credentials.length > 0)
+
+  return (
+    <div>
+      {selected && <JsonModal data={selected} onClose={() => setSelected(null)} />}
+
+      {serviceItem ? (
+        <ServiceProfile
+          serviceItem={serviceItem}
+          cvpItems={cvpItems}
+          jscItems={jscItems}
+          webDid={webDid}
+          endpoints={endpoints}
+          onSelect={setSelected}
+        />
+      ) : (
+        <ClassicView
+          agentConfig={agentConfig}
+          webDid={webDid}
+          endpoints={endpoints}
+          cvpItems={cvpItems}
+          jscItems={jscItems}
+          credsLoading={false}
+          onSelect={setSelected}
+        />
+      )}
     </div>
   )
 }

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -213,12 +213,20 @@ async function fetchJson(url) {
   }
 }
 
-function entryState(entry) {
-  return entry.perm_state ?? entry.pp_state ?? entry.state ?? 'ACTIVE'
-}
-
-function entryIsActive(entry) {
-  return entryState(entry) === 'ACTIVE' && !entry.revoked && !entry.slashed
+function entryStatus(entry) {
+  // v3 permission entries carry perm_state; v4 participant entries derive
+  // their state from revocation/slashing and the effective date range.
+  if (entry.perm_state) {
+    return { state: entry.perm_state, active: entry.perm_state === 'ACTIVE' && !entry.revoked && !entry.slashed }
+  }
+  if (entry.revoked) return { state: 'REVOKED', active: false }
+  if (entry.slashed && !entry.repaid) return { state: 'SLASHED', active: false }
+  const now = Date.now()
+  const from = entry.effective_from ? Date.parse(entry.effective_from) : NaN
+  const until = entry.effective_until ? Date.parse(entry.effective_until) : null
+  if (Number.isNaN(from) || from > now) return { state: 'PENDING', active: false }
+  if (until !== null && until <= now) return { state: 'EXPIRED', active: false }
+  return { state: 'ACTIVE', active: true }
 }
 
 /** Extracts the VPR network a credential schema is anchored in, or null. */
@@ -244,30 +252,38 @@ async function resolveDidAccreditations(did, networks) {
   const entries = []
   for (const { base, network } of networks) {
     const q = `did=${encodeURIComponent(did)}&response_max_size=64`
+    // v4 indexers serve /v4/* on the same host and drop the v3 paths.
+    const v4Base = `${new URL(base).origin}/v4`
+
+    let raw
     const v3 = await fetchJson(`${base}/perm/v1/list?${q}`)
-    const raw = v3?.permissions ?? (await fetchJson(`${base}/pp/v1/list?${q}`))?.participants ?? []
+    if (v3?.permissions) {
+      raw = v3.permissions.map(entry => ({ entry, jsUrl: `${base}/cs/v1/js/${entry.schema_id}` }))
+    } else {
+      const v4 = await fetchJson(`${v4Base}/participant/list?${q}`)
+      raw = (v4?.participants ?? []).map(entry => ({
+        entry,
+        jsUrl: `${v4Base}/credential-schema/js/${entry.schema_id}`,
+      }))
+    }
 
     const schemaCache = new Map()
-    for (const entry of raw) {
+    for (const { entry, jsUrl } of raw) {
       const schemaId = entry.schema_id
       let schemaTitle = null
       if (schemaId != null) {
         if (!schemaCache.has(schemaId)) {
-          const cs = await fetchJson(`${base}/cs/v1/get/${schemaId}`)
-          try {
-            schemaTitle = JSON.parse((cs?.schema ?? cs)?.json_schema)?.title ?? null
-          } catch {
-            schemaTitle = null
-          }
-          schemaCache.set(schemaId, schemaTitle)
+          const js = await fetchJson(jsUrl)
+          schemaCache.set(schemaId, typeof js?.title === 'string' ? js.title : null)
         }
         schemaTitle = schemaCache.get(schemaId)
       }
       const appUrl = APP_URLS[network]
+      const { state, active } = entryStatus(entry)
       entries.push({
         type: entry.type ?? entry.role,
-        state: entryState(entry),
-        active: entryIsActive(entry),
+        state,
+        active,
         schemaId,
         schemaTitle,
         network,

--- a/apps/vs-agent-ui/src/components/Footer.jsx
+++ b/apps/vs-agent-ui/src/components/Footer.jsx
@@ -1,0 +1,117 @@
+import { getAgentConfig } from '../api'
+import logoSvg from '../assets/logo.svg'
+
+const TAGLINE = 'The Open Trust Infrastructure for the Verifiable Internet.'
+
+const SOCIALS = [
+  { label: 'Discord', href: 'https://discord.gg/edjaFn252q' },
+  { label: 'LinkedIn', href: 'https://www.linkedin.com/company/verana-foundation/' },
+  { label: 'X', href: 'https://x.com/Verana_io' },
+]
+
+const COLUMNS = [
+  {
+    title: 'Build on Verana',
+    links: [
+      { label: 'Documentation', href: 'https://docs.verana.io' },
+      { label: 'Playground', href: 'https://playground.testnet.verana.network' },
+      { label: 'GitHub', href: 'https://github.com/verana-labs' },
+      { label: 'Verifiable Trust spec', href: 'https://verana-labs.github.io/verifiable-trust-spec/' },
+      { label: 'VPR spec', href: 'https://verana-labs.github.io/verifiable-trust-vpr-spec/' },
+    ],
+  },
+  {
+    title: 'Websites',
+    links: [
+      { label: 'verana.io', href: 'https://verana.io' },
+      { label: 'Verana Foundation', href: 'https://veranafoundation.org' },
+      { label: 'Verana Council', href: 'https://veranacouncil.org' },
+      { label: '2060', href: 'https://2060.io' },
+    ],
+  },
+]
+
+function SocialIcon({ label }) {
+  const common = { width: 18, height: 18, viewBox: '0 0 24 24', fill: 'currentColor', 'aria-hidden': true }
+  if (label === 'X') {
+    return (
+      <svg {...common}>
+        <path d="M18.9 1.15h3.68l-8.04 9.19L24 22.85h-7.41l-5.8-7.58-6.64 7.58H.47l8.6-9.83L0 1.15h7.59l5.24 6.93zM17.61 20.64h2.04L6.49 3.24H4.3z" />
+      </svg>
+    )
+  }
+  if (label === 'LinkedIn') {
+    return (
+      <svg {...common}>
+        <path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.14 1.45-2.14 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.46zM5.34 7.43a2.07 2.07 0 1 1 0-4.13 2.07 2.07 0 0 1 0 4.13zM7.12 20.45H3.55V9h3.57zM22.22 0H1.77C.79 0 0 .77 0 1.72v20.55C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.73V1.72C24 .77 23.2 0 22.22 0z" />
+      </svg>
+    )
+  }
+  return (
+    <svg {...common}>
+      <path d="M20.32 4.37a19.8 19.8 0 0 0-4.89-1.52.07.07 0 0 0-.08.04c-.21.38-.44.87-.6 1.25a18.3 18.3 0 0 0-5.49 0 12.6 12.6 0 0 0-.61-1.25.08.08 0 0 0-.08-.04 19.74 19.74 0 0 0-4.88 1.52.07.07 0 0 0-.04.03C.53 9.05-.32 13.58.1 18.06c0 .02.01.04.03.06a19.9 19.9 0 0 0 6 3.03.08.08 0 0 0 .08-.03c.46-.63.87-1.3 1.23-2a.08.08 0 0 0-.04-.1 13.1 13.1 0 0 1-1.87-.9.08.08 0 0 1-.01-.12c.13-.1.25-.19.37-.29a.07.07 0 0 1 .08-.01c3.93 1.79 8.18 1.79 12.06 0a.07.07 0 0 1 .08 0c.12.11.25.21.37.3a.08.08 0 0 1 0 .12 12.3 12.3 0 0 1-1.88.9.08.08 0 0 0-.04.1c.36.7.78 1.37 1.23 2a.08.08 0 0 0 .08.03 19.84 19.84 0 0 0 6.03-3.03.08.08 0 0 0 .03-.06c.5-5.18-.84-9.68-3.55-13.66a.06.06 0 0 0-.03-.03zM8.02 15.33c-1.18 0-2.16-1.08-2.16-2.42 0-1.33.96-2.42 2.16-2.42 1.21 0 2.18 1.1 2.16 2.42 0 1.34-.96 2.42-2.16 2.42zm7.97 0c-1.18 0-2.15-1.08-2.15-2.42 0-1.33.95-2.42 2.15-2.42 1.22 0 2.18 1.1 2.16 2.42 0 1.34-.94 2.42-2.16 2.42z" />
+    </svg>
+  )
+}
+
+export default function Footer() {
+  const { build, version } = getAgentConfig()
+
+  return (
+    <footer className="footer">
+      <div className="footer-inner">
+        <div className="footer-grid">
+          <div className="footer-brand">
+            <div className="header-logo">
+              <img src={logoSvg} alt="Verana" className="header-logo-icon" />
+              <span className="header-logo-name wordmark">Verana</span>
+            </div>
+            <p className="footer-tagline">{TAGLINE}</p>
+            <div className="footer-socials">
+              {SOCIALS.map(s => (
+                <a
+                  key={s.label}
+                  href={s.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={s.label}
+                  className="footer-social-link"
+                >
+                  <SocialIcon label={s.label} />
+                </a>
+              ))}
+            </div>
+          </div>
+          {COLUMNS.map(col => (
+            <div key={col.title}>
+              <h3 className="eyebrow footer-col-title">{col.title}</h3>
+              <ul className="footer-links">
+                {col.links.map(l => (
+                  <li key={l.label}>
+                    <a href={l.href} target="_blank" rel="noopener noreferrer">{l.label}</a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <div className="footer-bottom">
+          <span className="footer-build">
+            {build ?? 'vs-agent'}
+            {version ? ` · v${version}` : ''}
+          </span>
+          <span className="footer-legal">
+            <a href="https://veranafoundation.org" target="_blank" rel="noopener noreferrer">
+              © {new Date().getFullYear()} Verana Foundation
+            </a>
+            {' · '}
+            <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener noreferrer">
+              License Apache-2.0
+            </a>
+          </span>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/apps/vs-agent-ui/src/components/Footer.jsx
+++ b/apps/vs-agent-ui/src/components/Footer.jsx
@@ -26,7 +26,6 @@ const COLUMNS = [
       { label: 'verana.io', href: 'https://verana.io' },
       { label: 'Verana Foundation', href: 'https://veranafoundation.org' },
       { label: 'Verana Council', href: 'https://veranacouncil.org' },
-      { label: '2060', href: 'https://2060.io' },
     ],
   },
 ]

--- a/apps/vs-agent-ui/src/components/Header.jsx
+++ b/apps/vs-agent-ui/src/components/Header.jsx
@@ -1,7 +1,48 @@
 import { useEffect, useState } from 'react'
+import { getAgentConfig } from '../api'
 import logoSvg from '../assets/logo.svg'
 
 const THEME_KEY = 'vsa-theme'
+
+// Network status chip: a glowing LED and the badge text from
+// UI_NETWORK_BADGE (e.g. "Testnet"). The LED reflects the reachability of
+// the declared network's indexer: green OK, red down, gray while checking
+// or when no indexer is declared.
+function NetworkChip() {
+  const { networkBadge, network } = getAgentConfig()
+  const [indexer, setIndexer] = useState(null)
+
+  useEffect(() => {
+    if (!network?.indexerBaseUrl) return
+    let alive = true
+    fetch(network.indexerBaseUrl)
+      .then(r => {
+        if (alive) setIndexer(r.ok ? 'ok' : 'down')
+      })
+      .catch(() => {
+        if (alive) setIndexer('down')
+      })
+    return () => {
+      alive = false
+    }
+  }, [network?.indexerBaseUrl])
+
+  if (!networkBadge) return null
+
+  const title = [
+    network?.chainId ? `Connected to ${network.chainId}` : null,
+    indexer === 'down' ? 'indexer unreachable right now' : null,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+
+  return (
+    <span className="net-chip" title={title || undefined}>
+      <span aria-hidden className={`led${indexer === 'ok' ? ' led-ok' : indexer === 'down' ? ' led-down' : ''}`} />
+      {networkBadge}
+    </span>
+  )
+}
 
 export default function Header() {
   const [theme, setTheme] = useState('dark')
@@ -29,6 +70,7 @@ export default function Header() {
         <span className="header-logo-name wordmark">Verana</span>
       </div>
       <div className="header-center" />
+      <NetworkChip />
       <button
         type="button"
         onClick={toggleTheme}

--- a/apps/vs-agent/Dockerfile
+++ b/apps/vs-agent/Dockerfile
@@ -88,6 +88,7 @@ FROM node:22.19-slim AS vs-agent
 WORKDIR /www
 ENV RUN_MODE="docker"
 ENV VS_AGENT_PLUGINS=messaging,chat
+ENV VS_AGENT_BUILD=vs-agent
 
 COPY --from=build-vs-agent /www/node_modules ./node_modules
 COPY --from=build-vs-agent /www/packages/model/package.json ./packages/model/package.json
@@ -113,6 +114,7 @@ FROM node:22.19-slim AS vs-agent-mrtd
 WORKDIR /www
 ENV RUN_MODE="docker"
 ENV VS_AGENT_PLUGINS=messaging,chat,mrtd
+ENV VS_AGENT_BUILD=vs-agent-mrtd
 
 COPY --from=build-mrtd /www/node_modules ./node_modules
 COPY --from=build-mrtd /www/packages/model/package.json ./packages/model/package.json

--- a/apps/vs-agent/src/config/constants.ts
+++ b/apps/vs-agent/src/config/constants.ts
@@ -22,6 +22,8 @@ export const UI_WELCOME_MESSAGE = process.env.UI_WELCOME_MESSAGE || 'Welcome to 
 // Text of the network badge shown in the public UI header (e.g. "Testnet").
 // When unset, no badge is shown.
 export const UI_NETWORK_BADGE = process.env.UI_NETWORK_BADGE
+// Show the business wallet placeholder banner on the public UI (default true).
+export const UI_SHOW_PLACEHOLDER_MESSAGE = process.env.UI_SHOW_PLACEHOLDER_MESSAGE !== 'false'
 export const AGENT_INVITATION_IMAGE_URL = process.env.AGENT_INVITATION_IMAGE_URL
 export const AGENT_ENDPOINT = process.env.AGENT_ENDPOINT
 export const AGENT_ENDPOINTS = process.env.AGENT_ENDPOINT

--- a/apps/vs-agent/src/config/constants.ts
+++ b/apps/vs-agent/src/config/constants.ts
@@ -17,6 +17,9 @@ export const ADMIN_PORT = Number(process.env.ADMIN_PORT || 3000)
 export const AGENT_NAME = process.env.AGENT_NAME // This one is deprecated. Only used to throw error if it is defined
 export const AGENT_LABEL = process.env.AGENT_LABEL || 'Test VS Agent'
 export const UI_WELCOME_MESSAGE = process.env.UI_WELCOME_MESSAGE || 'Welcome to VS Agent'
+// Text of the network badge shown in the public UI header (e.g. "Testnet").
+// When unset, no badge is shown.
+export const UI_NETWORK_BADGE = process.env.UI_NETWORK_BADGE
 export const AGENT_INVITATION_IMAGE_URL = process.env.AGENT_INVITATION_IMAGE_URL
 export const AGENT_ENDPOINT = process.env.AGENT_ENDPOINT
 export const AGENT_ENDPOINTS = process.env.AGENT_ENDPOINT

--- a/apps/vs-agent/src/config/constants.ts
+++ b/apps/vs-agent/src/config/constants.ts
@@ -8,6 +8,8 @@ import packageJson from '../../package.json'
 dotenv.config()
 
 export const AGENT_VERSION: string = packageJson.version
+// Container build variant (set by the Docker image stage, e.g. vs-agent-mrtd)
+export const VS_AGENT_BUILD = process.env.VS_AGENT_BUILD || 'vs-agent'
 
 // Basic parameters
 

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -133,7 +133,17 @@ export const startServers = async (agent: VsAgent, serverConfig: ServerConfig) =
     .getHttpAdapter()
     .getInstance()
     .get(['/', '/index.html'], (_req: express.Request, res: express.Response) => {
-      const config = { label: AGENT_LABEL, welcomeMessage: UI_WELCOME_MESSAGE }
+      const config = {
+        label: AGENT_LABEL,
+        welcomeMessage: UI_WELCOME_MESSAGE,
+        // The declared Verana network. The public UI must use this network
+        // exclusively (accreditations, deep links); it never derives a
+        // network from presented credentials.
+        network:
+          VERANA_CHAIN_ID && VERANA_INDEXER_BASE_URL
+            ? { chainId: VERANA_CHAIN_ID, indexerBaseUrl: VERANA_INDEXER_BASE_URL.replace(/\/+$/, '') }
+            : null,
+      }
       const script = `<script>window.__VS_AGENT__=${JSON.stringify(config)};</script>`
       const html = fs.readFileSync(indexPath, 'utf-8').replace('</head>', `${script}</head>`)
       res.type('html').send(html)

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -46,6 +46,7 @@ import {
   SELF_ISSUED_VTC_SERVICE_PRIVACYPOLICY,
   SELF_ISSUED_VTC_SERVICE_TERMSANDCONDITIONS,
   SELF_ISSUED_VTC_SERVICE_TYPE,
+  UI_SHOW_PLACEHOLDER_MESSAGE,
   UI_NETWORK_BADGE,
   UI_WELCOME_MESSAGE,
   AGENT_VERSION,
@@ -144,6 +145,8 @@ export const startServers = async (agent: VsAgent, serverConfig: ServerConfig) =
         version: AGENT_VERSION,
         // Header network badge text (e.g. "Testnet"); no badge when unset.
         networkBadge: UI_NETWORK_BADGE ?? null,
+        // Business wallet placeholder banner (UI_SHOW_PLACEHOLDER_MESSAGE env).
+        showPlaceholderMessage: UI_SHOW_PLACEHOLDER_MESSAGE,
         // The declared Verana network. The public UI must use this network
         // exclusively (accreditations, deep links); it never derives a
         // network from presented credentials.

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -46,6 +46,7 @@ import {
   SELF_ISSUED_VTC_SERVICE_PRIVACYPOLICY,
   SELF_ISSUED_VTC_SERVICE_TERMSANDCONDITIONS,
   SELF_ISSUED_VTC_SERVICE_TYPE,
+  UI_NETWORK_BADGE,
   UI_WELCOME_MESSAGE,
   AGENT_DIDCOMM_VERSIONS,
   AGENT_LOG_LEVEL,
@@ -136,6 +137,8 @@ export const startServers = async (agent: VsAgent, serverConfig: ServerConfig) =
       const config = {
         label: AGENT_LABEL,
         welcomeMessage: UI_WELCOME_MESSAGE,
+        // Header network badge text (e.g. "Testnet"); no badge when unset.
+        networkBadge: UI_NETWORK_BADGE ?? null,
         // The declared Verana network. The public UI must use this network
         // exclusively (accreditations, deep links); it never derives a
         // network from presented credentials.

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -48,6 +48,8 @@ import {
   SELF_ISSUED_VTC_SERVICE_TYPE,
   UI_NETWORK_BADGE,
   UI_WELCOME_MESSAGE,
+  AGENT_VERSION,
+  VS_AGENT_BUILD,
   AGENT_DIDCOMM_VERSIONS,
   AGENT_LOG_LEVEL,
   AGENT_NAME,
@@ -137,6 +139,9 @@ export const startServers = async (agent: VsAgent, serverConfig: ServerConfig) =
       const config = {
         label: AGENT_LABEL,
         welcomeMessage: UI_WELCOME_MESSAGE,
+        // Container build variant and release version, shown in the footer.
+        build: VS_AGENT_BUILD,
+        version: AGENT_VERSION,
         // Header network badge text (e.g. "Testnet"); no badge when unset.
         networkBadge: UI_NETWORK_BADGE ?? null,
         // The declared Verana network. The public UI must use this network


### PR DESCRIPTION
**Changes**
- Rework the default public website: when an ECS-Service credential is presented, the page renders a service profile instead of the "Welcome to VS Agent" / "VS Agent Information" view.
- Service hero built from the ECS-Service credential: logo (`logoUri`, with initial-letter fallback), name, type chip, description, and a meta row with `minimumAgeRequired` ("18+ minimum age to connect"), `termsAndConditionsUri` and `privacyPolicyUri` links.
- "Operated by" card from the ECS-Organization credential (country flag, name, `registryId`, `lei`, address, kind, jurisdiction) or ECS-Persona credential (avatar, name, description, controller jurisdiction).
- Proof of Trust card in the style of the playground's PotCard: status band, service DID, and rows for every presented credential (issuer shown, raw JSON via the existing modal) plus linked schema presentations.
- **Accreditations**: the section lists the on-ledger entries of the service DID itself — every permission entry (VPR v3, `/verana/perm/v1/list?did=…`) or participant entry (VPR v4, `/v4/participant/list?did=…` fallback) the DID holds for a credential schema. Each row shows the entry type (ISSUER, VERIFIER, HOLDER, grantor roles, ECOSYSTEM), the credential schema title linked to the schema page in the Verana app (`/tr/cs/<id>`), the schema id and network, a link to the participant entries in the Verana app (`/participants/<id>`), the raw entry JSON, and the entry state. v4 participant entries carry no state field, so state is derived from revocation, slashing and the effective date range (PENDING / ACTIVE / EXPIRED / REVOKED / SLASHED).
- **Single-network binding**: the agent exposes its declared network (`VERANA_CHAIN_ID` + `VERANA_INDEXER_BASE_URL`) to the UI via `window.__VS_AGENT__.network`, and the page uses that network exclusively — accreditations are queried only from the declared indexer, networks are never derived from presented credentials, so credentials anchored in other networks cannot mix another network into the page. The Proof of Trust band shows the chain id; the Accreditations section is skipped when no network is declared.
- **Service Endpoints card** (replaces the sticky connect column): lists the DID document service entries after the Proof of Trust, skipping `LinkedVerifiablePresentation` services and `relativeRef` endpoints. Each row shows the service type and absolute endpoint URI with a copy button and, for http(s) endpoints, an open-in-new-window link. DIDComm entries (`did-communication`, `DIDCommMessaging`, `IndyAgent`) get a QR icon that reveals the invitation QR code on desktop and a Connect button on mobile.
- The band keeps a neutral **Self-declared** state: accreditations are read from the trust registry, but credential signatures and digest anchoring are not verified from this page (that remains resolver territory).
- Agents that present no ECS-Service credential keep the previous welcome + agent info view unchanged, including the `UI_WELCOME_MESSAGE` headline.
- Backend change is limited to the `window.__VS_AGENT__` config injection in `main.ts`; everything else renders from the DID document, linked `vpr-*-c-vp` / `vpr-*-jsc-vp` presentations, and the declared network's public index REST endpoints (CORS-open).

Related: #541 fixes `mapToEcosystem` in `packages/model` so ECS classification also works against v4 indexers (devnet).

**Testing**
- `pnpm build` in `apps/vs-agent-ui` (vite production build passes).
- Headless-browser smoke test against a stub server serving a sample DID document (did-communication, OID4VCI, a relativeRef service and linked VPs) plus ECS-Service and ECS-Organization presentations whose schemas digest-match the testnet ECS schemas, with the DID set to a real accredited testnet issuer and `network` set to `vna-testnet-1`: verified the profile renders in dark theme, light theme and a 390px mobile viewport; the band shows the declared chain id; the Accreditations section lists the DID's live ISSUER entries (ServiceCredential cs/170, BadgeCredential cs/250) as active with working Verana app links; the Service Endpoints card shows the DIDComm row with the QR toggle and the OID4VCI row with copy/open actions while excluding LinkedVerifiablePresentation and relativeRef entries; the classic view still renders when the ECS type does not resolve.
- The accreditation resolution logic was additionally exercised standalone against the v4 devnet indexer (`/v4/participant/list`), returning the expected ECOSYSTEM entry with derived ACTIVE state.

## Checklist
- [x] I have commented on my code, especially in areas that are hard to understand.
- [x] I have added only changes relevant to the issue in question.
- [ ] I have added tests to confirm that my fix is effective or that my feature works as intended.
- [ ] I have modified existing tests as needed to accommodate my changes.
- [x] I have flagged specific areas for further review, if necessary.
- [ ] I have updated the documentation where necessary.