### PR TITLE
fix(openid4vc): fail when metadataSigner cannot take effect on a stored issuer

### DIFF
--- a/packages/plugin-openid4vc/src/services/IssuerService.ts
+++ b/packages/plugin-openid4vc/src/services/IssuerService.ts
@@ -303,8 +303,9 @@ export class IssuerService {
       credentialConfigurationsSupported: this.credentialConfigurationsSupported(),
     }
 
+    let existing
     try {
-      await this.issuerApi().getIssuerByIssuerId(issuerId)
+      existing = await this.issuerApi().getIssuerByIssuerId(issuerId)
     } catch (error) {
       if (!(error instanceof RecordNotFoundError)) throw error
       await this.issuerApi().createIssuer({
@@ -312,6 +313,17 @@ export class IssuerService {
         metadataSigner: await this.buildMetadataSigner(signingCertificate),
       })
       return
+    }
+
+    // Credo takes `metadataSigner` on `createIssuer` only. `updateIssuer` re-signs an existing
+    // `signedMetadata` but cannot introduce one, so a record first created without the option
+    // stays unsigned however many times it is redeployed. Silently accepting the configuration
+    // makes a green deploy look like a working one while wallets still see no `signed_metadata`
+    // and have no DID to trust-resolve. Say so instead of pretending.
+    if (this.issuerOptions().metadataSigner === 'did' && !existing.signedMetadata) {
+      throw new Error(
+        `OpenID4VC issuer '${issuerId}' is configured with metadataSigner 'did', but its stored record was created without one and Credo cannot add it on update. Recreate the issuer record (a new issuer id, or clearing the stored record) for the setting to take effect.`,
+      )
     }
 
     await this.issuerApi().updateIssuerMetadata(metadata)


### PR DESCRIPTION
Setting `issuer.metadataSigner: "did"` on a service whose issuer record already exists does nothing at all, and nothing says so. The deploy is green, the pod is healthy, and the issuer still publishes no `signed_metadata`, so a wallet has no DID to trust-resolve and every Verana check falls back to "unknown organization".

`createOrUpdateIssuer` passes `metadataSigner` to `createIssuer` only. On an existing record it takes the `updateIssuerMetadata` path, and Credo's `updateIssuer` re-signs `signedMetadata` only `if (issuer.signedMetadata)` - it cannot introduce one (`OpenId4VcIssuerService.mjs`, `updateIssuer` vs `createIssuer`). So a record first created without the option stays unsigned for good.

This throws at initialization instead, naming the record and what to do about it. Small change, but it turns a silent no-op into something you find in thirty seconds rather than an evening.

## How this was found

On the playground demo cast, `demo-issuer-accredited` resolves TRUSTED with a valid ISSUER permission on the DemoCredential schema, and Paradym still rendered "Unknown Organization" for it. Chasing that:

- `v1.12.0-oidc4vc.6` (this branch, with #536 and #537) is a real improvement: the issuer no longer crashes at boot under `metadataSigner: "did"` as it did on `.5`, and its development key is now published under **both** `authentication` and `assertionMethod`, which is what `buildMetadataSigner` needs.
- Even so, `signed_metadata` is still absent, because of the update path above.
- Forcing a fresh record by renaming the issuer id does make the option apply, but the agent then fails to become ready and the service goes 503. Twice, with the key correctly published both times. I could not read the boot error - the pod dies before serving and I have no cluster access - so **I am not proposing a fix for that here**; it is a separate problem and it needs the crashloop logs.

Worth noting the two are linked: if the update path could adopt the configured signer, recreating the record would not be necessary and the crash would not be on the critical path. That needs `encodeJwtIssuer`, which Credo does not export, so it is not a change I can make from here.

No test added - the package has no suite wired up in this repo and I did not want to introduce one in a fix this size.