### PR TITLE
fix(openid4vc): record the dev signing key's KMS key id on the DID record

### DIFF
--- a/packages/plugin-openid4vc/src/services/CertificateService.ts
+++ b/packages/plugin-openid4vc/src/services/CertificateService.ts
@@ -1,9 +1,10 @@
 import type { OpenId4VcSigningOptions } from '../types'
-import type { DidPurpose } from '@credo-ts/core'
+import type { BaseAgent, DidPurpose } from '@credo-ts/core'
 
 import {
-  type BaseAgent,
+  AgentContext,
   DidDocument,
+  DidRepository,
   Kms,
   tryParseDid,
   VerificationMethod,
@@ -58,6 +59,7 @@ export interface SigningCertificateHandle {
 type DevelopmentDidAgent = {
   did?: string
   dids: Pick<BaseAgent['dids'], 'resolve' | 'update'>
+  dependencyManager: BaseAgent['dependencyManager']
 }
 
 export async function loadSigningCertificate(
@@ -115,6 +117,7 @@ export async function publishDevelopmentSigningKey(
   const basePurpose: DidPurpose = role === 'issuer' ? 'assertionMethod' : 'authentication'
   const purposes = [...new Set<DidPurpose>([basePurpose, ...extraPurposes])]
   const publicJwk = canonicalP256PublicJwk(signingCertificate.certificate.publicJwk.toJson())
+  await ensureCreatedDidRecordKeyMapping(agent, did, methodId, signingCertificate.keyId)
   const existingMethod = resolution.didDocument.verificationMethod?.find(method => method.id === methodId)
   const published = (purpose: DidPurpose) =>
     (resolution.didDocument?.[purpose] ?? []).some(
@@ -157,6 +160,40 @@ export async function publishDevelopmentSigningKey(
   if (update.didState.did !== did || update.didState.didDocument.id !== did) {
     throw new Error('development signing key DID update returned a different DID')
   }
+}
+
+/**
+ * Credo signs "through the DID" by mapping the verification method to a KMS key via the created
+ * DidRecord's `keys` entries (`didDocumentRelativeKeyId` → `kmsKeyId`) — the `kid` published in the
+ * DID document is never consulted, and the fallback is a legacy base58 key id no Askar backend
+ * holds. Registrars do not maintain that mapping on `dids.update` (did:webvh drops `options.keys`
+ * entirely), so record it on the DidRecord directly — also when the method itself is already
+ * published, which repairs documents written by earlier builds.
+ */
+async function ensureCreatedDidRecordKeyMapping(
+  agent: DevelopmentDidAgent,
+  did: string,
+  methodId: string,
+  kmsKeyId: string,
+): Promise<void> {
+  const agentContext = agent.dependencyManager.resolve(AgentContext)
+  const didRepository = agent.dependencyManager.resolve(DidRepository)
+  const didRecord = await didRepository.findCreatedDid(agentContext, did)
+  if (!didRecord) throw new Error('development signing key DID record was not found')
+
+  const didDocumentRelativeKeyId = methodId.slice(did.length)
+  const keys = didRecord.keys ?? []
+  if (
+    keys.some(key => key.didDocumentRelativeKeyId === didDocumentRelativeKeyId && key.kmsKeyId === kmsKeyId)
+  ) {
+    return
+  }
+
+  didRecord.keys = [
+    ...keys.filter(key => key.didDocumentRelativeKeyId !== didDocumentRelativeKeyId),
+    { didDocumentRelativeKeyId, kmsKeyId },
+  ]
+  await didRepository.update(agentContext, didRecord)
 }
 
 async function loadConfiguredSigningCertificate(

--- a/packages/plugin-openid4vc/src/services/IssuerService.ts
+++ b/packages/plugin-openid4vc/src/services/IssuerService.ts
@@ -10,8 +10,11 @@ import type {
 import { ClaimFormat, RecordNotFoundError } from '@credo-ts/core'
 
 import { findCredentialConfiguration, parseOfferClaims } from '../config'
-import { StatusListService } from './StatusListService'
-import { findBoundVerificationMethodId, ownDidResolutionPolicy, verifyKeyBoundToDid } from '../trust/keyBinding'
+import {
+  findBoundVerificationMethodId,
+  ownDidResolutionPolicy,
+  verifyKeyBoundToDid,
+} from '../trust/keyBinding'
 
 import {
   didFromValidatedCertificate,
@@ -21,6 +24,7 @@ import {
   type SigningCertificateHandle,
   type SigningCertificateInfo,
 } from './CertificateService'
+import { StatusListService } from './StatusListService'
 
 type IssuerApi = Pick<
   OpenId4VcIssuerApi,
@@ -277,7 +281,7 @@ export class IssuerService {
       )
       if (!didUrl) {
         throw new Error(
-          'OpenID4VC issuer is configured to sign metadata with its DID, but the DID does not publish the signing key for assertionMethod',
+          'OpenID4VC issuer is configured to sign metadata with its DID, but the DID does not publish the signing key for authentication',
         )
       }
       return { method: 'did' as const, didUrl }

--- a/packages/plugin-openid4vc/src/services/VerifierService.ts
+++ b/packages/plugin-openid4vc/src/services/VerifierService.ts
@@ -38,7 +38,10 @@ type VerifierApi = Pick<
   | 'getVerifiedAuthorizationResponse'
 >
 
-export type OpenId4VcVerifierAgent = Pick<BaseAgent, 'dids' | 'genericRecords' | 'kms' | 'x509'> & {
+export type OpenId4VcVerifierAgent = Pick<
+  BaseAgent,
+  'dids' | 'genericRecords' | 'kms' | 'x509' | 'dependencyManager'
+> & {
   did?: string
   modules: {
     openId4Vc?: {

--- a/packages/plugin-openid4vc/tests/CertificateService.test.ts
+++ b/packages/plugin-openid4vc/tests/CertificateService.test.ts
@@ -1,6 +1,6 @@
 import type { OpenId4VcSigningOptions } from '../src/types'
 
-import { Kms, X509Certificate } from '@credo-ts/core'
+import { AgentContext, DidDocument, DidRepository, Kms, X509Certificate } from '@credo-ts/core'
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -168,6 +168,69 @@ describe('CertificateService', () => {
     expect(agent.dids.update).not.toHaveBeenCalled()
   })
 
+  it('records the KMS key id mapping on the created DID record when publishing', async () => {
+    const agent = createAgent({ developmentCertificate: fixtures.attacker })
+    agent.did = 'did:web:attacker.example'
+    agent.publicApiBaseUrl = 'https://attacker.example/agent'
+    const handle = await loadSigningCertificate(agent, {
+      development: { enabled: true, commonName: 'Development Agent' },
+    })
+    agent.dids.resolve.mockResolvedValue({
+      didDocument: DidDocument.fromJSON({ id: 'did:web:attacker.example' }),
+    })
+    agent.dids.update.mockImplementation(async ({ did, didDocument }) => ({
+      didState: { state: 'finished', did, didDocument },
+    }))
+
+    await publishDevelopmentSigningKey(agent, handle, 'issuer')
+
+    expect(agent.dids.update).toHaveBeenCalledTimes(1)
+    expect(agent.didRepository.update).toHaveBeenCalledTimes(1)
+    expect(agent.didRecord.keys).toEqual([
+      { didDocumentRelativeKeyId: '#openid4vc-development-issuer', kmsKeyId: handle.keyId },
+    ])
+  })
+
+  it('repairs a missing KMS key id mapping even when the method is already published', async () => {
+    const agent = createAgent({ developmentCertificate: fixtures.attacker })
+    agent.did = 'did:web:attacker.example'
+    agent.publicApiBaseUrl = 'https://attacker.example/agent'
+    const handle = await loadSigningCertificate(agent, {
+      development: { enabled: true, commonName: 'Development Agent' },
+    })
+    agent.dids.resolve.mockResolvedValue({
+      didDocument: publishedDidDocument('did:web:attacker.example', handle.keyId),
+    })
+
+    await publishDevelopmentSigningKey(agent, handle, 'issuer')
+
+    expect(agent.dids.update).not.toHaveBeenCalled()
+    expect(agent.didRepository.update).toHaveBeenCalledTimes(1)
+    expect(agent.didRecord.keys).toEqual([
+      { didDocumentRelativeKeyId: '#openid4vc-development-issuer', kmsKeyId: handle.keyId },
+    ])
+  })
+
+  it('leaves the DID record untouched when the mapping is already correct', async () => {
+    const agent = createAgent({ developmentCertificate: fixtures.attacker })
+    agent.did = 'did:web:attacker.example'
+    agent.publicApiBaseUrl = 'https://attacker.example/agent'
+    const handle = await loadSigningCertificate(agent, {
+      development: { enabled: true, commonName: 'Development Agent' },
+    })
+    agent.didRecord.keys = [
+      { didDocumentRelativeKeyId: '#openid4vc-development-issuer', kmsKeyId: handle.keyId },
+    ]
+    agent.dids.resolve.mockResolvedValue({
+      didDocument: publishedDidDocument('did:web:attacker.example', handle.keyId),
+    })
+
+    await publishDevelopmentSigningKey(agent, handle, 'issuer')
+
+    expect(agent.dids.update).not.toHaveBeenCalled()
+    expect(agent.didRepository.update).not.toHaveBeenCalled()
+  })
+
   it('extracts the DID URI SAN from a validated certificate', () => {
     expect(didFromValidatedCertificate(fixtures.leaf)).toBe('did:web:issuer.example')
   })
@@ -299,6 +362,21 @@ function configuredSigning(
   }
 }
 
+function publishedDidDocument(did: string, kmsKeyId: string): DidDocument {
+  return DidDocument.fromJSON({
+    id: did,
+    verificationMethod: [
+      {
+        id: `${did}#openid4vc-development-issuer`,
+        type: 'JsonWebKey2020',
+        controller: did,
+        publicKeyJwk: { ...publicJwk(OTHER_PRIVATE_JWK), kid: kmsKeyId },
+      },
+    ],
+    assertionMethod: [`${did}#openid4vc-development-issuer`],
+  })
+}
+
 function publicJwk(privateJwk: Kms.KmsJwkPrivateEc): Kms.KmsJwkPublicEc {
   return {
     kty: privateJwk.kty,
@@ -381,12 +459,31 @@ function createAgent({
     }),
   }
 
+  const didRecord = {
+    keys: undefined as { didDocumentRelativeKeyId: string; kmsKeyId: string }[] | undefined,
+  }
+  const didRepository = {
+    findCreatedDid: vi.fn(async () => didRecord),
+    update: vi.fn(async () => undefined),
+  }
+  const agentContext = {}
+  const dependencyManager = {
+    resolve: vi.fn((token: unknown) => {
+      if (token === DidRepository) return didRepository
+      if (token === AgentContext) return agentContext
+      throw new Error('unexpected dependency requested in test')
+    }),
+  }
+
   const agent = {
     keys,
     dids: { resolve: vi.fn(), update: vi.fn() },
     kms,
     genericRecords,
     x509,
+    dependencyManager,
+    didRepository,
+    didRecord,
     did: undefined as string | undefined,
     publicApiBaseUrl: undefined as string | undefined,
   }

--- a/packages/plugin-openid4vc/tests/DevelopmentSigningDidPublication.test.ts
+++ b/packages/plugin-openid4vc/tests/DevelopmentSigningDidPublication.test.ts
@@ -13,6 +13,9 @@ import {
   Agent,
   ConsoleLogger,
   DidDocument,
+  DidDocumentRole,
+  DidRecord,
+  DidRepository,
   DidsModule,
   JsonTransformer,
   LogLevel,
@@ -118,6 +121,9 @@ describe('development signing DID publication', () => {
     expect(verificationMethodIds(document)).toContain(methodId)
     expect(relationshipIds(document.assertionMethod)).toContain(methodId)
     expect(relationshipIds(document.authentication)).toEqual([`${DID_WEB}#${EXISTING_METHOD_SUFFIX}`])
+    expect(await createdDidRecordKeys(agent, DID_WEB)).toEqual([
+      { didDocumentRelativeKeyId: '#openid4vc-development-issuer', kmsKeyId: expect.any(String) },
+    ])
   })
 
   it('publishes the generated verifier key through the generic DID API for did:webvh', async () => {
@@ -130,6 +136,9 @@ describe('development signing DID publication', () => {
     expect(verificationMethodIds(document)).toContain(methodId)
     expect(relationshipIds(document.authentication)).toContain(methodId)
     expect(relationshipIds(document.assertionMethod)).toEqual([`${DID_WEBVH}#${EXISTING_METHOD_SUFFIX}`])
+    expect(await createdDidRecordKeys(agent, DID_WEBVH)).toEqual([
+      { didDocumentRelativeKeyId: '#openid4vc-development-verifier', kmsKeyId: expect.any(String) },
+    ])
   })
 
   it('preserves both role relationships when issuer and verifier share one DID', async () => {
@@ -141,6 +150,15 @@ describe('development signing DID publication', () => {
     expect(relationshipIds(document.assertionMethod)).toContain(`${DID_WEB}#openid4vc-development-issuer`)
     expect(relationshipIds(document.authentication)).toContain(`${DID_WEB}#openid4vc-development-verifier`)
     expect(registry.updateCount).toBe(2)
+    const keys = await createdDidRecordKeys(agent, DID_WEB)
+    expect(keys).toContainEqual({
+      didDocumentRelativeKeyId: '#openid4vc-development-issuer',
+      kmsKeyId: expect.any(String),
+    })
+    expect(keys).toContainEqual({
+      didDocumentRelativeKeyId: '#openid4vc-development-verifier',
+      kmsKeyId: expect.any(String),
+    })
   })
 
   it('reuses persisted development keys without updating an already-published DID', async () => {
@@ -220,6 +238,12 @@ async function createHarness(
   }) as TestAgent
   agent.did = did
   await agent.initialize()
+  await agent.dependencyManager
+    .resolve(DidRepository)
+    .save(
+      agent.context,
+      new DidRecord({ did, role: DidDocumentRole.Created, didDocument: initialDidDocument(did) }),
+    )
   agents.push(agent)
   return { agent, plugin, registry, options }
 }
@@ -279,6 +303,11 @@ function initialDidDocument(did: string): DidDocument {
     },
     DidDocument,
   )
+}
+
+async function createdDidRecordKeys(agent: TestAgent, did: string) {
+  const record = await agent.dependencyManager.resolve(DidRepository).findCreatedDid(agent.context, did)
+  return record?.keys
 }
 
 function cloneDidDocument(document: DidDocument): DidDocument {


### PR DESCRIPTION
Part of #535.

metadataSigner: "did" crashes a fresh issuer at boot, and requestSigner: "did" makes every request 500. Same error both times: KeyManagementKeyNotFoundError on a legacy base58 key id. Credo looks up the signing key through the DID record's keys mapping and never reads the kid we publish in the document. Nothing ever writes that mapping: the plugin's dids.update passes no keys, and the webvh registrar drops them anyway. So Credo falls back to a legacy id askar doesn't hold, and signing dies. The issuer signs at boot so it crashloops, the verifier signs per request so it starts fine and then 500s.

The fix: publishDevelopmentSigningKey now writes the mapping on the DID record itself. Idempotent, and it also runs when the key is already published, so agents already deployed repair themselves on their next boot with no config change. Also fixed the buildMetadataSigner error message that said assertionMethod while actually checking authentication.

Tested by overlaying the rebuilt plugin on the released .6 image with the exact config that crashed the cast: unfixed it dies at boot, fixed it boots green, publishes DID-signed metadata and mints requests with a did client_id. 210/210 plugin tests.
