### PR TITLE
fix(model): map v4 networks to their v4 indexer schema routes

### DIFF
--- a/packages/model/src/utils/ecs.ts
+++ b/packages/model/src/utils/ecs.ts
@@ -5,19 +5,25 @@ export enum ECS {
   USER_AGENT = 'ecs-user-agent',
 }
 
-const urlMap = new Map<string, string>([
-  ['vpr:verana:vna-mainnet-1', 'https://idx.testnet.verana.network/verana'],
-  ['vpr:verana:vna-testnet-1', 'https://idx.testnet.verana.network/verana'],
-  ['vpr:verana:vna-devnet-1', 'https://idx.devnet.verana.network/verana'],
+// v3 indexers serve the Cosmos REST namespace under /verana/*; v4 indexers
+// drop those paths and serve /v4/* routes on the same host.
+const networkMap = new Map<string, { base: string; api: 'v3' | 'v4' }>([
+  ['vpr:verana:vna-mainnet-1', { base: 'https://idx.testnet.verana.network', api: 'v3' }],
+  ['vpr:verana:vna-testnet-1', { base: 'https://idx.testnet.verana.network', api: 'v3' }],
+  ['vpr:verana:vna-devnet-1', { base: 'https://idx.devnet.verana.network', api: 'v4' }],
 ])
 
 export function mapToEcosystem(input: string): string {
   const canonical = input.match(/^(vpr:verana:[^:/]+):cs:(\d+)$/)
   if (canonical) input = `${canonical[1]}/cs/v1/js/${canonical[2]}`
-  for (const [key, value] of urlMap.entries()) {
-    if (input.includes(key)) {
-      input = input.replace(key, value)
+  for (const [key, network] of networkMap.entries()) {
+    if (!input.includes(key)) continue
+    if (network.api === 'v4') {
+      const js = input.match(/\/cs\/v1\/js\/(\d+)/)
+      if (js) return `${network.base}/v4/credential-schema/js/${js[1]}`
+      return input.replace(key, `${network.base}/v4`)
     }
+    return input.replace(key, `${network.base}/verana`)
   }
   return input
 }

--- a/packages/model/tests/ecs.test.ts
+++ b/packages/model/tests/ecs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { mapToEcosystem } from '../src/utils/ecs'
+
+describe('mapToEcosystem', () => {
+  it('maps a canonical testnet schema id to the v3 indexer js path', () => {
+    expect(mapToEcosystem('vpr:verana:vna-testnet-1:cs:170')).toBe(
+      'https://idx.testnet.verana.network/verana/cs/v1/js/170',
+    )
+  })
+
+  it('maps an expanded testnet schema ref to the v3 indexer', () => {
+    expect(mapToEcosystem('vpr:verana:vna-testnet-1/cs/v1/js/170')).toBe(
+      'https://idx.testnet.verana.network/verana/cs/v1/js/170',
+    )
+  })
+
+  it('maps a canonical devnet schema id to the v4 credential-schema js path', () => {
+    expect(mapToEcosystem('vpr:verana:vna-devnet-1:cs:5')).toBe(
+      'https://idx.devnet.verana.network/v4/credential-schema/js/5',
+    )
+  })
+
+  it('maps an expanded devnet schema ref to the v4 credential-schema js path', () => {
+    expect(mapToEcosystem('vpr:verana:vna-devnet-1/cs/v1/js/5')).toBe(
+      'https://idx.devnet.verana.network/v4/credential-schema/js/5',
+    )
+  })
+
+  it('maps other devnet paths onto the v4 base', () => {
+    expect(mapToEcosystem('vpr:verana:vna-devnet-1/participant/list')).toBe(
+      'https://idx.devnet.verana.network/v4/participant/list',
+    )
+  })
+
+  it('returns unknown networks unchanged', () => {
+    expect(mapToEcosystem('vpr:verana:vna-unknown-1:cs:1')).toBe('vpr:verana:vna-unknown-1/cs/v1/js/1')
+  })
+
+  it('returns non-vpr URLs unchanged', () => {
+    expect(mapToEcosystem('https://example.com/schemas/service.json')).toBe(
+      'https://example.com/schemas/service.json',
+    )
+  })
+})


### PR DESCRIPTION
**Changes**
- `mapToEcosystem` still pointed every network at v3 `/verana/*` REST paths. v4 indexers (devnet today) drop those paths and serve `/v4/*` routes on the same host, so devnet schema refs resolved to dead URLs (`https://idx.devnet.verana.network/verana/cs/v1/js/{id}` → 404) and ECS credential classification (`resolveVTCType` / `resolveJSCType`) failed for any credential anchored in a v4 network — the public UI then falls back to the classic view.
- The network map now carries the API version per network: v4 schema refs (canonical `vpr:…:cs:{id}` and expanded `…/cs/v1/js/{id}`) resolve to `{base}/v4/credential-schema/js/{id}`; other v4 paths map onto `{base}/v4`; v3 networks (mainnet placeholder, testnet) keep the `/verana/cs/v1/js` behavior unchanged.
- Added unit tests for `mapToEcosystem` covering canonical/expanded refs on v3 and v4 networks, unknown networks and non-vpr URLs.

**Testing**
- `npx vitest run packages/model/tests/ecs.test.ts` — 7 tests pass.
- `pnpm build` in `packages/model` passes.
- Verified live that `https://idx.devnet.verana.network/v4/credential-schema/js/1` returns the schema JSON while the old `/verana/cs/v1/js/1` path 404s, and that the testnet URLs are unchanged.

## Checklist
- [x] I have commented on my code, especially in areas that are hard to understand.
- [x] I have added only changes relevant to the issue in question.
- [x] I have added tests to confirm that my fix is effective or that my feature works as intended.
- [ ] I have modified existing tests as needed to accommodate my changes.
- [ ] I have flagged specific areas for further review, if necessary.
- [ ] I have updated the documentation where necessary.