### PR TITLE
feat: openid4vc in default image

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -124,9 +124,6 @@ jobs:
           - image: vs-agent
             dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent
-          - image: vs-agent-openid4vc
-            dockerfile: ./apps/vs-agent/Dockerfile
-            target: vs-agent-openid4vc
           - image: vs-agent-mrtd
             dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent-mrtd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
           - dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent
           - dockerfile: ./apps/vs-agent/Dockerfile
-            target: vs-agent-openid4vc
-          - dockerfile: ./apps/vs-agent/Dockerfile
             target: vs-agent-mrtd
           - dockerfile: ./examples/chatbot/Dockerfile
           - dockerfile: ./examples/verifier/Dockerfile

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ VS Agent is a web application that can be used as a framework for building conve
 - Hands-on client for easy integrations in existing backends using NestJS
 - Plugin architecture: load only the features you need (`chat`, `mrtd`, `openid4vc`) via `VS_AGENT_PLUGINS`
 
-The OpenID4VC plugin provides `dc+sd-jwt` issuance and presentation groundwork. Use the `vs-agent-openid4vc` Docker target and see the [operator documentation](./packages/plugin-openid4vc/README.md).
+The OpenID4VC plugin provides `dc+sd-jwt` issuance and presentation groundwork. It ships in the standard `vs-agent` image but is disabled by default; add `openid4vc` to `VS_AGENT_PLUGINS` to enable it and see the [operator documentation](./packages/plugin-openid4vc/README.md).
 
 ---
 

--- a/apps/vs-agent/Dockerfile
+++ b/apps/vs-agent/Dockerfile
@@ -2,47 +2,8 @@ FROM node:22.19-slim AS base
 ENV COREPACK_INTEGRITY_KEYS=0
 RUN corepack enable && corepack prepare pnpm@9.15.3 --activate
 
-# Build: vs-agent (messaging + chat)
+# Build: vs-agent (messaging + chat, openid4vc available but disabled by default)
 FROM base AS build-vs-agent
-WORKDIR /www
-ENV RUN_MODE="docker"
-
-COPY patches ./patches
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.json tsconfig.build.json ./
-COPY packages/model/package.json packages/model/package.json
-COPY packages/agent-sdk/package.json packages/agent-sdk/package.json
-COPY packages/plugin-chat/package.json packages/plugin-chat/package.json
-COPY packages/vt-flow/package.json packages/vt-flow/package.json
-COPY apps/vs-agent/package.json apps/vs-agent/package.json
-COPY apps/vs-agent-ui/package.json apps/vs-agent-ui/package.json
-
-# plugin-mrtd package.json intentionally absent — its deps won't be installed
-RUN pnpm install --no-frozen-lockfile
-
-COPY packages/model/src packages/model/src
-COPY packages/model/tsconfig.json packages/model/tsconfig.build.json packages/model/
-COPY packages/agent-sdk/src packages/agent-sdk/src
-COPY packages/agent-sdk/tsconfig.json packages/agent-sdk/tsconfig.build.json packages/agent-sdk/
-COPY packages/plugin-chat/src packages/plugin-chat/src
-COPY packages/plugin-chat/tsconfig.build.json packages/plugin-chat/
-COPY packages/vt-flow/src packages/vt-flow/src
-COPY packages/vt-flow/tsconfig.json packages/vt-flow/tsconfig.build.json packages/vt-flow/
-COPY apps/vs-agent/src apps/vs-agent/src
-COPY apps/vs-agent/discovery.json apps/vs-agent/tsconfig.json apps/vs-agent/tsconfig.build.json apps/vs-agent/nest-cli.json apps/vs-agent/
-COPY apps/vs-agent-ui/src apps/vs-agent-ui/src
-COPY apps/vs-agent-ui/index.html apps/vs-agent-ui/vite.config.js apps/vs-agent-ui/tsconfig.json apps/vs-agent-ui/
-
-RUN pnpm --filter @verana-labs/vs-agent-model build && \
-    pnpm --filter @verana-labs/credo-ts-didcomm-vt-flow build && \
-    pnpm --filter @verana-labs/vs-agent-sdk build && \
-    pnpm --filter @verana-labs/vs-agent-plugin-chat build && \
-    pnpm --filter @verana-labs/vs-agent-ui build && \
-    pnpm --filter @verana-labs/vs-agent build
-
-RUN --mount=type=bind,source=scripts/docker-cleanup.sh,target=/tmp/cleanup.sh sh /tmp/cleanup.sh
-
-# Build: vs-agent (messaging + chat + openid4vc)
-FROM base AS build-openid4vc
 WORKDIR /www
 ENV RUN_MODE="docker"
 
@@ -126,7 +87,8 @@ RUN pnpm --filter @verana-labs/vs-agent-model build && \
 
 RUN --mount=type=bind,source=scripts/docker-cleanup.sh,target=/tmp/cleanup.sh sh /tmp/cleanup.sh
 
-# Final: vs-agent (messaging + chat)
+# Final: vs-agent (messaging + chat; the openid4vc plugin ships in the image
+# but stays disabled unless added to VS_AGENT_PLUGINS at runtime)
 FROM node:22.19-slim AS vs-agent
 WORKDIR /www
 ENV RUN_MODE="docker"
@@ -141,40 +103,15 @@ COPY --from=build-vs-agent /www/packages/agent-sdk/node_modules ./packages/agent
 COPY --from=build-vs-agent /www/packages/plugin-chat/package.json ./packages/plugin-chat/package.json
 COPY --from=build-vs-agent /www/packages/plugin-chat/build ./packages/plugin-chat/build
 COPY --from=build-vs-agent /www/packages/plugin-chat/node_modules ./packages/plugin-chat/node_modules
+COPY --from=build-vs-agent /www/packages/plugin-openid4vc/package.json ./packages/plugin-openid4vc/package.json
+COPY --from=build-vs-agent /www/packages/plugin-openid4vc/build ./packages/plugin-openid4vc/build
+COPY --from=build-vs-agent /www/packages/plugin-openid4vc/node_modules ./packages/plugin-openid4vc/node_modules
 COPY --from=build-vs-agent /www/packages/vt-flow/package.json ./packages/vt-flow/package.json
 COPY --from=build-vs-agent /www/packages/vt-flow/build ./packages/vt-flow/build
 COPY --from=build-vs-agent /www/apps/vs-agent/node_modules ./apps/vs-agent/node_modules
 COPY apps/vs-agent/package.json ./apps/vs-agent/package.json
 COPY --from=build-vs-agent /www/apps/vs-agent/build ./apps/vs-agent/build
 COPY --from=build-vs-agent /www/apps/vs-agent/public ./apps/vs-agent/public
-COPY apps/vs-agent/discovery.json ./apps/vs-agent/discovery.json
-
-CMD ["node", "apps/vs-agent/build/src/main"]
-
-# Final: vs-agent-openid4vc (messaging + chat + openid4vc)
-FROM node:22.19-slim AS vs-agent-openid4vc
-WORKDIR /www
-ENV RUN_MODE="docker"
-ENV VS_AGENT_PLUGINS=messaging,chat,openid4vc
-
-COPY --from=build-openid4vc /www/node_modules ./node_modules
-COPY --from=build-openid4vc /www/packages/model/package.json ./packages/model/package.json
-COPY --from=build-openid4vc /www/packages/model/build ./packages/model/build
-COPY --from=build-openid4vc /www/packages/agent-sdk/package.json ./packages/agent-sdk/package.json
-COPY --from=build-openid4vc /www/packages/agent-sdk/build ./packages/agent-sdk/build
-COPY --from=build-openid4vc /www/packages/agent-sdk/node_modules ./packages/agent-sdk/node_modules
-COPY --from=build-openid4vc /www/packages/plugin-chat/package.json ./packages/plugin-chat/package.json
-COPY --from=build-openid4vc /www/packages/plugin-chat/build ./packages/plugin-chat/build
-COPY --from=build-openid4vc /www/packages/plugin-chat/node_modules ./packages/plugin-chat/node_modules
-COPY --from=build-openid4vc /www/packages/plugin-openid4vc/package.json ./packages/plugin-openid4vc/package.json
-COPY --from=build-openid4vc /www/packages/plugin-openid4vc/build ./packages/plugin-openid4vc/build
-COPY --from=build-openid4vc /www/packages/plugin-openid4vc/node_modules ./packages/plugin-openid4vc/node_modules
-COPY --from=build-openid4vc /www/packages/vt-flow/package.json ./packages/vt-flow/package.json
-COPY --from=build-openid4vc /www/packages/vt-flow/build ./packages/vt-flow/build
-COPY --from=build-openid4vc /www/apps/vs-agent/node_modules ./apps/vs-agent/node_modules
-COPY apps/vs-agent/package.json ./apps/vs-agent/package.json
-COPY --from=build-openid4vc /www/apps/vs-agent/build ./apps/vs-agent/build
-COPY --from=build-openid4vc /www/apps/vs-agent/public ./apps/vs-agent/public
 COPY apps/vs-agent/discovery.json ./apps/vs-agent/discovery.json
 
 CMD ["node", "apps/vs-agent/build/src/main"]

--- a/apps/vs-agent/README.md
+++ b/apps/vs-agent/README.md
@@ -228,7 +228,7 @@ VS Agent uses an opt-in plugin architecture. Each plugin is an independent packa
 | `messaging` | _(built-in)_                             | Base credential and proof handlers. Always loaded — cannot be disabled.                                                                                    |
 | `chat`      | `@verana-labs/vs-agent-plugin-chat`      | Chat protocols: text messages, media, reactions, receipts, calls, action menus, user profile.                                                              |
 | `mrtd`      | `@verana-labs/vs-agent-plugin-mrtd`      | eMRTD / ePassport verification. Requires the `vs-agent-mrtd` Docker image.                                                                                 |
-| `openid4vc` | `@verana-labs/vs-agent-plugin-openid4vc` | `dc+sd-jwt` issuance and presentation. Requires the `vs-agent-openid4vc` Docker image and [JSON configuration](../../packages/plugin-openid4vc/README.md). |
+| `openid4vc` | `@verana-labs/vs-agent-plugin-openid4vc` | `dc+sd-jwt` issuance and presentation. Ships in the standard `vs-agent` image (disabled by default) and requires [JSON configuration](../../packages/plugin-openid4vc/README.md). |
 
 ### Selecting plugins
 
@@ -290,11 +290,10 @@ First
 
 The Dockerfile produces separate targets for the optional protocol plugins. Choose the one that matches your needs:
 
-| Target               | Image                  | Plugins included             |
-| -------------------- | ---------------------- | ---------------------------- |
-| `vs-agent`           | `2060io/vs-agent`      | messaging + chat             |
-| `vs-agent-mrtd`      | `2060io/vs-agent-mrtd` | messaging + chat + mrtd      |
-| `vs-agent-openid4vc` | local build target     | messaging + chat + openid4vc |
+| Target          | Image                  | Plugins included                                                    |
+| --------------- | ---------------------- | ------------------------------------------------------------------- |
+| `vs-agent`      | `2060io/vs-agent`      | messaging + chat (openid4vc shipped, enable via `VS_AGENT_PLUGINS`) |
+| `vs-agent-mrtd` | `2060io/vs-agent-mrtd` | messaging + chat + mrtd                                             |
 
 #### Building locally
 
@@ -304,10 +303,9 @@ The build context must be the **monorepo root**, not the `apps/vs-agent` directo
 # From the repository root
 docker build --target vs-agent      -t vs-agent      -f apps/vs-agent/Dockerfile .
 docker build --target vs-agent-mrtd -t vs-agent-mrtd -f apps/vs-agent/Dockerfile .
-docker build --target vs-agent-openid4vc -t vs-agent-openid4vc -f apps/vs-agent/Dockerfile .
 ```
 
-The OpenID4VC target requires a mounted JSON file and `OID4VC_CONFIG_FILE`. See the [OpenID4VC operator documentation](../../packages/plugin-openid4vc/README.md).
+Enabling the OpenID4VC plugin (`VS_AGENT_PLUGINS=messaging,chat,openid4vc`) requires a mounted JSON file and `OID4VC_CONFIG_FILE`. See the [OpenID4VC operator documentation](../../packages/plugin-openid4vc/README.md).
 
 #### Running a container
 
@@ -329,7 +327,7 @@ services:
     build:
       context: ../.. # repository root
       dockerfile: ./apps/vs-agent/Dockerfile
-      target: vs-agent # choose vs-agent, vs-agent-mrtd, or vs-agent-openid4vc
+      target: vs-agent # choose vs-agent or vs-agent-mrtd
     environment:
       - AGENT_PUBLIC_DID=did:web:myagent.example.com
       - EVENTS_BASE_URL=http://my-backend:5000

--- a/charts/vs-agent/values.yaml
+++ b/charts/vs-agent/values.yaml
@@ -48,13 +48,14 @@ database:
       cpu: 500m
       memory: 512Mi
 
-# OpenID4VC plugin configuration (requires the vs-agent-openid4vc image).
-# When config is non-empty it is rendered into a ConfigMap, mounted read-only,
-# and OID4VC_CONFIG_FILE points at it. The JSON must NOT contain
+# OpenID4VC plugin configuration. The plugin ships in the standard vs-agent
+# image but is disabled by default: set plugins to enable it. When config is
+# non-empty it is rendered into a ConfigMap, mounted read-only, and
+# OID4VC_CONFIG_FILE points at it. The JSON must NOT contain
 # publicApiBaseUrl (injected by VS Agent from PUBLIC_API_BASE_URL).
 oid4vc:
   config: "" # openid4vc.json content as a string
-  plugins: "" # optional VS_AGENT_PLUGINS override, e.g. "messaging,chat,openid4vc" (the openid4vc image already defaults to it)
+  plugins: "" # VS_AGENT_PLUGINS override, e.g. "messaging,chat,openid4vc" (required to activate the plugin)
 
 redis:
   enabled: false

--- a/packages/plugin-openid4vc/README.md
+++ b/packages/plugin-openid4vc/README.md
@@ -14,14 +14,14 @@ This is implementation groundwork, not EUDI certification or a claim of complete
 
 ## Configure VS Agent
 
-Use the `vs-agent-openid4vc` image target. It enables `messaging,chat,openid4vc` and requires `OID4VC_CONFIG_FILE`:
+The plugin ships in the standard `vs-agent` image but is disabled by default. Enable it with `VS_AGENT_PLUGINS=messaging,chat,openid4vc`, which requires `OID4VC_CONFIG_FILE`:
 
 The commands below explicitly select the Colima Docker context. Omit `--context colima` when the active Docker context already points to the intended engine.
 
 ```bash
 docker --context colima build \
-  --target vs-agent-openid4vc \
-  -t vs-agent-openid4vc:dev \
+  --target vs-agent \
+  -t vs-agent:dev \
   -f apps/vs-agent/Dockerfile .
 
 docker --context colima run --rm \
@@ -30,7 +30,8 @@ docker --context colima run --rm \
   -v "$PWD/openid4vc.json:/run/config/openid4vc.json:ro" \
   -p 3000:3000 \
   -p 3001:3001 \
-  vs-agent-openid4vc:dev
+  -e VS_AGENT_PLUGINS=messaging,chat,openid4vc \
+  vs-agent:dev
 ```
 
 Run both commands from the monorepo root. `env-vars` must set an HTTPS `PUBLIC_API_BASE_URL`, an `AGENT_PUBLIC_DID`, and the normal VS Agent wallet and deployment settings. The JSON file must not contain `publicApiBaseUrl`; VS Agent injects the trusted value from `PUBLIC_API_BASE_URL`. An HTTPS base path is supported and is used verbatim when composing protocol URLs. URLs containing a username or password are rejected.


### PR DESCRIPTION
Merges `feat/openid4vc-in-default-image` into `oidc4vc-uiprofile` (integration branch cut from `oidc4vc`), alongside #543 which brings the public service profile UI.

Once both are in, `oidc4vc-uiprofile` should be the branch to build integration images from (manual CD dispatch with a `publish_version` like `v1.12.0-oidc4vcui.1`; note the manual-publish workflow arrives with #543 — dispatch only after that merge, or the run has no `publish_version` input).