### PR TITLE
feat(vs-agent-ui): link the parent DID on the inherited Operated by card (oidc4vc-uiprofile)

### DIFF
--- a/apps/vs-agent-ui/src/App.css
+++ b/apps/vs-agent-ui/src/App.css
@@ -993,6 +993,14 @@ a.meta-chip:hover {
   word-break: break-all;
 }
 
+.op-parent {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-muted);
+  word-break: break-all;
+  margin-top: 8px;
+}
+
 .op-details {
   font-size: var(--text-sm);
   color: var(--color-muted);

--- a/apps/vs-agent-ui/src/components/Dashboard.jsx
+++ b/apps/vs-agent-ui/src/components/Dashboard.jsx
@@ -300,11 +300,11 @@ async function resolveParentController(serviceVc) {
     return fragment.startsWith('vpr') && fragment.endsWith('-c-vp')
   })
   const items = await Promise.all(cvpServices.map(resolveCVpService))
-  return (
+  const controller =
     items.find(i => i.type === 'ecs-org' && i.credentials.length > 0) ??
     items.find(i => i.type === 'ecs-persona' && i.credentials.length > 0) ??
     null
-  )
+  return controller ? { ...controller, parentDid: issuer } : null
 }
 
 /** ISO 3166-1 alpha-2 country code as an emoji flag (e.g. "CH"). */
@@ -541,6 +541,24 @@ function ControllerCard({ item, inherited, onSelect }) {
         </div>
       </div>
       {details && <p className="op-details">{details}</p>}
+      {inherited && item.parentDid && (
+        <p className="op-parent">
+          via{' '}
+          {didToUrl(item.parentDid) ? (
+            <a
+              className="subtle-link"
+              href={didToUrl(item.parentDid)}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Open the parent service page in a new window"
+            >
+              {item.parentDid}
+            </a>
+          ) : (
+            item.parentDid
+          )}
+        </p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Cherry-pick of the same commit as the `uiprofile` PR: when the Operated by controller is inherited, the card shows a small muted line with the DID of the parent (the issuer of the ECS-Service credential); clicking it opens the parent's vs-agent web interface in a new window. Non-web DIDs render as plain text.

Clean cherry-pick onto `oidc4vc-uiprofile` (on top of #547); vite production build passes.