### PR TITLE
fix(agent-sdk): sign webvh log proofs with a full verification-method reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
       "@credo-ts/askar": "0.7.1-pr-2704-20260630143332",
       "@credo-ts/openid4vc": "0.7.1-pr-2704-20260630143332",
       "@hyperledger/anoncreds-shared": "0.4.0"
+    },
+    "patchedDependencies": {
+      "@credo-ts/webvh@0.7.1-pr-2704-20260630143332": "patches/@credo-ts__webvh@0.7.1-pr-2704-20260630143332.patch"
     }
   }
 }

--- a/packages/agent-sdk/src/did/migrateWebVhLog.ts
+++ b/packages/agent-sdk/src/did/migrateWebVhLog.ts
@@ -51,7 +51,7 @@ class KmsSigner implements Signer {
   ) {}
 
   public getVerificationMethodId(): string {
-    return `did:key:${this.publicKeyMultibase}`
+    return `did:key:${this.publicKeyMultibase}#${this.publicKeyMultibase}`
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/agent-sdk/src/did/migrateWebVhVersionTime.ts
+++ b/packages/agent-sdk/src/did/migrateWebVhVersionTime.ts
@@ -50,7 +50,7 @@ class KmsSigner implements Signer {
   ) {}
 
   public getVerificationMethodId(): string {
-    return `did:key:${this.publicKeyMultibase}`
+    return `did:key:${this.publicKeyMultibase}#${this.publicKeyMultibase}`
   }
 
   public async sign(input: SigningInput): Promise<SigningOutput> {

--- a/patches/@credo-ts__webvh@0.7.1-pr-2704-20260630143332.patch
+++ b/patches/@credo-ts__webvh@0.7.1-pr-2704-20260630143332.patch
@@ -1,0 +1,11 @@
+--- a/build/dids/WebVhDidCryptoSigner.mjs
++++ b/build/dids/WebVhDidCryptoSigner.mjs
+@@ -23,7 +23,7 @@
+ 	* @returns The DID:key identifier as a string.
+ 	*/
+ 	getVerificationMethodId() {
+-		return `did:key:${this.publicKeyMultibase}`;
++		return `did:key:${this.publicKeyMultibase}#${this.publicKeyMultibase}`;
+ 	}
+ 	/**
+ 	* Signs the provided input document using the Ed25519 secret key.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,11 @@ overrides:
   '@credo-ts/openid4vc': 0.7.1-pr-2704-20260630143332
   libphonenumber-js: ^1.12.33
 
+patchedDependencies:
+  '@credo-ts/webvh@0.7.1-pr-2704-20260630143332':
+    hash: g3663txpx247txyoxjdkddf6ci
+    path: patches/@credo-ts__webvh@0.7.1-pr-2704-20260630143332.patch
+
 importers:
 
   .:
@@ -94,7 +99,7 @@ importers:
         version: 0.7.1-pr-2704-20260630143332(typescript@5.7.2)
       '@credo-ts/webvh':
         specifier: 0.7.1-pr-2704-20260630143332
-        version: 0.7.1-pr-2704-20260630143332(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.7.2)
+        version: 0.7.1-pr-2704-20260630143332(patch_hash=g3663txpx247txyoxjdkddf6ci)(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.7.2)
       '@hyperledger/anoncreds-nodejs':
         specifier: 0.4.0
         version: 0.4.0
@@ -481,7 +486,7 @@ importers:
         version: 0.7.1-pr-2704-20260630143332(typescript@5.8.3)
       '@credo-ts/webvh':
         specifier: 0.7.1-pr-2704-20260630143332
-        version: 0.7.1-pr-2704-20260630143332(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.8.3)
+        version: 0.7.1-pr-2704-20260630143332(patch_hash=g3663txpx247txyoxjdkddf6ci)(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.8.3)
       '@hyperledger/anoncreds-nodejs':
         specifier: 0.4.0
         version: 0.4.0
@@ -6819,7 +6824,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@credo-ts/webvh@0.7.1-pr-2704-20260630143332(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.7.2)':
+  '@credo-ts/webvh@0.7.1-pr-2704-20260630143332(patch_hash=g3663txpx247txyoxjdkddf6ci)(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.7.2)':
     dependencies:
       '@credo-ts/anoncreds': 0.7.1-pr-2704-20260630143332(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.7.2)
       '@credo-ts/core': 0.7.1-pr-2704-20260630143332(typescript@5.7.2)
@@ -6834,7 +6839,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@credo-ts/webvh@0.7.1-pr-2704-20260630143332(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.8.3)':
+  '@credo-ts/webvh@0.7.1-pr-2704-20260630143332(patch_hash=g3663txpx247txyoxjdkddf6ci)(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.8.3)':
     dependencies:
       '@credo-ts/anoncreds': 0.7.1-pr-2704-20260630143332(@hyperledger/anoncreds-shared@0.4.0)(typescript@5.8.3)
       '@credo-ts/core': 0.7.1-pr-2704-20260630143332(typescript@5.8.3)


### PR DESCRIPTION
Closes part of #553.

Our webvh log entries are signed with `proof.verificationMethod: did:key:z6Mk…`, the bare DID with no fragment. Data Integrity expects a verification-method reference there, and the Swiss `didresolver` enforces it with `^did:key:z…#z…$`, so it rejects the **entire log** and the swiyu wallet cannot resolve any DID on the playground cast. Credo's own webvh resolver is lenient, which is why Paradym and Sphereon never hit it.

Both `KmsSigner`s now emit `did:key:<mk>#<mk>`. Unit tests pass (79); the six failing suites are the e2e ones that need a live chain, failing the same way on the base branch.

Worth knowing: this only fixes **newly created** logs. `rebuildWebVhLog` deliberately preserves entry #1, so the DIDs already published by the cast keep their malformed first proof and stay unresolvable for strict resolvers unless those DIDs are recreated (which would move every SCID and every on-chain permission bound to them). I did not touch the cast.