### PR TITLE
fix(openid4vc): declare the JsonWebKey2020 context and retry issuer init on the offer routes (oidc4vc-uiprofile)

### DIFF
--- a/packages/plugin-openid4vc/src/services/CertificateService.ts
+++ b/packages/plugin-openid4vc/src/services/CertificateService.ts
@@ -15,6 +15,7 @@ import { createHash } from 'node:crypto'
 
 const DEVELOPMENT_CERTIFICATE_VALIDITY_MS = 365 * 24 * 60 * 60 * 1_000
 const DEVELOPMENT_RECORD_PREFIX = 'openid4vc-development-signing'
+const JSON_WEB_KEY_2020_CONTEXT = 'https://w3id.org/security/suites/jws-2020/v1'
 export type SigningRole = 'issuer' | 'verifier'
 
 type CertificateAgent = Pick<BaseAgent, 'genericRecords' | 'kms' | 'x509'> & {
@@ -123,11 +124,19 @@ export async function publishDevelopmentSigningKey(
     (resolution.didDocument?.[purpose] ?? []).some(
       method => (typeof method === 'string' ? method : method.id) === methodId,
     )
-  if (existingMethod && equalVerificationMethodJwk(existingMethod, publicJwk) && purposes.every(published)) {
+  if (
+    existingMethod &&
+    equalVerificationMethodJwk(existingMethod, publicJwk) &&
+    purposes.every(published) &&
+    contextValues(resolution.didDocument.context).includes(JSON_WEB_KEY_2020_CONTEXT)
+  ) {
     return
   }
 
   const didDocument = DidDocument.fromJSON(resolution.didDocument.toJSON())
+  didDocument.context = [
+    ...new Set([...contextValues(didDocument.context), JSON_WEB_KEY_2020_CONTEXT]),
+  ]
   didDocument.verificationMethod = [
     ...(didDocument.verificationMethod ?? []).filter(method => method.id !== methodId),
     new VerificationMethod({
@@ -380,6 +389,11 @@ function canonicalP256PublicJwk(jwk: unknown): Kms.KmsJwkPublicEc & { crv: 'P-25
 
 function equalPublicJwk(left: Kms.KmsJwkPublicEc, right: Kms.KmsJwkPublicEc): boolean {
   return left.kty === right.kty && left.crv === right.crv && left.x === right.x && left.y === right.y
+}
+
+function contextValues(context: string | string[] | undefined): string[] {
+  if (!context) return []
+  return Array.isArray(context) ? context : [context]
 }
 
 function equalVerificationMethodJwk(method: VerificationMethod, expected: Kms.KmsJwkPublicEc): boolean {

--- a/packages/plugin-openid4vc/src/services/IssuerService.ts
+++ b/packages/plugin-openid4vc/src/services/IssuerService.ts
@@ -92,7 +92,7 @@ export class IssuerService {
     credentialConfigurationId: string,
     inputClaims: unknown,
   ): Promise<OpenId4VcOfferResult> {
-    this.assertInitialized()
+    await this.ensureInitialized()
     const configuration = findCredentialConfiguration(this.options, credentialConfigurationId)
     if (!configuration) {
       throw new OpenId4VcIssuerRequestError(`unknown credential configuration '${credentialConfigurationId}'`)
@@ -116,7 +116,7 @@ export class IssuerService {
   }
 
   public async getOfferState(id: string): Promise<OpenId4VcOfferState> {
-    this.assertInitialized()
+    await this.ensureInitialized()
 
     let session: OpenId4VcIssuanceSessionRecord
     try {

--- a/packages/plugin-openid4vc/tests/CertificateService.test.ts
+++ b/packages/plugin-openid4vc/tests/CertificateService.test.ts
@@ -191,6 +191,53 @@ describe('CertificateService', () => {
     ])
   })
 
+  it('declares the JsonWebKey2020 context alongside the published method', async () => {
+    const agent = createAgent({ developmentCertificate: fixtures.attacker })
+    agent.did = 'did:web:attacker.example'
+    agent.publicApiBaseUrl = 'https://attacker.example/agent'
+    const handle = await loadSigningCertificate(agent, {
+      development: { enabled: true, commonName: 'Development Agent' },
+    })
+    agent.dids.resolve.mockResolvedValue({
+      didDocument: DidDocument.fromJSON({
+        '@context': ['https://www.w3.org/ns/did/v1'],
+        id: 'did:web:attacker.example',
+      }),
+    })
+    agent.dids.update.mockImplementation(async ({ did, didDocument }) => ({
+      didState: { state: 'finished', did, didDocument },
+    }))
+
+    await publishDevelopmentSigningKey(agent, handle, 'issuer')
+
+    expect(agent.dids.update.mock.calls[0][0].didDocument.context).toEqual([
+      'https://www.w3.org/ns/did/v1',
+      'https://w3id.org/security/suites/jws-2020/v1',
+    ])
+  })
+
+  it('republishes a document that already carries the method but not its context', async () => {
+    const agent = createAgent({ developmentCertificate: fixtures.attacker })
+    agent.did = 'did:web:attacker.example'
+    agent.publicApiBaseUrl = 'https://attacker.example/agent'
+    const handle = await loadSigningCertificate(agent, {
+      development: { enabled: true, commonName: 'Development Agent' },
+    })
+    const published = publishedDidDocument('did:web:attacker.example', handle.keyId)
+    published.context = ['https://www.w3.org/ns/did/v1']
+    agent.dids.resolve.mockResolvedValue({ didDocument: published })
+    agent.dids.update.mockImplementation(async ({ did, didDocument }) => ({
+      didState: { state: 'finished', did, didDocument },
+    }))
+
+    await publishDevelopmentSigningKey(agent, handle, 'issuer')
+
+    expect(agent.dids.update).toHaveBeenCalledTimes(1)
+    expect(agent.dids.update.mock.calls[0][0].didDocument.context).toContain(
+      'https://w3id.org/security/suites/jws-2020/v1',
+    )
+  })
+
   it('repairs a missing KMS key id mapping even when the method is already published', async () => {
     const agent = createAgent({ developmentCertificate: fixtures.attacker })
     agent.did = 'did:web:attacker.example'
@@ -364,6 +411,7 @@ function configuredSigning(
 
 function publishedDidDocument(did: string, kmsKeyId: string): DidDocument {
   return DidDocument.fromJSON({
+    '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
     id: did,
     verificationMethod: [
       {

--- a/packages/plugin-openid4vc/tests/IssuerService.test.ts
+++ b/packages/plugin-openid4vc/tests/IssuerService.test.ts
@@ -267,15 +267,29 @@ describe('IssuerService', () => {
     expect(api.createIssuer).not.toHaveBeenCalled()
   })
 
-  it('fails offer creation and credential mapping clearly before initialization', async () => {
+  it('fails credential mapping clearly before initialization', async () => {
     const service = new IssuerService(agent() as never, options())
 
-    await expect(service.createOffer('employee', { name: 'Ada', role: 'engineer' })).rejects.toThrow(
-      'not initialized',
-    )
     await expect(
       service.mapCredentialRequest({ credentialConfigurationId: 'employee' } as never),
     ).rejects.toThrow('not initialized')
+  })
+
+  it('initializes on demand when an offer is requested after a failed boot', async () => {
+    const api = issuerApi()
+    api.getIssuerByIssuerId.mockResolvedValue({ issuerId: 'issuer' })
+    api.createCredentialOffer.mockResolvedValue({
+      credentialOffer: 'openid-credential-offer://?credential_offer_uri=secret',
+      issuanceSession: { id: 'session-1' },
+    })
+    const service = new IssuerService(agent(api) as never, options())
+    loadSigningCertificate.mockRejectedValueOnce(new Error('storage not ready'))
+
+    await expect(service.ensureInitialized()).rejects.toThrow('storage not ready')
+    await expect(service.createOffer('employee', { name: 'Ada', role: 'engineer' })).resolves.toEqual({
+      credentialOffer: 'openid-credential-offer://?credential_offer_uri=secret',
+      issuanceSessionId: 'session-1',
+    })
   })
 
   it('creates only a pre-authorized offer with validated claims as issuance metadata', async () => {


### PR DESCRIPTION
Same two fixes as #556, cherry-picked onto the branch the cast runs. See #556 for the reasoning.