### PR TITLE
fix(agent-sdk): publish the DIDComm key as Multikey

### DIFF
--- a/packages/agent-sdk/src/agent/VsAgent.ts
+++ b/packages/agent-sdk/src/agent/VsAgent.ts
@@ -338,19 +338,24 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
     return await didRepository.findCreatedDid(this.context, parsedDid.did)
   }
 
-  // Prefer Ed25519VerificationKey2020 over Multikey: webvh's update Multikey is not ours to use.
+  // The DIDComm key is the one the document itself nominates for authentication; webvh's
+  // update Multikey looks identical by type and must never be picked.
   private findEd25519VerificationMethodId(didDocument: DidDocument): string | undefined {
     const vms = didDocument.verificationMethod ?? []
-    const preferred = vms.find(vm => vm.type === 'Ed25519VerificationKey2020')
-    if (preferred) return preferred.id
-    const fallback = vms.find(
-      vm =>
-        vm.type === 'Ed25519VerificationKey2018' ||
-        (vm.type === 'Multikey' &&
-          typeof vm.publicKeyMultibase === 'string' &&
-          vm.publicKeyMultibase.startsWith('z6Mk')),
-    )
-    return fallback?.id
+    const isEd25519 = (vm: (typeof vms)[number]) =>
+      vm.type === 'Ed25519VerificationKey2020' ||
+      vm.type === 'Ed25519VerificationKey2018' ||
+      (vm.type === 'Multikey' &&
+        typeof vm.publicKeyMultibase === 'string' &&
+        vm.publicKeyMultibase.startsWith('z6Mk'))
+
+    const nominated = [didDocument.authentication, didDocument.assertionMethod]
+      .flat()
+      .find((entry): entry is string => typeof entry === 'string')
+    const nominatedMethod = vms.find(vm => vm.id === nominated && isEd25519(vm))
+    if (nominatedMethod) return nominatedMethod.id
+
+    return vms.find(vm => vm.type === 'Ed25519VerificationKey2020')?.id ?? vms.find(isEd25519)?.id
   }
 
   private getDidCommServices(publicDid: string, ed25519VerificationMethodId: string) {
@@ -476,7 +481,7 @@ export class VsAgent<TModules extends BaseAgentModules = BaseAgentModules> exten
         controller: publicDid,
         id: verificationMethodId,
         publicKeyMultibase,
-        type: 'Ed25519VerificationKey2020',
+        type: 'Multikey',
       },
       {
         controller: publicDid,

--- a/packages/agent-sdk/src/utils/setupSelfTr.ts
+++ b/packages/agent-sdk/src/utils/setupSelfTr.ts
@@ -555,7 +555,11 @@ export function getVerificationMethodId(logger: Logger, didRecord: DidRecord): s
   try {
     const verificationMethod = didRecord.didDocument?.verificationMethod?.find(
       method =>
-        (method.type === 'Ed25519VerificationKey2020' || method.type === 'Ed25519VerificationKey2018') &&
+        (method.type === 'Ed25519VerificationKey2020' ||
+          method.type === 'Ed25519VerificationKey2018' ||
+          (method.type === 'Multikey' &&
+            typeof method.publicKeyMultibase === 'string' &&
+            method.publicKeyMultibase.startsWith('z6Mk'))) &&
         method.id === didRecord.didDocument?.assertionMethod?.[0],
     )
     if (!verificationMethod) {


### PR DESCRIPTION
Third and last strict-conformance gap on the DID document, found by driving the Swiss swiyu wallet against the freshly rolled cast (#553, #554, #556).

With the log proof and the jws-2020 context fixed, swiyu now gets one entry further and fails on `"Ed25519VerificationKey2020" is not one of "JsonWebKey2020" or "Multikey"`. The did:webvh 1.0 data model only admits those two; the resolver's own fixtures show both forms. Three of our four verification methods already comply (webvh update key and key agreement are Multikey, the OID4VC signing key is JsonWebKey2020) - only the DIDComm key still used the legacy type. Same key, same `publicKeyMultibase`, same z6Mk fingerprint, so this is a type rename on the wire.

Two readers had to follow: `getVerificationMethodId` would otherwise find nothing and throw, and `findEd25519VerificationMethodId` preferred the legacy type. The latter now resolves the key the document itself nominates for authentication/assertion, because once our key is a Multikey it is indistinguishable by type from webvh's update key - which must never be selected.

sdk suite 79 passed (the 6 e2e suites need a live chain, same on base).

**Not merged deliberately.** This changes the DIDComm identity shape for every agent, so it wants a deliberate roll: publish, roll the demo cast, then re-check the DIDComm rail (Hologram, the vesta cast) alongside swiyu. Everything else for swiyu is already done and waiting on this.