### PR TITLE
fix(agent-sdk): pin the e2e chain to dev.30 for the operator grant convention

### DIFF
--- a/packages/agent-sdk/tests/e2e/helpers.ts
+++ b/packages/agent-sdk/tests/e2e/helpers.ts
@@ -9,8 +9,8 @@ import type {
 import { GenericContainer, Network, Wait, type StartedTestContainer } from 'testcontainers'
 import WebSocket from 'ws'
 
-// applicant-ops needs dev.21+ (VSOA accepted for SetParticipantOPToValidated).
-const VERANA_IMAGE = process.env.FLOW_VERANA_IMAGE || 'veranalabs/verana-node:v0.10.1-dev.21'
+// v0.10.1+: MsgGrantOperatorAuthorization only skips the delegation check when operator == corporation.
+const VERANA_IMAGE = process.env.FLOW_VERANA_IMAGE || 'veranalabs/verana-node:v0.10.1'
 const VERANA_PLATFORM = process.env.FLOW_VERANA_PLATFORM || 'linux/amd64'
 const POSTGRES_IMAGE = process.env.FLOW_POSTGRES_IMAGE || 'postgres:16-alpine'
 const REDIS_IMAGE = process.env.FLOW_REDIS_IMAGE || 'redis:7-alpine'


### PR DESCRIPTION
#565 changed `grantOperatorAuthorization` to send `operator: policyAddress`. That is correct, but only from verana-node v0.10.1-dev.30.