### PR TITLE
fix(agent-sdk): send subscribe before draining indexer catch-up

### DIFF
--- a/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
+++ b/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
@@ -30,6 +30,8 @@ const MAX_RECONNECT_DELAY_MS = 300_000
 const WS_PATHNAME = 'v4/indexer/subscribe'
 const REST_PAGE_LIMIT = 500
 const MAX_SYNC_BUFFER = 10_000
+const SUBSCRIBE_TIMEOUT_MS = 5_000
+const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 // The indexer pings every 30 seconds, so a longer gap means the socket is dead.
 const LIVENESS_TIMEOUT_MS = 90_000
 
@@ -43,6 +45,7 @@ export class IndexerWebSocketService {
   private generation = 0
   private chain: Promise<void> = Promise.resolve()
   private syncBuffer: IndexerEventRecord[] = []
+  private subscribeSent: (() => void) | null = null
   private readonly indexer: VeranaIndexerService
   private readonly handlerRegistry: IndexerHandlerRegistry
 
@@ -80,7 +83,12 @@ export class IndexerWebSocketService {
     this.syncing = true
     this.syncBuffer = []
 
+    const subscribed = new Promise<void>(resolve => {
+      this.subscribeSent = resolve
+    })
     this.openWebSocket()
+    await Promise.race([subscribed, delay(SUBSCRIBE_TIMEOUT_MS)])
+    if (this.stopped || generation !== this.generation) return
 
     try {
       await this.syncRest(generation)
@@ -109,6 +117,13 @@ export class IndexerWebSocketService {
     ws.on('open', () => {
       if (ws === this.ws) this.logger.info(`[IndexerWS] Connected to indexer`)
     })
+
+    const releaseSubscribeWait = (): void => {
+      this.subscribeSent?.()
+      this.subscribeSent = null
+    }
+    ws.on('error', releaseSubscribeWait)
+    ws.on('close', releaseSubscribeWait)
 
     ws.on('ping', () => {
       if (ws === this.ws) this.armWatchdog()
@@ -146,7 +161,10 @@ export class IndexerWebSocketService {
         this.options.corporationId != null
           ? { action: 'subscribe', corporationId: this.options.corporationId }
           : { action: 'subscribe', dids: this.options.agent.did ? [this.options.agent.did] : undefined }
-      ws.send(JSON.stringify(subscribe))
+      ws.send(JSON.stringify(subscribe), () => {
+        this.subscribeSent?.()
+        this.subscribeSent = null
+      })
       return
     }
     if (message.type !== 'block') return

--- a/packages/agent-sdk/tests/IndexerWebSocketService.test.ts
+++ b/packages/agent-sdk/tests/IndexerWebSocketService.test.ts
@@ -29,8 +29,9 @@ const { FakeWebSocket } = vi.hoisted(() => {
     emit(event: string, ...args: unknown[]): void {
       ;(this.listeners[event] ?? []).forEach(cb => cb(...args))
     }
-    send(data: string): void {
+    send(data: string, cb?: () => void): void {
       this.sent.push(data)
+      cb?.()
     }
     close(): void {
       this.emit('close')
@@ -139,7 +140,9 @@ describe('IndexerWebSocketService', () => {
       agent,
       handlerRegistry: registry,
     })
-    return service.start()
+    const started = service.start()
+    FakeWebSocket.instances.at(-1)?.emit('message', readyFrame())
+    return started
   }
 
   const lastWs = (): InstanceType<typeof FakeWebSocket> => FakeWebSocket.instances.at(-1)!
@@ -151,6 +154,23 @@ describe('IndexerWebSocketService', () => {
     expect(subscribe).toContainEqual({ action: 'subscribe', dids: ['did:web:agent.test'] })
   })
 
+  it('waits for subscribe to be sent before reading old events', async () => {
+    service = new IndexerWebSocketService({
+      indexerUrl: 'http://indexer.test',
+      agent,
+      handlerRegistry: registry,
+    })
+    const started = service.start()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(fetchJsonMock).not.toHaveBeenCalled()
+
+    lastWs().emit('message', readyFrame())
+    await started
+
+    expect(fetchJsonMock).toHaveBeenCalled()
+  })
+
   it('sends a corp-scoped subscribe and catch-up when corporationId is set', async () => {
     registry.register({ msg: 'TestMsg', handle: async () => undefined })
     service = new IndexerWebSocketService({
@@ -159,7 +179,9 @@ describe('IndexerWebSocketService', () => {
       handlerRegistry: registry,
       corporationId: 42,
     })
-    await service.start()
+    const corpStarted = service.start()
+    lastWs().emit('message', readyFrame())
+    await corpStarted
 
     const catchupUrl = fetchJsonMock.mock.calls.at(0)?.[0] as string
     expect(catchupUrl).toContain('corporation_id=42')
@@ -352,9 +374,10 @@ describe('IndexerWebSocketService', () => {
       agent,
       handlerRegistry: registry,
     })
-    await session1.start()
+    const s1 = session1.start()
+    lastWs().emit('message', readyFrame())
+    await s1
     const ws1 = lastWs()
-    ws1.emit('message', readyFrame())
     ws1.emit('message', blockFrame(50, [tail]))
     await vi.waitFor(() => expect(dispatched).toEqual(['A']))
     session1.stop()
@@ -372,7 +395,9 @@ describe('IndexerWebSocketService', () => {
       agent,
       handlerRegistry: registry2,
     })
-    await session2.start()
+    const s2 = session2.start()
+    lastWs().emit('message', readyFrame())
+    await s2
     session2.stop()
 
     expect(dispatched).toEqual(['A'])


### PR DESCRIPTION
Part of #574.

`connect()` opened the socket and started the REST drain right away, while `subscribe` only went out later when `ready` arrived. An event landing in between was delivered by neither.

Now it waits for the subscribe frame to be sent. A dead socket releases the wait on error or close, and a 5s timeout stops a slow indexer blocking startup.

Does not fully close the gap. The indexer sends no reply to `subscribe`, so we still cannot tell when it actually takes effect. That part is in #574.