### PR TITLE
fix(demo): make the v4 lifecycle demo run end to end

### DIFF
--- a/.env.demo.example
+++ b/.env.demo.example
@@ -1,17 +1,23 @@
 # Copy to .env and adjust. Used by docker-compose.demo.yml.
 
-# Funded demo account from docker/verana-node-init.sh (cooluser). Replace per agent
-# with distinct funded accounts once you have seeded corporations and grants.
-VALIDATOR_MNEMONIC="pink glory help gown abstract eight nice crazy forward ketchup skill cheese"
-APPLICANT_MNEMONIC="pink glory help gown abstract eight nice crazy forward ketchup skill cheese"
+# Throwaway local-devnet keys, one per agent. These must stay distinct from each other and
+# from the cooluser mnemonic in docker/verana-node-init.sh that the seed script signs with:
+# the seed grants the validator a VSOA and the applicant an OperatorAuthorization on the same
+# corporation, and the chain rejects an account that would end up holding both.
+# The seed funds both accounts, so they need no balance up front.
+VALIDATOR_MNEMONIC="recall buyer young reopen napkin will office warm chronic witness rigid wood"
+APPLICANT_MNEMONIC="oblige wild human tomato announce method slim buzz maid seat chunk raven"
 
-# Set after seeding: the corporation each agent operates for.
-VALIDATOR_CORPORATION_ID=
-APPLICANT_CORPORATION_ID=
+# The corporation each agent operates for. The seed creates three corporations on a fresh chain,
+# in this order: the validator, the ecosystem owner, and the applicant. Neither agent operates for
+# the ecosystem corporation. Both agents require these values at startup, and the seed prints the
+# ids it created so you can confirm them.
+VALIDATOR_CORPORATION_ID=1
+APPLICANT_CORPORATION_ID=3
 
-# Set after seeding: comma-separated DIDs of the ECS ecosystems the agents trust (WL-ECS).
-TRUSTED_ECS_ECOSYSTEM_DIDS=
+# Comma-separated DIDs of the ECS ecosystems the agents trust (WL-ECS). The seed creates this one.
+TRUSTED_ECS_ECOSYSTEM_DIDS=did:example:demo-ecosystem
 
 # Optional image overrides.
-#VERANA_NODE_IMAGE=veranalabs/verana-node:v0.10.1-dev.25
+#VERANA_NODE_IMAGE=veranalabs/verana-node:v0.10.1
 #VERANA_INDEXER_IMAGE=veranalabs/verana-indexer:dev

--- a/apps/vs-agent/tests/e2e/demoSeed.e2e.test.ts
+++ b/apps/vs-agent/tests/e2e/demoSeed.e2e.test.ts
@@ -1,5 +1,5 @@
 import { ConsoleLogger, LogLevel } from '@credo-ts/core'
-import { VeranaChainService } from '@verana-labs/vs-agent-sdk'
+import { getEcsSchemas, VeranaChainService } from '@verana-labs/vs-agent-sdk'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -14,46 +14,55 @@ const describeSeed = SEED_ENABLED ? describe : describe.skip
 const RPC_URL = process.env.DEMO_RPC_URL ?? 'http://localhost:26658'
 const VALIDATOR_PUBLIC_URL = process.env.DEMO_VALIDATOR_URL ?? 'http://localhost:4001'
 const VALIDATOR_OPERATOR = process.env.DEMO_VALIDATOR_OPERATOR ?? ''
+const APPLICANT_OPERATOR = process.env.DEMO_APPLICANT_OPERATOR ?? ''
 
 const PP_VALIDATE = '/verana.pp.v1.MsgSetParticipantOPToValidated'
 const PP_SESSION = '/verana.pp.v1.MsgCreateOrUpdateParticipantSession'
 
-const ecsSchema = (title: string) =>
-  JSON.stringify({
-    $schema: 'https://json-schema.org/draft/2020-12/schema',
-    title,
-    description: `demo ${title}`,
-    type: 'object',
-    properties: { name: { type: 'string' } },
-    required: ['name'],
-  })
+const ECS_SCHEMAS = getEcsSchemas(process.env.DEMO_ECS_SCHEMA_BASE_URL ?? 'https://agent-validator.demo')
 
 describeSeed('demo chain seed', () => {
   it('seeds corporation, ecosystem, ECS schemas, roots, and the validator grant', async () => {
     expect(VALIDATOR_OPERATOR, 'set DEMO_VALIDATOR_OPERATOR to the validator operator address').toBeTruthy()
+    expect(APPLICANT_OPERATOR, 'set DEMO_APPLICANT_OPERATOR to the applicant operator address').toBeTruthy()
+    expect(
+      VALIDATOR_OPERATOR,
+      'the validator and applicant must use distinct accounts: the validator receives a VSOA on its participant OP, ' +
+        'the applicant an OperatorAuthorization, and the chain forbids one account from holding both on a corporation',
+    ).not.toBe(APPLICANT_OPERATOR)
 
     const didLog = await fetch(`${VALIDATOR_PUBLIC_URL}/.well-known/did.jsonl`).then(r => r.text())
     const validatorDid = JSON.parse(didLog.split('\n')[0]).state.id as string
 
     const chain = await VeranaTestChain.connect(RPC_URL, COOLUSER_MNEMONIC)
+    // The corporation each agent operates for. Each one holds only its own participants.
     const corp = await chain.createCorporation({ did: 'did:example:demo-corp' })
     await chain.fundCorporation(corp.policyAddress)
     await chain.grantOperatorAuthorization(corp.policyAddress)
 
-    const eco = await chain.createEcosystem(corp.policyAddress, { did: 'did:example:demo-ecosystem' })
-    const orgSchema = await chain.createCredentialSchema(corp.policyAddress, {
-      ecosystemId: eco.ecosystemId,
-      jsonSchema: ecsSchema('OrganizationCredential'),
+    // The ecosystem belongs to a corporation of its own, and no agent operates for it. An agent
+    // publishes a VTJSC for every schema its own corporation owns, and a Verifiable Service that
+    // presents self-issued credentials owns no schema, so it must reference only its own URLs.
+    const ecosystemCorp = await chain.createCorporation({ did: 'did:example:demo-ecosystem-corp' })
+    await chain.fundCorporation(ecosystemCorp.policyAddress)
+    await chain.grantOperatorAuthorization(ecosystemCorp.policyAddress)
+
+    const eco = await chain.createEcosystem(ecosystemCorp.policyAddress, {
+      did: 'did:example:demo-ecosystem',
     })
-    const serviceSchema = await chain.createCredentialSchema(corp.policyAddress, {
+    const orgSchema = await chain.createCredentialSchema(ecosystemCorp.policyAddress, {
       ecosystemId: eco.ecosystemId,
-      jsonSchema: ecsSchema('ServiceCredential'),
+      jsonSchema: ECS_SCHEMAS['ecs-org'],
     })
-    const orgRoot = await chain.createRootParticipant(corp.policyAddress, {
+    const serviceSchema = await chain.createCredentialSchema(ecosystemCorp.policyAddress, {
+      ecosystemId: eco.ecosystemId,
+      jsonSchema: ECS_SCHEMAS['ecs-service'],
+    })
+    const orgRoot = await chain.createRootParticipant(ecosystemCorp.policyAddress, {
       schemaId: orgSchema.schemaId,
       did: 'did:example:demo-org-root',
     })
-    await chain.createRootParticipant(corp.policyAddress, {
+    const serviceRoot = await chain.createRootParticipant(ecosystemCorp.policyAddress, {
       schemaId: serviceSchema.schemaId,
       did: 'did:example:demo-service-root',
     })
@@ -67,30 +76,61 @@ describeSeed('demo chain seed', () => {
       vsOperatorAuthzMsgTypes: [PP_VALIDATE, PP_SESSION],
     })
 
+    // The applicant is a separate organization joining the ecosystem, so it gets its own
+    // corporation: a participant OP is unique per (schema, role, validator, authority), and one
+    // shared corporation would collide with the validator's own Service OP below.
+    const applicantCorp = await chain.createCorporation({ did: 'did:example:demo-applicant-corp' })
+    await chain.fundCorporation(applicantCorp.policyAddress)
+
+    // The applicant self-onboards: its ECS bootstrap signs MsgStartParticipantOP with its own
+    // account, so that account needs funds and an OperatorAuthorization on its corporation.
+    await chain.fundAccount(APPLICANT_OPERATOR)
+    await chain.grantOperatorAuthorization(applicantCorp.policyAddress, APPLICANT_OPERATOR)
+
+    // The applicant runs VS-CONN-VS against the validator before it will send an onboarding
+    // request, and that resolves the validator's self-issued ECS Service credential. So the
+    // validator needs an active ISSUER participant on the Service schema too. No vsOperator here:
+    // it already holds its VSOA from the OP above, and one per corporation/operator pair is the max.
+    const validatorServiceOp = await chain.startParticipantOp(corp.policyAddress, {
+      role: PARTICIPANT_ROLE_ISSUER,
+      validatorParticipantId: serviceRoot.participantId,
+      did: validatorDid,
+    })
+
+    // The roots that validate these OPs belong to the ecosystem corporation, so the seeder signs
+    // the validation on its behalf.
     const seeder = new VeranaChainService({
       rpcUrl: RPC_URL,
       mnemonic: COOLUSER_MNEMONIC,
-      corporationAddress: corp.policyAddress,
+      corporationAddress: ecosystemCorp.policyAddress,
       logger: new ConsoleLogger(LogLevel.Warn),
     })
     await seeder.start()
     await seeder.setParticipantOPToValidated({ id: validatorOp.participantId, opSummaryDigest: 'sha384-v' })
+    await seeder.setParticipantOPToValidated({
+      id: validatorServiceOp.participantId,
+      opSummaryDigest: 'sha384-s',
+    })
 
     // biome-ignore lint/suspicious/noConsole: prints the seeded ids for the demo walkthrough
     console.log(
       JSON.stringify(
         {
-          corporationId: corp.corporationId,
+          validatorCorporationId: corp.corporationId,
+          applicantCorporationId: applicantCorp.corporationId,
+          ecosystemCorporationId: ecosystemCorp.corporationId,
           ecosystemDid: 'did:example:demo-ecosystem',
           orgSchemaId: orgSchema.schemaId,
           serviceSchemaId: serviceSchema.schemaId,
           validatorDid,
           validatorParticipantId: validatorOp.participantId,
+          validatorServiceParticipantId: validatorServiceOp.participantId,
         },
         null,
         2,
       ),
     )
     expect(corp.corporationId).toBe(1)
+    expect(applicantCorp.corporationId).not.toBe(corp.corporationId)
   }, 180_000)
 })

--- a/apps/vs-agent/tests/trustService.test.ts
+++ b/apps/vs-agent/tests/trustService.test.ts
@@ -7,7 +7,6 @@ import {
   type BaseAgentModules,
   type VsAgent,
   migrateVtjscServiceIds,
-  reconcileVtjscPublications,
 } from '@verana-labs/vs-agent-sdk'
 import { Subject } from 'rxjs'
 import request from 'supertest'

--- a/apps/vs-agent/tests/trustService.test.ts
+++ b/apps/vs-agent/tests/trustService.test.ts
@@ -3,11 +3,7 @@ import { DidCommConnectionRecord } from '@credo-ts/didcomm'
 import { WebVhAnonCredsRegistry } from '@credo-ts/webvh'
 import { INestApplication } from '@nestjs/common'
 import { Claim, CredentialIssuanceMessage } from '@verana-labs/vs-agent-model'
-import {
-  type BaseAgentModules,
-  type VsAgent,
-  migrateVtjscServiceIds,
-} from '@verana-labs/vs-agent-sdk'
+import { type BaseAgentModules, type VsAgent, migrateVtjscServiceIds } from '@verana-labs/vs-agent-sdk'
 import { Subject } from 'rxjs'
 import request from 'supertest'
 import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'

--- a/docker-compose.demo.yml
+++ b/docker-compose.demo.yml
@@ -1,6 +1,6 @@
 services:
   verana-node:
-    image: ${VERANA_NODE_IMAGE:-veranalabs/verana-node:v0.10.1-dev.25}
+    image: ${VERANA_NODE_IMAGE:-veranalabs/verana-node:v0.10.1}
     platform: linux/amd64
     entrypoint: ['/bin/bash', '/init/verana-node-init.sh']
     volumes:
@@ -51,7 +51,7 @@ services:
       NODE_ENV: production
       SERVICEDIR: dist/src/services
       SERVICES: '**/*.service.js'
-      CHAIN_ID: vna-testnet-1
+      CHAIN_ID: vna-demo-1
       RPC_ENDPOINT: http://verana-node:26657/
       LCD_ENDPOINT: http://verana-node:1317
       POSTGRES_HOST: postgres
@@ -66,6 +66,17 @@ services:
       - caddy-data:/caddy:ro
     ports:
       - '3011:3001'
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "require('http').get('http://localhost:3001/', r => process.exit(0)).on('error', () => process.exit(1))",
+        ]
+      interval: 3s
+      timeout: 3s
+      retries: 40
 
   caddy:
     image: caddy:2-alpine
@@ -90,7 +101,7 @@ services:
       target: vs-agent
     depends_on:
       indexer:
-        condition: service_started
+        condition: service_healthy
       caddy:
         condition: service_healthy
     volumes:
@@ -108,7 +119,7 @@ services:
       ADMIN_API_AUTH_MODE: internal
       AGENT_MODE: standalone
       VERANA_RPC_ENDPOINT_URL: http://verana-node:26657
-      VERANA_CHAIN_ID: vna-testnet-1
+      VERANA_CHAIN_ID: vna-demo-1
       VERANA_INDEXER_BASE_URL: http://indexer:3001
       VERANA_ACCOUNT_MNEMONIC: ${VALIDATOR_MNEMONIC:?set VALIDATOR_MNEMONIC in .env}
       VERANA_CORPORATION_ID: ${VALIDATOR_CORPORATION_ID:-}
@@ -124,7 +135,7 @@ services:
       target: vs-agent
     depends_on:
       indexer:
-        condition: service_started
+        condition: service_healthy
       caddy:
         condition: service_healthy
     volumes:
@@ -142,7 +153,7 @@ services:
       ADMIN_API_AUTH_MODE: internal
       AGENT_MODE: standalone
       VERANA_RPC_ENDPOINT_URL: http://verana-node:26657
-      VERANA_CHAIN_ID: vna-testnet-1
+      VERANA_CHAIN_ID: vna-demo-1
       VERANA_INDEXER_BASE_URL: http://indexer:3001
       VERANA_ACCOUNT_MNEMONIC: ${APPLICANT_MNEMONIC:?set APPLICANT_MNEMONIC in .env}
       VERANA_CORPORATION_ID: ${APPLICANT_CORPORATION_ID:-}

--- a/docker/verana-node-init.sh
+++ b/docker/verana-node-init.sh
@@ -3,7 +3,7 @@ set -e
 HOME_DIR=/root/.verana
 GENESIS=$HOME_DIR/config/genesis.json
 SENTINEL=$HOME_DIR/.init-complete
-CHAIN_ID=vna-testnet-1
+CHAIN_ID=vna-demo-1
 MONIKER=validator1
 KEY=cooluser
 MNEMONIC="pink glory help gown abstract eight nice crazy forward ketchup skill cheese"

--- a/docs/v4-lifecycle.md
+++ b/docs/v4-lifecycle.md
@@ -23,7 +23,7 @@ cd apps/vs-agent
 pnpm test:e2e
 ```
 
-Requires Docker and the `veranalabs/verana-node:v0.10.1-dev.25` and `veranalabs/verana-indexer:dev` images. First run pulls them; the stack starts and stops per run.
+Requires Docker and the `veranalabs/verana-node:v0.10.1` and `veranalabs/verana-indexer:dev` images. First run pulls them; the stack starts and stops per run.
 
 ## Local demo environment
 
@@ -50,27 +50,48 @@ Endpoints once healthy:
 
 ### Seed the chain
 
-The demo chain starts empty apart from the funded `cooluser` account. Once both agents are up, seed the corporation, ecosystem, ECS schemas, root participants, and the validator grant. The seed needs the validator's operator address, which the agent prints at startup:
+The demo chain starts empty apart from the funded `cooluser` account. Once both agents are up, seed the three corporations, the ecosystem, the ECS schemas, the root participants, and the operator grants. Until the seed runs, each agent logs that it cannot resolve its corporation and that it skipped its bootstrap; that is expected.
+
+The seed creates three corporations, and each one holds a single role:
+
+| Corporation | Holds |
+|---|---|
+| Validator | the validator's participants |
+| Ecosystem | the ecosystem, the ECS schemas and the root participants |
+| Applicant | the applicant's participants |
+
+The ecosystem needs a corporation of its own, and no agent operates for it. An agent publishes a VTJSC for every schema its own corporation owns, and such a credential references the schema on chain. Both agents here present self-issued credentials that must reference only their own URLs, so neither may own a schema.
+
+The validator and the applicant also need separate corporations from each other. A participant OP is unique per (schema, role, validator, authority), so one shared corporation makes the applicant's Service onboarding collide with the validator's.
+
+The seed needs both agents' operator addresses, which each agent derives from its mnemonic and prints at startup:
 
 ```bash
 docker logs $(docker compose -f docker-compose.demo.yml ps -q agent-validator) 2>&1 | grep vs_operator
+docker logs $(docker compose -f docker-compose.demo.yml ps -q agent-applicant) 2>&1 | grep vs_operator
 ```
 
-Then run the seed with that address:
+The two agents must use distinct mnemonics, and neither may reuse the `cooluser` mnemonic the seed itself signs with: the seed grants the validator a VSOA on its participant OP and the applicant an OperatorAuthorization, and the chain rejects an account that would end up holding both on one corporation. The defaults in `.env.demo.example` already satisfy this.
+
+Then run the seed with both addresses:
 
 ```bash
 cd apps/vs-agent
-SEED_DEMO=1 DEMO_VALIDATOR_OPERATOR=<validator operator address> \
+SEED_DEMO=1 \
+  DEMO_VALIDATOR_OPERATOR=<validator operator address> \
+  DEMO_APPLICANT_OPERATOR=<applicant operator address> \
   pnpm exec vitest run tests/e2e/demoSeed.e2e.test.ts
 ```
 
-The seed prints the corporation id, ecosystem DID, schema ids, and validator participant id. Put the ecosystem DID in `TRUSTED_ECS_ECOSYSTEM_DIDS` and the corporation id in `APPLICANT_CORPORATION_ID` in `.env`, then restart the applicant:
+The seed prints the three corporation ids, the ecosystem DID, the schema ids, and the validator participant ids. Only `validatorCorporationId` and `applicantCorporationId` go into `.env`; no agent uses the ecosystem corporation. A fresh chain produces the ids that `.env.demo.example` already carries, so confirm them against that output and correct `.env` if they differ. Then restart both agents, because each agent reads the chain only at startup:
 
 ```bash
-docker compose -f docker-compose.demo.yml --env-file .env up -d agent-applicant
+docker compose -f docker-compose.demo.yml --env-file .env restart agent-validator agent-applicant
 ```
 
-Its ECS bootstrap self-onboards and sends the onboarding request to the validator over DIDComm.
+Use `restart` here, not `up -d`. Compose recreates a container only when its configuration changes, and `.env` already holds the seeded values.
+
+The applicant's ECS bootstrap self-onboards and sends the onboarding request to the validator over DIDComm.
 
 ### Drive the flow
 

--- a/packages/agent-sdk/src/utils/setupSelfTr.ts
+++ b/packages/agent-sdk/src/utils/setupSelfTr.ts
@@ -2,6 +2,7 @@ import {
   W3cCredential,
   W3cPresentation,
   W3cCredentialSchema,
+  DidDocumentService,
   DidRepository,
   ClaimFormat,
   W3cCredentialSubject,
@@ -355,6 +356,21 @@ export async function generateVerifiablePresentation(
     }
     return s
   })
+  // Resolvers only discover the credential through the [VT-CRED-W3C-LINKED-VP] fragment, and
+  // #whois does not match it. The rename above only covers documents that already carry the
+  // service, so publish it here when nothing declared it yet.
+  let didDocumentChanged = false
+  if (!didDocument.service?.some(s => s.id === didDocumentServiceId)) {
+    didDocument.service = [
+      ...(didDocument.service ?? []),
+      new DidDocumentService({
+        id: didDocumentServiceId,
+        serviceEndpoint: id,
+        type: 'LinkedVerifiablePresentation',
+      }),
+    ]
+    didDocumentChanged = true
+  }
   const credential = verifiablePresentation.verifiableCredential[0]
   record[credentialSchema.id] = {
     credential,
@@ -365,6 +381,9 @@ export async function generateVerifiablePresentation(
   }
   didRecord.metadata.set('_vt/vtc', record)
   await agent.context.dependencyManager.resolve(DidRepository).update(agent.context, didRecord)
+  if (didDocumentChanged) {
+    await agent.dids.update({ did: didRecord.did, didDocument })
+  }
   return verifiablePresentation
 }
 

--- a/packages/agent-sdk/tests/e2e/VeranaTestChain.ts
+++ b/packages/agent-sdk/tests/e2e/VeranaTestChain.ts
@@ -162,14 +162,18 @@ export class VeranaTestChain {
     )
   }
 
-  async grantOperatorAuthorization(policyAddress: string, grantee = this.address): Promise<void> {
+  async grantOperatorAuthorization(
+    policyAddress: string,
+    grantee = this.address,
+    msgTypes = OPERATOR_GRANT_MSG_TYPES,
+  ): Promise<void> {
     const grant = {
       typeUrl: veranaTypeUrls.MsgGrantOperatorAuthorization,
       value: MsgGrantOperatorAuthorization.fromPartial({
         corporation: policyAddress,
         operator: policyAddress,
-        grantee: this.address,
-        msgTypes: OPERATOR_GRANT_MSG_TYPES,
+        grantee,
+        msgTypes,
       }),
     }
 


### PR DESCRIPTION
## Summary

The local demo in `docs/v4-lifecycle.md` could not reach the onboarding flow. Six
separate defects blocked it, and each one hid the next. This PR clears all six.

The demo now runs from a clean start to a live DIDComm flow between the two agents.

One fix lands in `agent-sdk`. Everything else is demo material: the seed, compose,
the chain init script, the env example, and the docs.

## The one product fix

`setupSelfTr` now publishes the `vpr-schemas-<key>-vtc-vp` service and republishes
the DID document.

A resolver discovers a credential only through that fragment, and `#whois` does not
match it. The previous code renamed a service that already carried the schema key,
but no code ever created one, so the branch never ran. It also wrote to the DID
repository alone, which kept the new service local while resolvers read the
published document.

Without this, a Verifiable Service that presents self-issued credentials is
invisible to a resolver, whatever the chain holds.

## Demo topology: three corporations

The seed now creates three corporations, and each one holds a single role.

| Corporation | Id | Holds |
|---|---|---|
| Validator | 1 | the validator's participants |
| Ecosystem | 2 | the ecosystem, the ECS schemas, the root participants |
| Applicant | 3 | the applicant's participants |

An agent publishes a VTJSC for every schema its own corporation owns, and that
credential references the schema on chain. Both agents here present self-issued
credentials, which must reference only their own URLs, so neither may own a schema.
No agent operates for the ecosystem corporation.

The validator and the applicant also need separate corporations. A participant OP
is unique per (schema, role, validator, authority), so one shared corporation makes
the applicant's Service onboarding collide with the validator's.

## Other demo fixes

- **Indexer race.** The indexer had no healthcheck, and both agents waited only for
  `service_started`. They raced ahead and failed with `ECONNREFUSED`. The indexer
  now has a healthcheck, and both agents wait for `service_healthy`.
- **Mnemonic collision.** `.env.demo.example` gave both agents the `cooluser`
  mnemonic, which the seed itself signs with. The seed's operator grant therefore
  collided with the validator's, and the seed always failed. Each agent now has its
  own throwaway key.
- **Applicant grant.** The seed never funded the applicant operator and never gave
  it an OperatorAuthorization, so the applicant could never pass its bootstrap
  preflight check. The seed now does both, through the new
  `DEMO_APPLICANT_OPERATOR` variable.
- **Real ECS schemas.** The seed registered placeholder schemas. `identifySchema`
  matches an ECS schema by its SHA-384 digest, so the agents never recognised them.
  The seed now registers the published v4 schemas through `getEcsSchemas`.
- **Validator Service participant.** The validator needs an active ISSUER
  participant on the Service schema, or the applicant's VS-CONN-VS check fails.
- **Chain id.** The demo chain used `vna-testnet-1`, and `mapToEcosystem` maps that
  id to `https://idx.testnet.verana.network`. A local reference could therefore
  reach a public host and return the wrong schema without an error. The demo chain
  is now `vna-demo-1`.
- **Node image.** The compose default moves from `v0.10.1-dev.25` to `v0.10.1`.
- **`VeranaTestChain.grantOperatorAuthorization`** declared a `grantee` parameter
  and then ignored it, so it could grant only to the caller.

## Documentation

`docs/v4-lifecycle.md` now describes the three corporations, collects both operator
addresses, and uses `restart` rather than `up -d`. Compose recreates a container
only when its configuration changes, and `.env` already holds the seeded values, so
`up -d` restarts nothing.

## How to verify

```bash
cp .env.demo.example .env
docker compose -f docker-compose.demo.yml --env-file .env up --build -d
# collect both vs_operator addresses, then seed, then:
docker compose -f docker-compose.demo.yml --env-file .env restart agent-validator agent-applicant
```

Expected result: `applicant OR_SENT` and `validator AWAITING_OR` on one session id.
The validator's credential chain stays local:

```
credentialSchema : https://agent-validator.demo/vt/schemas-example-service-jsc.json
jsonSchema.$ref  : https://agent-validator.demo/vt/cs/v1/js/ecs-service
```

## What is left

**Review this one first.** A self-issued credential returns after a restart. When a
real credential arrives, `updateVtcEntries` detaches the self-issued entries. The
early return in `generateVerifiablePresentation` then fails on the next start,
because it requires `attached`, so the agent rebuilds the credential and writes
`attached: true`. This PR makes that visible in the published DID document, because
the agent now republishes the service. A resolver takes the first service credential
it finds, so a self-issued credential could outrank a real one. A fix is to keep a
detached entry detached, and to restore it only through an explicit removal.

Other items, none of which block the demo:

- `publishVtjscIfOwner` performs no ownership check, although its name promises one.
  The `CreateNewCredentialSchema` handler calls it for every schema on the chain.
- `GET /vt/cs/v1/js/<unknown>` answers 200 with an empty body. `getSchema` raises a
  404, so a handler ahead of the controller answers that path.
- The testcontainers stack in `packages/agent-sdk/tests/e2e/helpers.ts` still uses
  `vna-testnet-1`, so it carries the same public-host hazard the demo just lost.
- `fullLifecycle.e2e.test.ts` stubs `assertVerifiableService: async () => true`, so
  no test exercises the real VS-CONN-VS path. A test there would have caught the
  missing linked presentation service.
- A self-issued service resolves with outcome `NOT_TRUSTED` and `verified: true`.
  `VERIFIED_TEST` needs a `vpr:` reference with a non-production registry, and that
  reference brings back the anchored digest requirement. This deserves a decision.
- The applicant's Service onboarding cannot complete. Its validator is
  `did:example:demo-service-root`, a placeholder with no agent behind it. The
  participant OP exists on chain and stays PENDING.
