### PR TITLE
fix(agent-sdk): check schema ownership before publishing a VTJSC

### DIFF
--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -486,6 +486,7 @@ const run = async () => {
         agent,
         handlerRegistry,
         corporationId: indexerCorporationId,
+        agentCorporationId: Number(VERANA_CORPORATION_ID),
       })
       await indexerWs.start()
     } else {

--- a/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
+++ b/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
@@ -24,6 +24,7 @@ export interface IndexerWebSocketServiceOptions {
   agent: VsAgent
   handlerRegistry?: IndexerHandlerRegistry
   corporationId?: number
+  agentCorporationId?: number
 }
 
 const MAX_RECONNECT_DELAY_MS = 300_000
@@ -272,6 +273,7 @@ export class IndexerWebSocketService {
       agent: this.options.agent,
       blockHeight: block,
       operatorAddress: event.payload.sender,
+      agentCorporationId: this.options.agentCorporationId,
       state: syncState,
       txHash: event.tx_hash,
     })

--- a/packages/agent-sdk/src/blockchain/handlers/IndexerHandlerRegistry.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/IndexerHandlerRegistry.ts
@@ -5,6 +5,7 @@ export interface IndexerHandlerContext {
   agent: VsAgent
   blockHeight: number
   operatorAddress: string
+  agentCorporationId?: number
   state: VeranaSyncState
   txHash: string
 }

--- a/packages/agent-sdk/src/blockchain/handlers/defaultHandlers.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/defaultHandlers.ts
@@ -54,7 +54,7 @@ export const defaultHandlers: IndexerEventHandler[] = [
       ctx.agent.config.logger.info(
         `[IndexerWS] CreateNewCredentialSchema entity=${activity.entity_id} block=${ctx.blockHeight}`,
       )
-      await publishVtjscIfOwner(ctx.state, ctx.agent, String(activity.entity_id))
+      await publishVtjscIfOwner(ctx.state, ctx.agent, String(activity.entity_id), ctx.agentCorporationId)
     },
   },
   {

--- a/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
@@ -391,15 +391,25 @@ export async function publishVtjscIfOwner(
   state: VeranaSyncState,
   agent: VsAgent,
   schemaEntityId: string,
+  agentCorporationId?: number,
 ): Promise<void> {
   const schema = state.credentialSchemas[schemaEntityId]
   if (!schema) {
     agent.config.logger.warn(`[VTJSC] Schema ${schemaEntityId} not found in state`)
+    return
   }
 
   const ecosystem = state.ecosystems[String(schema.ecosystemId)]
   if (!ecosystem) {
     agent.config.logger.warn(`[VTJSC] Ecosystem ${schema.ecosystemId} not found in state`)
+    return
+  }
+
+  if (ecosystem.corporationId !== agentCorporationId) {
+    agent.config.logger.debug(
+      `[VTJSC] Skipping schema ${schema.id}: ecosystem ${ecosystem.id} belongs to corporation ${ecosystem.corporationId}`,
+    )
+    return
   }
 
   const chainId = agent.veranaChain?.getChainId ?? DEFAULT_CHAIN_ID

--- a/packages/agent-sdk/tests/publishVtjsc.test.ts
+++ b/packages/agent-sdk/tests/publishVtjsc.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { publishVtjscIfOwner } from '../src/blockchain/handlers/stateMutations'
+import { VeranaSyncState } from '../src/blockchain/types'
+
+const createJsc = vi.fn()
+vi.mock('../src/utils/trustCredentialStore', async importOriginal => ({
+  ...(await importOriginal<typeof import('../src/utils/trustCredentialStore')>()),
+  createJsc: (...args: unknown[]) => createJsc(...args),
+}))
+
+function makeAgent() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  }
+  return {
+    agent: {
+      config: { logger },
+      publicApiBaseUrl: 'https://agent.example',
+      veranaChain: { getChainId: 'vna-demo-1' },
+    },
+  }
+}
+
+function stateWith(ecosystemCorporationId: number): VeranaSyncState {
+  return {
+    lastBlockHeight: 10,
+    ecosystems: {
+      '1': {
+        id: 1,
+        did: 'did:example:eco',
+        corporationId: ecosystemCorporationId,
+        archived: false,
+        lastModifiedBlock: 10,
+      },
+    },
+    credentialSchemas: {
+      '5': { id: 5, ecosystemId: 1, jsonSchema: '{"title":"x"}', lastModifiedBlock: 10 },
+    },
+    participants: {},
+  } as unknown as VeranaSyncState
+}
+
+describe('publishVtjscIfOwner', () => {
+  beforeEach(() => createJsc.mockReset())
+
+  it('publishes a schema owned by the agent corporation', async () => {
+    const { agent } = makeAgent()
+    await publishVtjscIfOwner(stateWith(7), agent as never, '5', 7)
+    expect(createJsc).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a schema owned by another corporation', async () => {
+    const { agent } = makeAgent()
+    await publishVtjscIfOwner(stateWith(8), agent as never, '5', 7)
+    expect(createJsc).not.toHaveBeenCalled()
+  })
+
+  it('returns without throwing when the schema is not in state', async () => {
+    const { agent } = makeAgent()
+    await expect(publishVtjscIfOwner(stateWith(7), agent as never, '404', 7)).resolves.toBeUndefined()
+    expect(createJsc).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Closes https://github.com/verana-labs/vs-agent/issues/581

`publishVtjscIfOwner` did no ownership check despite its name, so the agent would publish a VTJSC for a schema owned by another corporation. It now compares the ecosystem corporation against the agent's own, the same way `reconcileVtjscPublications` does.

The agent's corporation was not available in that path. The one on the indexer service is the subscription corporation and is unset in the default DID scope, so I added a separate `agentCorporationId` that main always sets from `VERANA_CORPORATION_ID`.

Also added the missing returns. An unknown schema used to warn and then throw on the next line.