### PR TITLE
fix: precompute SRI of default content

### DIFF
--- a/apps/vs-agent/src/config/constants.ts
+++ b/apps/vs-agent/src/config/constants.ts
@@ -125,6 +125,50 @@ export const DEFAULT_SELF_ISSUED_VTC_RESOURCES = {
   privacyPolicyUri: (baseUrl: string) => `${baseUrl}/vt/default/privacy.html`,
 }
 
+// Content served at the DEFAULT_SELF_ISSUED_VTC_RESOURCES URLs above (by
+// DefaultResourcesController) and hashed for the corresponding *DigestSri
+// self-tr claim (see main.ts). Defined here, once, so both sides use the
+// exact same bytes without the agent having to fetch its own public URL over
+// HTTP to hash content it already has in memory — self-fetching that URL at
+// startup raced the ingress and 503'd intermittently right after a restart.
+// kept in sync with apps/vs-agent-ui/src/assets/logo.svg
+export const DEFAULT_LOGO_SVG = `<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Matches Tailwind's bg-gradient-to-br from #763EF0 to #9F7AEA -->
+    <linearGradient id="veranaHeaderGradient" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#763EF0"/>
+      <stop offset="100%" stop-color="#9F7AEA"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Purple gradient capsule -->
+  <rect x="0" y="0" width="64" height="64" rx="12" fill="url(#veranaHeaderGradient)"/>
+
+  <!-- White Verana mark scaled to the header proportion -->
+  <g transform="translate(32 33) scale(0.76923) translate(-27 -27)" fill="white">
+    <path d="M26.9932 51.6972L5.805 11.0977L2.91263 16.2161L0 10.6048L5.98725 0L26.9932 40.2483L47.9993 0L54 10.6217L51.0773 16.2161L48.1849 11.0977L26.9932 51.6972Z"/>
+    <path d="M13.696 0L26.9935 25.4637L39.9367 0H13.696Z"/>
+  </g>
+</svg>
+`
+
+const defaultResourcePage = (title: string, body: string) => `<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>${title}</title></head>
+<body><h1>${title}</h1><p>${body}</p></body>
+</html>
+`
+
+export const DEFAULT_TERMS_HTML = defaultResourcePage(
+  'Terms and Conditions',
+  'This Verifiable Service has not published its own terms and conditions yet.',
+)
+
+export const DEFAULT_PRIVACY_HTML = defaultResourcePage(
+  'Privacy Policy',
+  'This Verifiable Service has not published its own privacy policy yet.',
+)
+
 // Utils params
 export const MASTER_LIST_CSCA_LOCATION = process.env.MASTER_LIST_CSCA_LOCATION
 

--- a/apps/vs-agent/src/controllers/public/self-tr/DefaultResourcesController.ts
+++ b/apps/vs-agent/src/controllers/public/self-tr/DefaultResourcesController.ts
@@ -1,37 +1,13 @@
 import { Controller, Get, Header } from '@nestjs/common'
 import { ApiExcludeController } from '@nestjs/swagger'
 
-// kept in sync with apps/vs-agent-ui/src/assets/logo.svg
-const LOGO_SVG = `<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <!-- Matches Tailwind's bg-gradient-to-br from #763EF0 to #9F7AEA -->
-    <linearGradient id="veranaHeaderGradient" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
-      <stop offset="0%" stop-color="#763EF0"/>
-      <stop offset="100%" stop-color="#9F7AEA"/>
-    </linearGradient>
-  </defs>
-
-  <!-- Purple gradient capsule -->
-  <rect x="0" y="0" width="64" height="64" rx="12" fill="url(#veranaHeaderGradient)"/>
-
-  <!-- White Verana mark scaled to the header proportion -->
-  <g transform="translate(32 33) scale(0.76923) translate(-27 -27)" fill="white">
-    <path d="M26.9932 51.6972L5.805 11.0977L2.91263 16.2161L0 10.6048L5.98725 0L26.9932 40.2483L47.9993 0L54 10.6217L51.0773 16.2161L48.1849 11.0977L26.9932 51.6972Z"/>
-    <path d="M13.696 0L26.9935 25.4637L39.9367 0H13.696Z"/>
-  </g>
-</svg>
-`
-
-const page = (title: string, body: string) => `<!doctype html>
-<html lang="en">
-<head><meta charset="utf-8"><title>${title}</title></head>
-<body><h1>${title}</h1><p>${body}</p></body>
-</html>
-`
+import { DEFAULT_LOGO_SVG, DEFAULT_PRIVACY_HTML, DEFAULT_TERMS_HTML } from '../../../config'
 
 /**
  * Placeholder resources for a Verifiable Service that has not configured its own. The self-issued
  * credentials reference these by URL and hash them, so they must be fetchable for the agent to start.
+ * Content lives in config/constants.ts so it can be hashed locally (see main.ts) without the agent
+ * having to fetch its own public URL over HTTP.
  */
 @ApiExcludeController()
 @Controller('vt/default')
@@ -39,21 +15,18 @@ export class DefaultResourcesController {
   @Get('logo.svg')
   @Header('Content-Type', 'image/svg+xml')
   getLogo(): string {
-    return LOGO_SVG
+    return DEFAULT_LOGO_SVG
   }
 
   @Get('terms.html')
   @Header('Content-Type', 'text/html; charset=utf-8')
   getTermsAndConditions(): string {
-    return page(
-      'Terms and Conditions',
-      'This Verifiable Service has not published its own terms and conditions yet.',
-    )
+    return DEFAULT_TERMS_HTML
   }
 
   @Get('privacy.html')
   @Header('Content-Type', 'text/html; charset=utf-8')
   getPrivacyPolicy(): string {
-    return page('Privacy Policy', 'This Verifiable Service has not published its own privacy policy yet.')
+    return DEFAULT_PRIVACY_HTML
   }
 }

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -419,7 +419,7 @@ const run = async () => {
     )
   }
 
-  // Initialize Self-Trust Registry  
+  // Initialize Self-Trust Registry
   const selfTrDefaults = {
     agentLabel: AGENT_LABEL,
     serviceLogoUri:

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -18,6 +18,7 @@ import {
   registerAuthorizationHandlers,
   EcsBootstrapService,
   reconcileVtjscPublications,
+  generateDigestSRI,
 } from '@verana-labs/vs-agent-sdk'
 import * as express from 'express'
 import * as fs from 'fs'
@@ -35,6 +36,9 @@ import {
   AGENT_ENDPOINTS,
   AGENT_INVITATION_IMAGE_URL,
   DEFAULT_SELF_ISSUED_VTC_RESOURCES,
+  DEFAULT_LOGO_SVG,
+  DEFAULT_TERMS_HTML,
+  DEFAULT_PRIVACY_HTML,
   SELF_ISSUED_VTC_SERVICE_LOGOURI,
   AGENT_LABEL,
   SELF_ISSUED_VTC_ORG_ADDRESS,
@@ -415,20 +419,27 @@ const run = async () => {
     )
   }
 
-  // Initialize Self-Trust Registry
+  // Initialize Self-Trust Registry  
   const selfTrDefaults = {
     agentLabel: AGENT_LABEL,
     serviceLogoUri:
       SELF_ISSUED_VTC_SERVICE_LOGOURI ?? DEFAULT_SELF_ISSUED_VTC_RESOURCES.logoUri(publicApiBaseUrl),
+    serviceLogoDigestSri: SELF_ISSUED_VTC_SERVICE_LOGOURI ? undefined : generateDigestSRI(DEFAULT_LOGO_SVG),
     serviceType: SELF_ISSUED_VTC_SERVICE_TYPE,
     serviceDescription: SELF_ISSUED_VTC_SERVICE_DESCRIPTION,
     serviceMinimumAgeRequired: SELF_ISSUED_VTC_SERVICE_MINIMUMAGEREQUIRED,
     serviceTermsAndConditions:
       SELF_ISSUED_VTC_SERVICE_TERMSANDCONDITIONS ??
       DEFAULT_SELF_ISSUED_VTC_RESOURCES.termsAndConditionsUri(publicApiBaseUrl),
+    serviceTermsAndConditionsDigestSri: SELF_ISSUED_VTC_SERVICE_TERMSANDCONDITIONS
+      ? undefined
+      : generateDigestSRI(DEFAULT_TERMS_HTML),
     servicePrivacyPolicy:
       SELF_ISSUED_VTC_SERVICE_PRIVACYPOLICY ??
       DEFAULT_SELF_ISSUED_VTC_RESOURCES.privacyPolicyUri(publicApiBaseUrl),
+    servicePrivacyPolicyDigestSri: SELF_ISSUED_VTC_SERVICE_PRIVACYPOLICY
+      ? undefined
+      : generateDigestSRI(DEFAULT_PRIVACY_HTML),
     orgRegistryId: SELF_ISSUED_VTC_ORG_REGISTRYID,
     orgRegistryUri: SELF_ISSUED_VTC_ORG_REGISTRYURI,
     orgAddress: SELF_ISSUED_VTC_ORG_ADDRESS,

--- a/packages/agent-sdk/src/utils/setupSelfTr.ts
+++ b/packages/agent-sdk/src/utils/setupSelfTr.ts
@@ -430,7 +430,9 @@ export async function getClaims(
           description: claims?.description ?? defaults.serviceDescription,
           logoUri,
           logoDigestSri:
-            (claims?.logoDigestSri as string) ?? defaults.serviceLogoDigestSri ?? (await urlDigestSri(logoUri)),
+            (claims?.logoDigestSri as string) ??
+            defaults.serviceLogoDigestSri ??
+            (await urlDigestSri(logoUri)),
           minimumAgeRequired: claims?.minimumAgeRequired ?? defaults.serviceMinimumAgeRequired,
           termsAndConditionsUri,
           termsAndConditionsDigestSri:
@@ -447,7 +449,9 @@ export async function getClaims(
           name: claims?.name ?? defaults.agentLabel,
           logoUri,
           logoDigestSri:
-            (claims?.logoDigestSri as string) ?? defaults.serviceLogoDigestSri ?? (await urlDigestSri(logoUri)),
+            (claims?.logoDigestSri as string) ??
+            defaults.serviceLogoDigestSri ??
+            (await urlDigestSri(logoUri)),
           registryId: claims?.registryId ?? defaults.orgRegistryId,
           registryUri: claims?.registryUri ?? defaults.orgRegistryUri,
           address: claims?.address ?? defaults.orgAddress,

--- a/packages/agent-sdk/src/utils/setupSelfTr.ts
+++ b/packages/agent-sdk/src/utils/setupSelfTr.ts
@@ -35,11 +35,14 @@ const DIGEST_FETCH_TIMEOUT_MS = 5000
 export interface SelfTrDefaults {
   agentLabel: string
   serviceLogoUri: string
+  serviceLogoDigestSri?: string
   serviceType: string
   serviceDescription: string
   serviceMinimumAgeRequired: number
   serviceTermsAndConditions: string
+  serviceTermsAndConditionsDigestSri?: string
   servicePrivacyPolicy: string
+  servicePrivacyPolicyDigestSri?: string
   orgRegistryId: string
   orgRegistryUri: string
   orgAddress: string
@@ -426,19 +429,25 @@ export async function getClaims(
           type: claims?.type ?? defaults.serviceType,
           description: claims?.description ?? defaults.serviceDescription,
           logoUri,
-          logoDigestSri: (claims?.logoDigestSri as string) ?? (await urlDigestSri(logoUri)),
+          logoDigestSri:
+            (claims?.logoDigestSri as string) ?? defaults.serviceLogoDigestSri ?? (await urlDigestSri(logoUri)),
           minimumAgeRequired: claims?.minimumAgeRequired ?? defaults.serviceMinimumAgeRequired,
           termsAndConditionsUri,
           termsAndConditionsDigestSri:
-            (claims?.termsAndConditionsDigestSri as string) ?? (await urlDigestSri(termsAndConditionsUri)),
+            (claims?.termsAndConditionsDigestSri as string) ??
+            defaults.serviceTermsAndConditionsDigestSri ??
+            (await urlDigestSri(termsAndConditionsUri)),
           privacyPolicyUri,
           privacyPolicyDigestSri:
-            (claims?.privacyPolicyDigestSri as string) ?? (await urlDigestSri(privacyPolicyUri)),
+            (claims?.privacyPolicyDigestSri as string) ??
+            defaults.servicePrivacyPolicyDigestSri ??
+            (await urlDigestSri(privacyPolicyUri)),
         }
       : {
           name: claims?.name ?? defaults.agentLabel,
           logoUri,
-          logoDigestSri: (claims?.logoDigestSri as string) ?? (await urlDigestSri(logoUri)),
+          logoDigestSri:
+            (claims?.logoDigestSri as string) ?? defaults.serviceLogoDigestSri ?? (await urlDigestSri(logoUri)),
           registryId: claims?.registryId ?? defaults.orgRegistryId,
           registryUri: claims?.registryUri ?? defaults.orgRegistryUri,
           address: claims?.address ?? defaults.orgAddress,


### PR DESCRIPTION
Mainly to avoid a fresh VS Agent to HTTP fetching itself before being actually ready.

Changes:

- constants.ts: moved the static default logo/terms/privacy content out of DefaultResourcesController.ts into named exports (DEFAULT_LOGO_SVG, DEFAULT_TERMS_HTML, DEFAULT_PRIVACY_HTML), byte-for-byte identical to what was there.
- DefaultResourcesController.ts: now just returns those constants (still serves them over HTTP for actual resolvers/third parties — unchanged external behavior).
- SelfTrDefaults (setupSelfTr.ts): gained three optional precomputed-digest fields.
- getClaims (setupSelfTr.ts): checks the precomputed digest before falling back to urlDigestSri (the network self-fetch).
- main.ts: populates those precomputed digests with generateDigestSRI() over the local constants only when the self-hosted default URI is in play (i.e., the operator hasn't set -SELF_ISSUED_VTC_SERVICE_LOGOURI/TERMSANDCONDITIONS/PRIVACYPOLICY). If an operator does configure a real external URL, the digest is still computed honestly over the network — this only removes the self-referential round trip for the agent's own bundled placeholder.