### PR TITLE
fix(agent-sdk): keep self-issued ECS credentials detached once a real one is stored

### DIFF
--- a/packages/agent-sdk/src/utils/setupSelfTr.ts
+++ b/packages/agent-sdk/src/utils/setupSelfTr.ts
@@ -332,7 +332,8 @@ export async function generateVerifiablePresentation(
   const integrityData = buildIntegrityData({ id, type, credentialSchema, claims })
   const record = didRecord.metadata.get('_vt/vtc') ?? {}
   const metadata = record[credentialSchema.id]
-  if (metadata?.integrityData === integrityData && metadata.attached) return metadata.verifiablePresentation
+  const attached = metadata?.attached ?? true
+  if (metadata?.integrityData === integrityData) return metadata.verifiablePresentation
 
   const presentation = createPresentation({
     id,
@@ -351,19 +352,20 @@ export async function generateVerifiablePresentation(
     presentation,
   )
   // Update linked VP when the presentation has changed
-  didDocument.service = didDocument.service?.map(s => {
-    if (typeof s.serviceEndpoint !== 'string') return s
-    if (s.serviceEndpoint.includes(schemaKey) && s.id !== `${agent.did}#whois`) {
-      s.id = didDocumentServiceId
-      s.serviceEndpoint = id
-    }
-    return s
-  })
+  if (attached)
+    didDocument.service = didDocument.service?.map(s => {
+      if (typeof s.serviceEndpoint !== 'string') return s
+      if (s.serviceEndpoint.includes(schemaKey) && s.id !== `${agent.did}#whois`) {
+        s.id = didDocumentServiceId
+        s.serviceEndpoint = id
+      }
+      return s
+    })
   // Resolvers only discover the credential through the [VT-CRED-W3C-LINKED-VP] fragment, and
   // #whois does not match it. The rename above only covers documents that already carry the
   // service, so publish it here when nothing declared it yet.
   let didDocumentChanged = false
-  if (!didDocument.service?.some(s => s.id === didDocumentServiceId)) {
+  if (attached && !didDocument.service?.some(s => s.id === didDocumentServiceId)) {
     didDocument.service = [
       ...(didDocument.service ?? []),
       new DidDocumentService({
@@ -380,7 +382,7 @@ export async function generateVerifiablePresentation(
     verifiablePresentation,
     didDocumentServiceId,
     integrityData,
-    attached: true,
+    attached,
   }
   didRecord.metadata.set('_vt/vtc', record)
   await agent.context.dependencyManager.resolve(DidRepository).update(agent.context, didRecord)

--- a/packages/agent-sdk/src/utils/trustCredentialStore.ts
+++ b/packages/agent-sdk/src/utils/trustCredentialStore.ts
@@ -112,8 +112,9 @@ export async function saveMetadataEntry(
   if (service && verifiablePresentation.id?.includes('service'))
     service.serviceEndpoint = verifiablePresentation.id!
 
-  // When a new VTC has been added, remove the self VTCs
-  updateVtcEntries(didRecord, false, publicApiBaseUrl)
+  // A JSON schema credential says nothing about this agent's own ECS identity, so only a real
+  // trust credential replaces the self-issued ones.
+  if (key === '_vt/vtc') updateVtcEntries(didRecord, false, publicApiBaseUrl)
   await updateDidRecord(agent, didRecord)
 }
 

--- a/packages/agent-sdk/tests/selfVtcAttachState.test.ts
+++ b/packages/agent-sdk/tests/selfVtcAttachState.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { mapToSelfTr, presentations } from '../src/utils/setupSelfTr'
+import { saveMetadataEntry } from '../src/utils/trustCredentialStore'
+
+const PUBLIC_URL = 'https://agent.example'
+const DID = 'did:web:agent.example'
+const CRED_ID = `${PUBLIC_URL}/vt/cred-1.json`
+const SCHEMA_REF = 'vpr:verana:vna-demo-1:cs:9'
+
+const selfIds = presentations.map(p => mapToSelfTr(p.schemaUrl, PUBLIC_URL))
+const serviceIdFor = (schemaId: string) => `${DID}#vpr-${schemaId.split('/').pop()}-vtc-vp`
+
+function makeRecord() {
+  const vtc = Object.fromEntries(
+    selfIds.map(id => [
+      id,
+      {
+        credential: {},
+        verifiablePresentation: { id: `${id}-vp.json` },
+        didDocumentServiceId: serviceIdFor(id),
+        attached: true,
+      },
+    ]),
+  )
+  const store: Record<string, unknown> = { '_vt/vtc': vtc }
+  return {
+    did: DID,
+    didDocument: {
+      service: selfIds.map(id => ({
+        id: serviceIdFor(id),
+        serviceEndpoint: `${id}-vp.json`,
+        type: 'LinkedVerifiablePresentation',
+      })),
+    },
+    metadata: {
+      get: (k: string) => store[k],
+      set: (k: string, v: unknown) => {
+        store[k] = v
+      },
+    },
+    attachedFlags: () =>
+      selfIds.map(id => (store['_vt/vtc'] as Record<string, { attached: boolean }>)[id].attached),
+  }
+}
+
+const agent = {
+  did: DID,
+  context: { dependencyManager: { resolve: () => ({ update: vi.fn() }) } },
+  dids: { update: vi.fn() },
+} as never
+
+const credential = {
+  id: CRED_ID,
+  jsonCredential: { id: CRED_ID },
+  credentialSchema: { id: SCHEMA_REF },
+  credentialSubject: { id: SCHEMA_REF },
+} as never
+
+const presentation = { id: `${PUBLIC_URL}/vt/cred-1-vp.json` } as never
+
+const storeReal = (record: ReturnType<typeof makeRecord>, key: '_vt/vtc' | '_vt/jsc') =>
+  saveMetadataEntry(agent, record as never, credential, presentation, `${DID}#vpr-real`, key, PUBLIC_URL)
+
+describe('self-issued VTC attach state', () => {
+  it('keeps the self-issued entries when a json schema credential is stored', async () => {
+    const record = makeRecord()
+    await storeReal(record, '_vt/jsc')
+
+    expect(record.attachedFlags()).toEqual([true, true])
+    expect(record.didDocument.service.map(s => s.id)).toContain(serviceIdFor(selfIds[0]))
+  })
+})

--- a/packages/agent-sdk/tests/selfVtcAttachState.test.ts
+++ b/packages/agent-sdk/tests/selfVtcAttachState.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { mapToSelfTr, presentations } from '../src/utils/setupSelfTr'
+vi.mock('axios', () => ({
+  default: { get: vi.fn(async (url: string) => ({ data: Buffer.from(`bytes of ${url}`) })) },
+}))
+
+import { getEcsSchemas } from '../src/utils/data'
+import {
+  generateDigestSRI,
+  generateVerifiablePresentation,
+  getClaims,
+  linkedVpFragment,
+  mapToSelfTr,
+  presentations,
+  SelfTrDefaults,
+} from '../src/utils/setupSelfTr'
 import { saveMetadataEntry } from '../src/utils/trustCredentialStore'
 
 const PUBLIC_URL = 'https://agent.example'
@@ -62,6 +75,83 @@ const presentation = { id: `${PUBLIC_URL}/vt/cred-1-vp.json` } as never
 const storeReal = (record: ReturnType<typeof makeRecord>, key: '_vt/vtc' | '_vt/jsc') =>
   saveMetadataEntry(agent, record as never, credential, presentation, `${DID}#vpr-real`, key, PUBLIC_URL)
 
+const target = presentations[0]
+const schemaKey = target.name
+const targetSchemaId = mapToSelfTr(target.schemaUrl, PUBLIC_URL)
+const linkedServiceId = `${DID}#${linkedVpFragment(schemaKey)}`
+const VP_ID = `${PUBLIC_URL}/vt/${schemaKey}-vtc-vp.json`
+const TYPE = ['VerifiableCredential', 'VerifiableTrustCredential']
+const targetCredentialSchema = { id: targetSchemaId, type: 'JsonSchemaCredential' } as never
+const schemas = getEcsSchemas(PUBLIC_URL)
+const logger = { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() }
+
+const defaults: SelfTrDefaults = {
+  agentLabel: 'Agent',
+  serviceLogoUri: 'https://cdn.example/logo.png',
+  serviceType: 'ECommerce',
+  serviceDescription: 'demo',
+  serviceMinimumAgeRequired: 18,
+  serviceTermsAndConditions: 'https://cdn.example/terms',
+  servicePrivacyPolicy: 'https://cdn.example/privacy',
+  orgRegistryId: 'REG-1',
+  orgRegistryUri: 'https://registry.example',
+  orgAddress: '1 Demo Street',
+  orgOrganizationKind: 'PUBLIC',
+  orgCountryCode: 'US',
+}
+
+async function unchangedIntegrityData() {
+  const claims = await getClaims(logger as never, schemas, { id: DID }, schemaKey, defaults)
+  const data = { id: VP_ID, type: TYPE, credentialSchema: targetCredentialSchema, claims }
+  return generateDigestSRI(JSON.stringify(data, Object.keys(data).sort()))
+}
+
+function agentAfterRealCredential(integrityData: string) {
+  const vm = `${DID}#key-1`
+  const didDocument = {
+    verificationMethod: [{ id: vm, type: 'Ed25519VerificationKey2020', controller: DID }],
+    assertionMethod: [vm],
+    service: [] as { id: string }[],
+  }
+  const store: Record<string, unknown> = {
+    '_vt/vtc': {
+      [targetSchemaId]: {
+        integrityData,
+        attached: false,
+        verifiablePresentation: { id: VP_ID },
+        didDocumentServiceId: linkedServiceId,
+      },
+    },
+  }
+  const didRecord = {
+    did: DID,
+    didDocument,
+    metadata: {
+      get: (k: string) => store[k],
+      set: (k: string, v: unknown) => {
+        store[k] = v
+      },
+    },
+  }
+  return {
+    agent: {
+      did: DID,
+      config: { logger },
+      dids: { getCreatedDids: async () => [didRecord], update: vi.fn() },
+      w3cCredentials: {
+        signCredential: async (o: never) => ({ ...(o as { credential: object }).credential, proof: {} }),
+        signPresentation: async (o: never) => ({
+          ...(o as { presentation: object }).presentation,
+          id: VP_ID,
+          proof: {},
+        }),
+      },
+      context: { dependencyManager: { resolve: () => ({ update: vi.fn() }) } },
+    },
+    didDocument,
+  }
+}
+
 describe('self-issued VTC attach state', () => {
   it('keeps the self-issued entries when a json schema credential is stored', async () => {
     const record = makeRecord()
@@ -69,5 +159,21 @@ describe('self-issued VTC attach state', () => {
 
     expect(record.attachedFlags()).toEqual([true, true])
     expect(record.didDocument.service.map(s => s.id)).toContain(serviceIdFor(selfIds[0]))
+  })
+
+  it('does not republish a detached self-issued service on the next boot', async () => {
+    const { agent, didDocument } = agentAfterRealCredential(await unchangedIntegrityData())
+
+    await generateVerifiablePresentation(
+      agent as never,
+      VP_ID,
+      schemas,
+      schemaKey,
+      TYPE,
+      targetCredentialSchema,
+      defaults,
+    )
+
+    expect(didDocument.service.map(s => s.id)).not.toContain(linkedServiceId)
   })
 })


### PR DESCRIPTION
Closes https://github.com/verana-labs/vs-agent/issues/578

Two bugs, both around the `attached` flag on the self-issued ECS entries.

`saveMetadataEntry` detached them on every write, including `_vt/jsc`. So publishing any JSON schema credential stripped the agent's own ECS services from the DID document, even with no real credential involved. Only a real `_vt/vtc` write does that now.

`generateVerifiablePresentation` wrote `attached: true` on every rebuild and its early return required `attached`, so a detached entry came back on the next restart. It now keeps the stored value and only touches the DID document while the entry is attached. That also repairs the restore path, since `updateVtcEntries(true)` no longer sees a flag that already says true.

One test, on the `_vt/jsc` case. I checked the others I had written against main and they passed there, so they were testing existing behavior and I dropped them. The restart half needs the real signing path, so it is not covered here.