### PR TITLE
feat(vs-agent): anchor digestJCS in admin jsonld issuance

### DIFF
--- a/apps/vs-agent/package.json
+++ b/apps/vs-agent/package.json
@@ -70,6 +70,7 @@
     "@nestjs/swagger": "^8.0.7",
     "@openwallet-foundation/askar-nodejs": "^0.6.0",
     "@types/qrcode": "^1.5.0",
+    "@verana-labs/verre": "0.4.0-dev.1",
     "@verana-labs/vs-agent-model": "workspace:*",
     "@verana-labs/vs-agent-sdk": "workspace:*",
     "bull": "^4.16.2",

--- a/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeService.ts
+++ b/apps/vs-agent/src/controllers/admin/credentials/CredentialTypeService.ts
@@ -516,7 +516,12 @@ export class CredentialTypesService {
       if (attrNames.length === 0) {
         throw new Error(`No properties found in credentialSubject of schema from ${jsonSchemaCredentialId}`)
       }
-      return { parsedSchema, attrNames, title: parsedSchema?.title as string | undefined }
+      return {
+        parsedSchema,
+        attrNames,
+        title: parsedSchema?.title as string | undefined,
+        subjectRef: subjectId,
+      }
     } catch (error) {
       throw new Error(`Failed to parse JSON Schema Credential ${jsonSchemaCredentialId}: ${error}`)
     }

--- a/apps/vs-agent/src/controllers/admin/verifiable/TrustController.ts
+++ b/apps/vs-agent/src/controllers/admin/verifiable/TrustController.ts
@@ -72,8 +72,24 @@ export class TrustController {
       'The response includes either the JSON-LD W3C Credential contents, directly to transmit to the recipient, or the DIDComm Invitation and Credential Exchange ID associated in case of AnonCreds for further tracking through events interface.',
   })
   async issueCredential(@Body() body: IssueCredentialRequestDto) {
-    const { format, did, jsonSchemaCredentialId, claims } = body
-    return await this.trustService.issueCredential({ format, jsonSchemaCredentialId, claims, did })
+    const {
+      format,
+      did,
+      jsonSchemaCredentialId,
+      claims,
+      participantSessionId,
+      agentParticipantId,
+      walletAgentParticipantId,
+    } = body
+    return await this.trustService.issueCredential({
+      format,
+      jsonSchemaCredentialId,
+      claims,
+      did,
+      participantSessionId,
+      agentParticipantId,
+      walletAgentParticipantId,
+    })
   }
 
   @Post('revoke-credential')

--- a/apps/vs-agent/src/controllers/admin/verifiable/TrustService.ts
+++ b/apps/vs-agent/src/controllers/admin/verifiable/TrustService.ts
@@ -7,6 +7,7 @@ import {
   W3cJsonLdVerifiableCredential,
 } from '@credo-ts/core'
 import { Logger, Inject, Injectable, HttpException, HttpStatus } from '@nestjs/common'
+import { computeCredentialDigestJCS } from '@verana-labs/verre'
 import {
   CredentialIssuanceRequest,
   CredentialIssuanceResponse,
@@ -177,17 +178,68 @@ export class TrustService {
     return credential.jsonCredential
   }
 
+  private async anchorDigest(
+    agent: VsAgent,
+    subjectRef: string,
+    credential: Record<string, unknown>,
+    session: { participantSessionId: string; agentParticipantId?: number; walletAgentParticipantId?: number },
+  ): Promise<string> {
+    const chain = agent.veranaChain
+    if (!chain) throw new HttpException('ANCHORING_FAILED: no chain configured', HttpStatus.BAD_GATEWAY)
+
+    const ref = subjectRef.match(new RegExp(`^vpr:verana:${chain.getChainId}:cs:(\\d+)$`))
+    if (!ref)
+      throw new HttpException(
+        `ANCHORING_FAILED: schema reference '${subjectRef}' is not governed by chain '${chain.getChainId}'`,
+        HttpStatus.BAD_GATEWAY,
+      )
+    const schemaId = Number(ref[1])
+
+    if (!agent.did)
+      throw new HttpException('ANCHORING_FAILED: agent has no public DID', HttpStatus.BAD_GATEWAY)
+    const issuerParticipantId = await chain.findActiveIssuerParticipantId(agent.did, schemaId)
+    if (issuerParticipantId === undefined)
+      throw new HttpException(
+        `ANCHORING_FAILED: no active ISSUER participant for schema ${schemaId}`,
+        HttpStatus.BAD_GATEWAY,
+      )
+
+    const schema = await chain.getCredentialSchema(schemaId)
+    if (!schema?.digestAlgorithm)
+      throw new HttpException(
+        `ANCHORING_FAILED: credential schema ${schemaId} has no digest_algorithm`,
+        HttpStatus.BAD_GATEWAY,
+      )
+
+    const digestJCS = computeCredentialDigestJCS(credential as never, schema.digestAlgorithm)
+    try {
+      await chain.createOrUpdateParticipantSession({
+        id: session.participantSessionId,
+        issuerParticipantId,
+        agentParticipantId: session.agentParticipantId ?? 0,
+        walletAgentParticipantId: session.walletAgentParticipantId ?? 0,
+        digest: digestJCS,
+      })
+    } catch (error) {
+      throw new HttpException(`ANCHORING_FAILED: ${(error as Error).message}`, HttpStatus.BAD_GATEWAY)
+    }
+    return digestJCS
+  }
+
   public async issueCredential({
     format,
     jsonSchemaCredentialId,
     claims,
     did,
+    participantSessionId,
+    agentParticipantId,
+    walletAgentParticipantId,
   }: CredentialIssuanceRequest): Promise<CredentialIssuanceResponse> {
     try {
       // Check schema for credential
       const { agent, didRecord } = await this.getDidRecord()
 
-      const { parsedSchema, attrNames } =
+      const { parsedSchema, attrNames, subjectRef } =
         await this.credentialTypesService.parseJsonSchemaCredential(jsonSchemaCredentialId)
       if (attrNames.length === 0) {
         throw new HttpException(
@@ -198,11 +250,22 @@ export class TrustService {
       validateSchema(parsedSchema, claims)
 
       switch (format) {
-        case 'jsonld':
+        case 'jsonld': {
           if (!did)
             throw new HttpException('did must be present for JSON-LD credentials', HttpStatus.BAD_REQUEST)
+          if (!participantSessionId)
+            throw new HttpException(
+              'participantSessionId must be present for JSON-LD credentials',
+              HttpStatus.BAD_REQUEST,
+            )
           const credential = await this.issueW3cJsonLd(agent, didRecord, did, jsonSchemaCredentialId, claims)
-          return { status: 200, didcommInvitationUrl: '', credential }
+          const digestJCS = await this.anchorDigest(agent, subjectRef, credential, {
+            participantSessionId,
+            agentParticipantId,
+            walletAgentParticipantId,
+          })
+          return { status: 200, didcommInvitationUrl: '', credential, digestJCS }
+        }
         case 'anoncreds':
           const { credentialDefinitionId } =
             await this.credentialTypesService.getOrRegisterAnonCredsCredentialDefinition({

--- a/apps/vs-agent/src/controllers/admin/verifiable/dto/issue-credential-request.dto.ts
+++ b/apps/vs-agent/src/controllers/admin/verifiable/dto/issue-credential-request.dto.ts
@@ -1,6 +1,16 @@
 import { JsonObject } from '@credo-ts/core'
 import { ApiProperty } from '@nestjs/swagger'
-import { IsNotEmpty, IsString, IsUrl, Matches, IsObject, IsOptional } from 'class-validator'
+import {
+  IsInt,
+  IsNotEmpty,
+  IsString,
+  IsUrl,
+  IsUUID,
+  Matches,
+  Min,
+  IsObject,
+  IsOptional,
+} from 'class-validator'
 
 /**
  * DTO used to request the issuance of a Verifiable Credential.
@@ -47,4 +57,34 @@ export class IssueCredentialRequestDto {
   @IsObject()
   @IsNotEmpty()
   claims!: JsonObject
+
+  @ApiProperty({
+    description:
+      'ParticipantSession uuid supplied by the recipient agent. Required for jsonld: the digest of the signed credential is anchored under this session before the credential is returned.',
+    example: 'd7f2f4c6-9c9b-4c39-9e6a-3e1c2a3b4c5d',
+    required: false,
+  })
+  @IsUUID()
+  @IsOptional()
+  participantSessionId?: string
+
+  @ApiProperty({
+    description:
+      'Participant id of the agent that will receive the credential. Only when the recipient is a Verifiable User Agent.',
+    required: false,
+  })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  agentParticipantId?: number
+
+  @ApiProperty({
+    description:
+      'Participant id of the wallet agent that will store the credential. Only when the recipient is a Verifiable User Agent.',
+    required: false,
+  })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  walletAgentParticipantId?: number
 }

--- a/apps/vs-agent/tests/__mocks__/object.ts
+++ b/apps/vs-agent/tests/__mocks__/object.ts
@@ -176,7 +176,13 @@ export const jsonSchemaV2Mock = {
   type: 'object',
 }
 
+export const jsonSchemaCredentialVprMock = JSON.parse(
+  '{"@context": ["https://www.w3.org/2018/credentials/v1", "https://www.w3.org/2018/credentials/examples/v1"], "id": "https://example.org/vt/schemas-vpr-org-jsc.json", "type": ["VerifiableCredential", "JsonSchemaCredential"], "issuer": "did:webvh:QmZq5CvJVgNk6k2gzze6A7z7PNrpYdpPxjeWD6rFxjfdzY:dm.chatbot.demos.dev.2060.io", "issuanceDate": "2025-11-05T20:52:22.688Z", "expirationDate": "2035-11-03T20:52:22.688Z", "credentialSubject": {"type": "JsonSchema", "jsonSchema": {"$ref": "vpr:verana:vna-test-1:cs:7"}, "digestSRI": "sha256-ttE9qtGhU8GrPI33/6Y0sc0AT5XEaBLo0O4z9AMeTBM=", "id": "vpr:verana:vna-test-1:cs:7"}, "credentialSchema": {"id": "https://www.w3.org/ns/credentials/json-schema/v2.json", "type": "JsonSchema", "digestSRI": "sha256-qm/TCo3y3vnDW3lvcF42wTannkJbyU+uUxWHyl23NKM="}, "proof": {"verificationMethod": "did:webvh:QmZq5CvJVgNk6k2gzze6A7z7PNrpYdpPxjeWD6rFxjfdzY:dm.chatbot.demos.dev.2060.io#z6MkukriSiZbUxTaiPMPQz6Lu6vEL6vB9vjwfRi4gjFLCx18", "type": "Ed25519Signature2020", "created": "2025-11-05T20:52:22Z", "proofPurpose": "assertionMethod", "proofValue": "zDAvpiww2mMp9XaUcWqpmjwEAds3KqauKE3oMVMnZfSWMfYb5vUwon8FfM4twZ6x5Hvcbga7U56HkHzp14GX46J4"}}',
+)
+
 export const mockResponses: { [key: string]: any } = {
+  'https://example.org/vt/schemas-vpr-org-jsc.json': jsonSchemaCredentialVprMock,
+  'vpr:verana:vna-test-1:cs:7': jsonSchemaOrgMock,
   'https://example.org/vt/schemas-example-org-jsc.json': jsonSchemaCredentialMock,
   'https://dm.chatbot.demos.dev.2060.io/vt/cs/v1/js/ecs-org': jsonSchemaOrgMock,
   'https://dm.chatbot.demos.dev.2060.io/vt/cs/v1/js/ecs-service': jsonSchemaServiceMock,

--- a/apps/vs-agent/tests/trustService.test.ts
+++ b/apps/vs-agent/tests/trustService.test.ts
@@ -10,6 +10,8 @@ import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest'
 
 import { MessageService, TrustService } from '../src/controllers'
 
+import { computeCredentialDigestJCS } from '@verana-labs/verre'
+
 import { isCredentialStateChangedEvent, startAgent, startServersTesting } from './__mocks__'
 import {
   makeConnection,
@@ -133,8 +135,17 @@ describe('TrustService', () => {
   })
 
   describe('Testing for message exchange with VsAgent', async () => {
+    let sessionMock: ReturnType<typeof vi.fn>
+    let fakeChain: Record<string, unknown>
     beforeEach(async () => {
-      faberAgent = await startAgent({ label: 'Faber Test', domain: 'faber' })
+      sessionMock = vi.fn(async () => ({ txHash: 'tx-1' }))
+      fakeChain = {
+        getChainId: 'vna-test-1',
+        findActiveIssuerParticipantId: vi.fn(async () => 12),
+        getCredentialSchema: vi.fn(async () => ({ digestAlgorithm: 'sha384' })),
+        createOrUpdateParticipantSession: sessionMock,
+      }
+      faberAgent = await startAgent({ label: 'Faber Test', domain: 'faber', veranaChain: fakeChain as never })
       faberAgent.didcomm.registerInboundTransport(new SubjectInboundTransport(faberMessages))
       faberAgent.didcomm.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
       await faberAgent.initialize()
@@ -163,7 +174,8 @@ describe('TrustService', () => {
       const credentialResponse = await faberService.issueCredential({
         format: 'jsonld',
         did: 'did:web:example.com',
-        jsonSchemaCredentialId: 'https://example.org/vt/schemas-example-org-jsc.json',
+        participantSessionId: 'd7f2f4c6-9c9b-4c39-9e6a-3e1c2a3b4c5d',
+        jsonSchemaCredentialId: 'https://example.org/vt/schemas-vpr-org-jsc.json',
         claims: {
           id: 'https://example.org/org/123',
           name: 'OpenAI Research',
@@ -185,6 +197,84 @@ describe('TrustService', () => {
           proofValue: expect.any(String),
         }),
       )
+      expect(credentialResponse.digestJCS).toBe(
+        computeCredentialDigestJCS(credentialResponse.credential as never, 'sha384'),
+      )
+      expect(sessionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'd7f2f4c6-9c9b-4c39-9e6a-3e1c2a3b4c5d',
+          issuerParticipantId: 12,
+          digest: credentialResponse.digestJCS,
+        }),
+      )
+    })
+
+    it('rejects a jsonld issuance without a participantSessionId', async () => {
+      await expect(
+        faberService.issueCredential({
+          format: 'jsonld',
+          did: 'did:web:example.com',
+          jsonSchemaCredentialId: 'https://example.org/vt/schemas-vpr-org-jsc.json',
+          claims: {
+            id: 'https://example.org/org/123',
+            name: 'OpenAI Research',
+            logoUri: 'https://example.com/logo.png',
+            logoDigestSri: 'sha384-AAAA',
+            registryId: 'REG-123',
+            registryUri: 'https://registry.example.org',
+            address: '123 Main St, San Francisco, CA',
+            organizationKind: 'PRIVATE',
+            countryCode: 'US',
+          },
+        }),
+      ).rejects.toThrow(/participantSessionId/)
+      expect(sessionMock).not.toHaveBeenCalled()
+    })
+
+    it('returns no credential when the anchoring transaction fails', async () => {
+      sessionMock.mockRejectedValueOnce(new Error('tx rejected'))
+      await expect(
+        faberService.issueCredential({
+          format: 'jsonld',
+          did: 'did:web:example.com',
+          participantSessionId: 'd7f2f4c6-9c9b-4c39-9e6a-3e1c2a3b4c5d',
+          jsonSchemaCredentialId: 'https://example.org/vt/schemas-vpr-org-jsc.json',
+          claims: {
+            id: 'https://example.org/org/123',
+            name: 'OpenAI Research',
+            logoUri: 'https://example.com/logo.png',
+            logoDigestSri: 'sha384-AAAA',
+            registryId: 'REG-123',
+            registryUri: 'https://registry.example.org',
+            address: '123 Main St, San Francisco, CA',
+            organizationKind: 'PRIVATE',
+            countryCode: 'US',
+          },
+        }),
+      ).rejects.toThrow(/ANCHORING_FAILED/)
+    })
+
+    it('rejects a schema that is not governed by the configured chain', async () => {
+      await expect(
+        faberService.issueCredential({
+          format: 'jsonld',
+          did: 'did:web:example.com',
+          participantSessionId: 'd7f2f4c6-9c9b-4c39-9e6a-3e1c2a3b4c5d',
+          jsonSchemaCredentialId: 'https://example.org/vt/schemas-example-org-jsc.json',
+          claims: {
+            id: 'https://example.org/org/123',
+            name: 'OpenAI Research',
+            logoUri: 'https://example.com/logo.png',
+            logoDigestSri: 'sha384-AAAA',
+            registryId: 'REG-123',
+            registryUri: 'https://registry.example.org',
+            address: '123 Main St, San Francisco, CA',
+            organizationKind: 'PRIVATE',
+            countryCode: 'US',
+          },
+        }),
+      ).rejects.toThrow(/ANCHORING_FAILED/)
+      expect(sessionMock).not.toHaveBeenCalled()
     })
 
     it('should issue a valid anoncreds credential', async () => {

--- a/packages/agent-sdk/src/blockchain/VeranaChainService.ts
+++ b/packages/agent-sdk/src/blockchain/VeranaChainService.ts
@@ -55,6 +55,7 @@ const {
 
 // ParticipantRole.HOLDER (x/pp/types); the only role whose vs_operator may send TriggerResolver (chain Path 1).
 const PARTICIPANT_ROLE_HOLDER = 6
+const PARTICIPANT_ROLE_ISSUER = 1
 
 function mapParticipant(p: RawParticipant): Participant {
   return {
@@ -200,6 +201,7 @@ export class VeranaChainService {
       id: s.id,
       ecosystemId: s.ecosystemId,
       jsonSchema: s.jsonSchema,
+      digestAlgorithm: s.digestAlgorithm,
       issuerOnboardingMode: s.issuerOnboardingMode,
       verifierOnboardingMode: s.verifierOnboardingMode,
       holderOnboardingMode: s.holderOnboardingMode,
@@ -321,6 +323,19 @@ export class VeranaChainService {
     const { participants } = await this.ppQuery.FindParticipantsWithDID(request)
     return participants.find(
       p => p.did === did && p.role === PARTICIPANT_ROLE_HOLDER && !p.revoked && !p.slashed,
+    )?.id
+  }
+
+  async findActiveIssuerParticipantId(did: string, schemaId: number): Promise<number | undefined> {
+    const request = QueryFindParticipantsWithDIDRequest.fromPartial({ did })
+    const { participants } = await this.ppQuery.FindParticipantsWithDID(request)
+    return participants.find(
+      p =>
+        p.did === did &&
+        p.role === PARTICIPANT_ROLE_ISSUER &&
+        p.schemaId === schemaId &&
+        !p.revoked &&
+        !p.slashed,
     )?.id
   }
 

--- a/packages/agent-sdk/src/blockchain/types.ts
+++ b/packages/agent-sdk/src/blockchain/types.ts
@@ -247,6 +247,7 @@ export interface CredentialSchema {
   id: number
   ecosystemId: number
   jsonSchema: string
+  digestAlgorithm: string
   issuerOnboardingMode: number
   verifierOnboardingMode: number
   holderOnboardingMode: number

--- a/packages/model/src/types.ts
+++ b/packages/model/src/types.ts
@@ -35,6 +35,9 @@ export interface CredentialIssuanceRequest {
   jsonSchemaCredentialId: string
   claims: JsonObject
   did?: string
+  participantSessionId?: string
+  agentParticipantId?: number
+  walletAgentParticipantId?: number
 }
 
 export interface CredentialIssuanceResponse {
@@ -42,6 +45,7 @@ export interface CredentialIssuanceResponse {
   didcommInvitationUrl?: string
   jsonSchemaCredentialId?: string
   credential?: Record<string, unknown>
+  digestJCS?: string
 }
 
 export interface CredentialRevocationRequest {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.0
         version: 1.5.5
+      '@verana-labs/verre':
+        specifier: 0.4.0-dev.1
+        version: 0.4.0-dev.1(web-streams-polyfill@3.3.3)
       '@verana-labs/vs-agent-model':
         specifier: workspace:*
         version: link:../../packages/model


### PR DESCRIPTION
Closes #568.

The standalone issuance endpoint signed and returned the credential without anchoring. Now, for jsonld, it signs, computes the digestJCS with verre using the schema's digest_algorithm, anchors it via CreateOrUpdateParticipantSession under the caller-supplied participantSessionId, and only then returns. A failed anchor throws ANCHORING_FAILED and no credential is returned.

New inputs per the merged spec: participantSessionId (required for jsonld, the agent never generates it), plus optional agentParticipantId and walletAgentParticipantId. The response now includes the anchored digestJCS.

The schema must be governed by the configured chain (vpr:verana:<chain>:cs:<n>), anything else fails closed. Along the way, getCredentialSchema was dropping digest_algorithm from its mapping even though the proto carries it.

anoncreds is unchanged, anchoring happens in its DIDComm flow as per the spec.