### PR TITLE
fix: wait for DID Document availability on delegated mode

### DIFF
--- a/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
@@ -12,6 +12,7 @@ import { identifySchema } from '@verana-labs/vs-agent-model'
 
 import { VsAgent } from '../../agent/VsAgent'
 import { getEcsSchemas } from '../../utils/data'
+import { waitUntilOwnDidIsPubliclyResolvable } from '../../utils/didReadiness'
 import { SelfTrDefaults, generateDigestSRI } from '../../utils/setupSelfTr'
 import {
   createJsc,
@@ -320,6 +321,7 @@ export async function startParticipantOPAutoFlow(agent: VsAgent, activity: Index
   const holderParticipant = await chain.getParticipant(applicantParticipantId)
   if (!holderParticipant || holderParticipant.did !== agent.did) return
   try {
+    await waitUntilOwnDidIsPubliclyResolvable(agent, agent.config.logger)
     const orchestrator = new VtFlowOrchestrator(agent)
     await orchestrator.startOnboardingProcess({ applicantParticipantId })
   } catch (err) {

--- a/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
+++ b/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
@@ -34,6 +34,18 @@ const ECS_TITLE_BY_TYPE: Record<string, ECS> = {
 }
 
 const DELEGATED_OUTCOME_TIMEOUT_MS = 15 * 60_000
+// On a fresh deployment, the ingress route to this agent's own public endpoint
+// can lag a few seconds behind the process becoming ready (e.g. a k8s Service
+// has not finished propagating the new pod IP yet). The parent VS resolves our
+// DID as part of processing the delegated request, so we wait for our own DID
+// document to be publicly fetchable before sending anything.
+const OWN_DID_READY_TIMEOUT_MS = 60_000
+const OWN_DID_READY_POLL_INTERVAL_MS = 2_000
+// Thin safety net for any remaining transient failure (e.g. a network blip from
+// the parent's vantage point), on top of the readiness wait above.
+const DELEGATED_REQUEST_MAX_ATTEMPTS = 2
+const DELEGATED_REQUEST_ATTEMPT_TIMEOUT_MS = 60_000
+const DELEGATED_REQUEST_RETRY_DELAY_MS = 5_000
 
 export interface EcsBootstrapOptions {
   mode: 'standalone' | 'delegated'
@@ -370,6 +382,8 @@ export class EcsBootstrapService {
       )
     }
 
+    await this.waitUntilOwnDidIsPubliclyResolvable()
+
     const verified = await this.options.verifyPeer(parentDid).catch(() => false)
     if (!verified) {
       throw new Error(`parent VS ${parentDid} is not a Verifiable Service`)
@@ -377,6 +391,57 @@ export class EcsBootstrapService {
 
     const schemaId = await this.findParentServiceSchemaId(parentDid)
 
+    let lastError: Error | undefined
+    for (let attempt = 1; attempt <= DELEGATED_REQUEST_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.requestDelegatedServiceCredential(parentDid, schemaId, attempt)
+        return
+      } catch (error) {
+        lastError = error as Error
+        this.logger.warn(
+          `[EcsBootstrap] delegated issuance attempt ${attempt}/${DELEGATED_REQUEST_MAX_ATTEMPTS} failed: ${lastError.message}`,
+        )
+        if (attempt < DELEGATED_REQUEST_MAX_ATTEMPTS) {
+          await new Promise(resolve => setTimeout(resolve, DELEGATED_REQUEST_RETRY_DELAY_MS))
+        }
+      }
+    }
+    throw lastError ?? new Error(`parent VS ${parentDid} did not complete the issuance in time`)
+  }
+
+  // Waits until this agent's own DID document is fetchable at its public endpoint, so the
+  // parent VS can resolve us as soon as we reach out to it. Checks the same file a peer's
+  // resolver would fetch: did.jsonl for did:webvh, did.json for did:web. Logs and moves on
+  // if the deadline passes, rather than blocking bootstrap forever on a misconfigured deployment.
+  private async waitUntilOwnDidIsPubliclyResolvable(): Promise<void> {
+    const did = this.agent.did
+    if (!did || !this.agent.publicApiBaseUrl) return
+
+    const wellKnownFile = did.startsWith('did:web:') ? 'did.json' : 'did.jsonl'
+    const url = `${this.agent.publicApiBaseUrl}/.well-known/${wellKnownFile}`
+
+    const deadline = Date.now() + OWN_DID_READY_TIMEOUT_MS
+    let lastStatus: number | string = 'unreachable'
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(url)
+        if (response.ok) return
+        lastStatus = response.status
+      } catch (error) {
+        lastStatus = (error as Error).message
+      }
+      await new Promise(resolve => setTimeout(resolve, OWN_DID_READY_POLL_INTERVAL_MS))
+    }
+    this.logger.warn(
+      `[EcsBootstrap] own DID document at ${url} was not publicly resolvable after ${OWN_DID_READY_TIMEOUT_MS}ms (last: ${lastStatus}); proceeding anyway`,
+    )
+  }
+
+  private async requestDelegatedServiceCredential(
+    parentDid: string,
+    schemaId: number,
+    attempt: number,
+  ): Promise<void> {
     let connectionId: string
     try {
       const { connectionRecord } = await this.agent.didcomm.oob.receiveImplicitInvitation({
@@ -400,10 +465,12 @@ export class EcsBootstrapService {
       walletAgentParticipantId: '0',
     })
     this.logger.info(
-      `[EcsBootstrap] requested the Service credential (schema ${schemaId}) from parent VS ${parentDid}`,
+      `[EcsBootstrap] requested the Service credential (schema ${schemaId}) from parent VS ${parentDid} (attempt ${attempt}/${DELEGATED_REQUEST_MAX_ATTEMPTS})`,
     )
 
-    await this.awaitDelegatedOutcome(record.id, parentDid)
+    const isLastAttempt = attempt === DELEGATED_REQUEST_MAX_ATTEMPTS
+    const timeoutMs = isLastAttempt ? DELEGATED_OUTCOME_TIMEOUT_MS : DELEGATED_REQUEST_ATTEMPT_TIMEOUT_MS
+    await this.awaitDelegatedOutcome(record.id, parentDid, timeoutMs)
   }
 
   private async findParentServiceSchemaId(parentDid: string): Promise<number> {
@@ -420,25 +487,31 @@ export class EcsBootstrapService {
     throw new Error(`parent VS ${parentDid} holds no active ISSUER participant for an ECS Service schema`)
   }
 
-  private awaitDelegatedOutcome(recordId: string, parentDid: string): Promise<void> {
+  private awaitDelegatedOutcome(recordId: string, parentDid: string, timeoutMs: number): Promise<void> {
     return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        reject(new Error(`parent VS ${parentDid} did not complete the issuance in time`))
-      }, DELEGATED_OUTCOME_TIMEOUT_MS)
-      timer.unref()
-      this.agent.events.on<VtFlowStateChangedEvent>(VtFlowEventTypes.VtFlowStateChanged, ({ payload }) => {
+      const listener = ({ payload }: VtFlowStateChangedEvent) => {
         if (payload.vtFlowRecordId !== recordId) return
         if (payload.state === VtFlowState.Completed) {
-          clearTimeout(timer)
+          cleanup()
           resolve()
         } else if (
           payload.state === VtFlowState.TerminatedByValidator ||
           payload.state === VtFlowState.Error
         ) {
-          clearTimeout(timer)
+          cleanup()
           reject(new Error(`parent VS ${parentDid} rejected the Service credential request`))
         }
-      })
+      }
+      const cleanup = () => {
+        clearTimeout(timer)
+        this.agent.events.off<VtFlowStateChangedEvent>(VtFlowEventTypes.VtFlowStateChanged, listener)
+      }
+      const timer = setTimeout(() => {
+        cleanup()
+        reject(new Error(`parent VS ${parentDid} did not complete the issuance in time`))
+      }, timeoutMs)
+      timer.unref()
+      this.agent.events.on<VtFlowStateChangedEvent>(VtFlowEventTypes.VtFlowStateChanged, listener)
     })
   }
 }

--- a/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
+++ b/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
@@ -18,6 +18,7 @@ import {
   VeranaIndexerService,
 } from '../blockchain'
 import { HOLDER_PARTICIPANT_TYPE, ISSUER_PARTICIPANT_TYPE } from '../types'
+import { waitUntilOwnDidIsPubliclyResolvable } from '../utils/didReadiness'
 
 const START_OP_MSG = '/verana.pp.v1.MsgStartParticipantOP'
 const SELF_CREATE_MSG = '/verana.pp.v1.MsgSelfCreateParticipant'
@@ -34,15 +35,8 @@ const ECS_TITLE_BY_TYPE: Record<string, ECS> = {
 }
 
 const DELEGATED_OUTCOME_TIMEOUT_MS = 15 * 60_000
-// On a fresh deployment, the ingress route to this agent's own public endpoint
-// can lag a few seconds behind the process becoming ready (e.g. a k8s Service
-// has not finished propagating the new pod IP yet). The parent VS resolves our
-// DID as part of processing the delegated request, so we wait for our own DID
-// document to be publicly fetchable before sending anything.
-const OWN_DID_READY_TIMEOUT_MS = 60_000
-const OWN_DID_READY_POLL_INTERVAL_MS = 2_000
 // Thin safety net for any remaining transient failure (e.g. a network blip from
-// the parent's vantage point), on top of the readiness wait above.
+// the parent's vantage point), on top of the readiness wait in waitUntilOwnDidIsPubliclyResolvable.
 const DELEGATED_REQUEST_MAX_ATTEMPTS = 2
 const DELEGATED_REQUEST_ATTEMPT_TIMEOUT_MS = 60_000
 const DELEGATED_REQUEST_RETRY_DELAY_MS = 5_000
@@ -382,7 +376,7 @@ export class EcsBootstrapService {
       )
     }
 
-    await this.waitUntilOwnDidIsPubliclyResolvable()
+    await waitUntilOwnDidIsPubliclyResolvable(this.agent, this.logger)
 
     const verified = await this.options.verifyPeer(parentDid).catch(() => false)
     if (!verified) {
@@ -407,34 +401,6 @@ export class EcsBootstrapService {
       }
     }
     throw lastError ?? new Error(`parent VS ${parentDid} did not complete the issuance in time`)
-  }
-
-  // Waits until this agent's own DID document is fetchable at its public endpoint, so the
-  // parent VS can resolve us as soon as we reach out to it. Checks the same file a peer's
-  // resolver would fetch: did.jsonl for did:webvh, did.json for did:web. Logs and moves on
-  // if the deadline passes, rather than blocking bootstrap forever on a misconfigured deployment.
-  private async waitUntilOwnDidIsPubliclyResolvable(): Promise<void> {
-    const did = this.agent.did
-    if (!did || !this.agent.publicApiBaseUrl) return
-
-    const wellKnownFile = did.startsWith('did:web:') ? 'did.json' : 'did.jsonl'
-    const url = `${this.agent.publicApiBaseUrl}/.well-known/${wellKnownFile}`
-
-    const deadline = Date.now() + OWN_DID_READY_TIMEOUT_MS
-    let lastStatus: number | string = 'unreachable'
-    while (Date.now() < deadline) {
-      try {
-        const response = await fetch(url)
-        if (response.ok) return
-        lastStatus = response.status
-      } catch (error) {
-        lastStatus = (error as Error).message
-      }
-      await new Promise(resolve => setTimeout(resolve, OWN_DID_READY_POLL_INTERVAL_MS))
-    }
-    this.logger.warn(
-      `[EcsBootstrap] own DID document at ${url} was not publicly resolvable after ${OWN_DID_READY_TIMEOUT_MS}ms (last: ${lastStatus}); proceeding anyway`,
-    )
   }
 
   private async requestDelegatedServiceCredential(

--- a/packages/agent-sdk/src/utils/didReadiness.ts
+++ b/packages/agent-sdk/src/utils/didReadiness.ts
@@ -1,0 +1,41 @@
+import { Logger } from '@credo-ts/core'
+
+import { VsAgent } from '../agent/VsAgent'
+
+// On a fresh deployment, the ingress route to this agent's own public endpoint
+// can lag a few seconds behind the process becoming ready (e.g. a k8s Service
+// has not finished propagating the new pod IP yet). A peer resolves our DID as
+// part of processing any message we send it, so we wait for our own DID
+// document to be publicly fetchable before reaching out to one.
+const OWN_DID_READY_TIMEOUT_MS = 60_000
+const OWN_DID_READY_POLL_INTERVAL_MS = 2_000
+
+/**
+ * Waits until this agent's own DID document is fetchable at its public endpoint, so a peer
+ * can resolve it as soon as we reach out. Checks the same file a peer's resolver would fetch:
+ * did.jsonl for did:webvh, did.json for did:web. Logs and returns if the deadline passes,
+ * rather than blocking the caller forever on a misconfigured deployment.
+ */
+export async function waitUntilOwnDidIsPubliclyResolvable(agent: VsAgent, logger: Logger): Promise<void> {
+  const did = agent.did
+  if (!did || !agent.publicApiBaseUrl) return
+
+  const wellKnownFile = did.startsWith('did:web:') ? 'did.json' : 'did.jsonl'
+  const url = `${agent.publicApiBaseUrl}/.well-known/${wellKnownFile}`
+
+  const deadline = Date.now() + OWN_DID_READY_TIMEOUT_MS
+  let lastStatus: number | string = 'unreachable'
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url)
+      if (response.ok) return
+      lastStatus = response.status
+    } catch (error) {
+      lastStatus = (error as Error).message
+    }
+    await new Promise(resolve => setTimeout(resolve, OWN_DID_READY_POLL_INTERVAL_MS))
+  }
+  logger.warn(
+    `[DidReadiness] own DID document at ${url} was not publicly resolvable after ${OWN_DID_READY_TIMEOUT_MS}ms (last: ${lastStatus}); proceeding anyway`,
+  )
+}

--- a/packages/agent-sdk/tests/EcsBootstrapService.test.ts
+++ b/packages/agent-sdk/tests/EcsBootstrapService.test.ts
@@ -2,7 +2,7 @@ import type { VsAgent } from '../src/agent/VsAgent'
 import type { VeranaIndexerService } from '../src/blockchain'
 
 import { VtFlowRole, VtFlowState } from '@verana-labs/credo-ts-didcomm-vt-flow'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ParticipantRole, ParticipantState } from '../src/blockchain'
 import { EcsBootstrapService, type EcsBootstrapOptions } from '../src/bootstrap/EcsBootstrapService'
@@ -63,6 +63,10 @@ function makeMocks() {
     events: {
       on: (_type: string, cb: (event: { payload: Record<string, unknown> }) => void) => {
         eventHandlers.push(cb)
+      },
+      off: (_type: string, cb: (event: { payload: Record<string, unknown> }) => void) => {
+        const index = eventHandlers.indexOf(cb)
+        if (index !== -1) eventHandlers.splice(index, 1)
       },
     },
     dependencyManager: { resolve: () => vtFlowApi },
@@ -250,6 +254,50 @@ describe('EcsBootstrapService standalone', () => {
 describe('EcsBootstrapService delegated', () => {
   const delegated = { mode: 'delegated' as const, delegatedParentVsDid: 'did:web:parent' }
 
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('waits for its own DID document to be resolvable before contacting the parent', async () => {
+    const mocks = makeMocks()
+    mocks.indexer.listParticipants.mockResolvedValue([{ id: 3, schema_id: 5 }])
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    const service = makeService(mocks, { ...delegated, verifyPeer: async () => true })
+
+    const outcome = service.run()
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), { timeout: 5000 })
+    expect(fetchMock).toHaveBeenCalledWith('https://agent/.well-known/did.json')
+
+    await vi.waitFor(() => expect(mocks.vtFlowApi.sendIssuanceRequest).toHaveBeenCalled())
+    for (const cb of mocks.eventHandlers) {
+      void cb({ payload: { vtFlowRecordId: 'rec-1', state: VtFlowState.Completed } })
+    }
+    await expect(outcome).resolves.toBeUndefined()
+  }, 8000)
+
+  it('checks did.jsonl instead of did.json for a did:webvh agent', async () => {
+    const mocks = makeMocks()
+    mocks.agent.did = 'did:webvh:Qm123:agent.example.com'
+    mocks.indexer.listParticipants.mockResolvedValue([{ id: 3, schema_id: 5 }])
+    const service = makeService(mocks, { ...delegated, verifyPeer: async () => true })
+
+    const outcome = service.run()
+    await vi.waitFor(() => expect(mocks.vtFlowApi.sendIssuanceRequest).toHaveBeenCalled())
+    expect(fetch).toHaveBeenCalledWith('https://agent/.well-known/did.jsonl')
+    for (const cb of mocks.eventHandlers) {
+      void cb({ payload: { vtFlowRecordId: 'rec-1', state: VtFlowState.Completed } })
+    }
+    await expect(outcome).resolves.toBeUndefined()
+  })
+
   it('fails when peer verification is not configured', async () => {
     const mocks = makeMocks()
     const service = makeService(mocks, delegated)
@@ -274,8 +322,11 @@ describe('EcsBootstrapService delegated', () => {
     mocks.indexer.listParticipants.mockResolvedValue([{ id: 3, schema_id: 5 }])
     mocks.agent.didcomm.oob.receiveImplicitInvitation.mockRejectedValue(new Error('no endpoint'))
     const service = makeService(mocks, { ...delegated, verifyPeer: async () => true })
+
     await expect(service.run()).rejects.toThrow('did:web:parent is unreachable: no endpoint')
-  })
+    // Retries every failed attempt, including connection-level failures, before giving up.
+    expect(mocks.agent.didcomm.oob.receiveImplicitInvitation).toHaveBeenCalledTimes(2)
+  }, 15000)
 
   it('sends the issuance request and resolves when the flow completes', async () => {
     const mocks = makeMocks()

--- a/packages/agent-sdk/tests/didReadiness.test.ts
+++ b/packages/agent-sdk/tests/didReadiness.test.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@credo-ts/core'
 import { describe, expect, it, vi, afterEach } from 'vitest'
 
 import { waitUntilOwnDidIsPubliclyResolvable } from '../src/utils/didReadiness'
@@ -7,7 +8,14 @@ function makeAgent(did: string) {
 }
 
 function makeLogger() {
-  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), trace: vi.fn(), fatal: vi.fn() }
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+  } as unknown as Logger
 }
 
 describe('waitUntilOwnDidIsPubliclyResolvable', () => {

--- a/packages/agent-sdk/tests/didReadiness.test.ts
+++ b/packages/agent-sdk/tests/didReadiness.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, afterEach } from 'vitest'
+
+import { waitUntilOwnDidIsPubliclyResolvable } from '../src/utils/didReadiness'
+
+function makeAgent(did: string) {
+  return { did, publicApiBaseUrl: 'https://agent.example' } as never
+}
+
+function makeLogger() {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), trace: vi.fn(), fatal: vi.fn() }
+}
+
+describe('waitUntilOwnDidIsPubliclyResolvable', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns immediately when the DID document is already resolvable', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await waitUntilOwnDidIsPubliclyResolvable(makeAgent('did:web:agent.example'), makeLogger())
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('https://agent.example/.well-known/did.json')
+  })
+
+  it('checks did.jsonl instead of did.json for a did:webvh agent', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await waitUntilOwnDidIsPubliclyResolvable(makeAgent('did:webvh:Qm123:agent.example'), makeLogger())
+
+    expect(fetchMock).toHaveBeenCalledWith('https://agent.example/.well-known/did.jsonl')
+  })
+
+  it('retries until the DID document becomes resolvable', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({ ok: false, status: 503 })
+      .mockResolvedValueOnce({ ok: true })
+    vi.stubGlobal('fetch', fetchMock)
+    const logger = makeLogger()
+
+    await waitUntilOwnDidIsPubliclyResolvable(makeAgent('did:web:agent.example'), logger)
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('no-ops when the agent has no DID or no public API base URL', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await waitUntilOwnDidIsPubliclyResolvable({ did: undefined } as never, makeLogger())
+    await waitUntilOwnDidIsPubliclyResolvable(
+      { did: 'did:web:agent.example', publicApiBaseUrl: undefined } as never,
+      makeLogger(),
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This is mostly a workaround for a problem I've found when testing delegated mode in k8s: in delegated mode, the agent starts and immediately tries to start the direct credential issuance process, but its public endpoints are not yet available, so the validator fails to fetch its DID Document. So either a retry mechanism or a delay must be introduced. Retrying something that it's likely to always fail in our environments does not sound efficient, so I opted for the delay in the simplest way I could.

I don't like this approach (I'd like to use `rxjs` for a more efficient/elegant event handling) but I left it just for consistency with other parts of the code. To be improved everywhere in vs-agent code once the timeouts and retry mechanisms are properly defined on spec.