### PR TITLE
fix: self-tr integrity data calculation

### DIFF
--- a/packages/agent-sdk/src/utils/setupSelfTr.ts
+++ b/packages/agent-sdk/src/utils/setupSelfTr.ts
@@ -98,8 +98,26 @@ export const linkedVpFragment = (schemaKey: string): string =>
 export const mapToSelfTr = (url: string, publicApiBaseUrl: string): string =>
   url.replace('ecosystem', `${publicApiBaseUrl}/vt`)
 
+// A plain array replacer only allowlists property names, applied at every
+// nesting level — nested objects like `claims` and `credentialSchema` would
+// serialize to `{}` since none of their own keys appear in a top-level
+// key list. Sort keys recursively instead, so the hash actually reflects
+// nested content and changes to claims invalidate the cache correctly.
+const sortKeysDeep = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(sortKeysDeep)
+  if (value !== null && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortKeysDeep((value as Record<string, unknown>)[key])
+        return acc
+      }, {})
+  }
+  return value
+}
+
 const buildIntegrityData = (data: Record<string, unknown>) => {
-  return generateDigestSRI(JSON.stringify(data, Object.keys(data).sort()))
+  return generateDigestSRI(JSON.stringify(sortKeysDeep(data)))
 }
 
 export const setupSelfTr = async ({

--- a/packages/agent-sdk/src/utils/setupSelfTr.ts
+++ b/packages/agent-sdk/src/utils/setupSelfTr.ts
@@ -103,7 +103,7 @@ export const mapToSelfTr = (url: string, publicApiBaseUrl: string): string =>
 // serialize to `{}` since none of their own keys appear in a top-level
 // key list. Sort keys recursively instead, so the hash actually reflects
 // nested content and changes to claims invalidate the cache correctly.
-const sortKeysDeep = (value: unknown): unknown => {
+export const sortKeysDeep = (value: unknown): unknown => {
   if (Array.isArray(value)) return value.map(sortKeysDeep)
   if (value !== null && typeof value === 'object') {
     return Object.keys(value as Record<string, unknown>)

--- a/packages/agent-sdk/tests/selfTrPublishOrder.test.ts
+++ b/packages/agent-sdk/tests/selfTrPublishOrder.test.ts
@@ -2,7 +2,7 @@ import { DidDocument, VerificationMethod } from '@credo-ts/core'
 import { describe, expect, it, vi } from 'vitest'
 
 import { getEcsSchemas } from '../src/utils/data'
-import { generateVerifiablePresentation, SelfTrDefaults } from '../src/utils/setupSelfTr'
+import { generateVerifiablePresentation, SelfTrDefaults, sortKeysDeep } from '../src/utils/setupSelfTr'
 
 const DID = 'did:web:agent.example'
 const VP_URL = 'https://agent.example/vt/ecs-service-vtc-vp.json'
@@ -129,5 +129,22 @@ describe('generateVerifiablePresentation beforePublish step', () => {
       beforePublish,
     )
     expect(repositoryUpdate).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('sortKeysDeep', () => {
+  it('sorts keys at every nesting level, including inside arrays', () => {
+    const a = { b: 1, a: { d: 1, c: 2 }, list: [{ z: 1, a: 2 }] }
+    const b = { a: { c: 2, d: 1 }, list: [{ a: 2, z: 1 }], b: 1 }
+
+    // Differently-ordered but equivalent inputs must serialize identically.
+    expect(JSON.stringify(sortKeysDeep(a))).toBe(JSON.stringify(sortKeysDeep(b)))
+    expect(JSON.stringify(sortKeysDeep(a))).toBe('{"a":{"c":2,"d":1},"b":1,"list":[{"a":2,"z":1}]}')
+  })
+
+  it('leaves primitive and null values unchanged', () => {
+    expect(sortKeysDeep('value')).toBe('value')
+    expect(sortKeysDeep(42)).toBe(42)
+    expect(sortKeysDeep(null)).toBeNull()
   })
 })

--- a/packages/agent-sdk/tests/selfTrPublishOrder.test.ts
+++ b/packages/agent-sdk/tests/selfTrPublishOrder.test.ts
@@ -102,4 +102,32 @@ describe('generateVerifiablePresentation beforePublish step', () => {
     expect(didsUpdate).not.toHaveBeenCalled()
     expect(metadata.get('_vt/vtc')).toBeUndefined()
   })
+
+  it('regenerates when claims change, and skips when they do not', async () => {
+    // beforePublish always fires, cache hit or not (it's how a failed publish retries), so
+    // regeneration is observed via repositoryUpdate: it only runs when content actually changes.
+    const { agent, repositoryUpdate } = makeAgent()
+    const beforePublish = vi.fn(async () => {})
+
+    await publish(agent, beforePublish)
+    expect(repositoryUpdate).toHaveBeenCalledTimes(1)
+
+    // Same claims again: cache hit, no regeneration.
+    await publish(agent, beforePublish)
+    expect(repositoryUpdate).toHaveBeenCalledTimes(1)
+
+    // A changed claim must invalidate the cache and regenerate.
+    const changed: SelfTrDefaults = { ...defaults, serviceDescription: 'a different description' }
+    await generateVerifiablePresentation(
+      agent as never,
+      VP_URL,
+      getEcsSchemas('https://agent.example'),
+      'ecs-service',
+      ['VerifiableCredential', 'VerifiableTrustCredential'],
+      { id: JSC_URL, type: 'JsonSchemaCredential' },
+      changed,
+      beforePublish,
+    )
+    expect(repositoryUpdate).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
Quick fix for an issue found during devtest integration. Maybe we should just make something similar to the "digestJCS" instead of an SRI... Let's add this to the "TODO" list on the spec.