### PR TITLE
fix: wait for the indexer subscribed acknowledgement before the catch-up

### DIFF
--- a/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
+++ b/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
@@ -16,6 +16,7 @@ import {
   IndexerEventRecord,
   IndexerReadyMessage,
   IndexerSubscribeMessage,
+  IndexerSubscribedMessage,
   VeranaSyncState,
 } from './types'
 
@@ -46,7 +47,7 @@ export class IndexerWebSocketService {
   private generation = 0
   private chain: Promise<void> = Promise.resolve()
   private syncBuffer: IndexerEventRecord[] = []
-  private subscribeSent: (() => void) | null = null
+  private settleSubscribed: ((acknowledged: boolean) => void) | null = null
   private readonly indexer: VeranaIndexerService
   private readonly handlerRegistry: IndexerHandlerRegistry
 
@@ -84,12 +85,17 @@ export class IndexerWebSocketService {
     this.syncing = true
     this.syncBuffer = []
 
-    const subscribed = new Promise<void>(resolve => {
-      this.subscribeSent = resolve
+    const subscribed = new Promise<boolean>(resolve => {
+      this.settleSubscribed = resolve
     })
     this.openWebSocket()
-    await Promise.race([subscribed, delay(SUBSCRIBE_TIMEOUT_MS)])
+    const acknowledged = await Promise.race([subscribed, delay(SUBSCRIBE_TIMEOUT_MS).then(() => false)])
     if (this.stopped || generation !== this.generation) return
+    if (!acknowledged) {
+      this.logger.warn(
+        `[IndexerWS] No 'subscribed' acknowledgement within ${SUBSCRIBE_TIMEOUT_MS}ms; starting the catch-up anyway. Events landing before the subscription becomes active may be missed.`,
+      )
+    }
 
     try {
       await this.syncRest(generation)
@@ -119,12 +125,9 @@ export class IndexerWebSocketService {
       if (ws === this.ws) this.logger.info(`[IndexerWS] Connected to indexer`)
     })
 
-    const releaseSubscribeWait = (): void => {
-      this.subscribeSent?.()
-      this.subscribeSent = null
-    }
-    ws.on('error', releaseSubscribeWait)
-    ws.on('close', releaseSubscribeWait)
+    const abandonSubscribeWait = (): void => this.resolveSubscribed(false)
+    ws.on('error', abandonSubscribeWait)
+    ws.on('close', abandonSubscribeWait)
 
     ws.on('ping', () => {
       if (ws === this.ws) this.armWatchdog()
@@ -147,8 +150,13 @@ export class IndexerWebSocketService {
     })
   }
 
+  private resolveSubscribed(acknowledged: boolean): void {
+    this.settleSubscribed?.(acknowledged)
+    this.settleSubscribed = null
+  }
+
   private handleMessage(ws: WebSocket, data: WebSocket.RawData): void {
-    let message: IndexerReadyMessage | IndexerBlockMessage
+    let message: IndexerReadyMessage | IndexerSubscribedMessage | IndexerBlockMessage
     try {
       message = JSON.parse(data.toString())
     } catch {
@@ -162,12 +170,16 @@ export class IndexerWebSocketService {
         this.options.corporationId != null
           ? { action: 'subscribe', corporationId: this.options.corporationId }
           : { action: 'subscribe', dids: this.options.agent.did ? [this.options.agent.did] : undefined }
-      ws.send(JSON.stringify(subscribe), () => {
-        this.subscribeSent?.()
-        this.subscribeSent = null
-      })
+      ws.send(JSON.stringify(subscribe))
       return
     }
+
+    if (message.type === 'subscribed') {
+      this.logger.debug(`[IndexerWS] Subscription active, delivery starts at block ${message.block}`)
+      this.resolveSubscribed(true)
+      return
+    }
+
     if (message.type !== 'block') return
 
     const generation = this.generation

--- a/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
+++ b/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
@@ -33,6 +33,7 @@ const WS_PATHNAME = 'v4/indexer/subscribe'
 const REST_PAGE_LIMIT = 500
 const MAX_SYNC_BUFFER = 10_000
 const SUBSCRIBE_TIMEOUT_MS = 5_000
+type SubscribeOutcome = 'acknowledged' | 'timed-out' | 'disconnected'
 const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 // The indexer pings every 30 seconds, so a longer gap means the socket is dead.
 const LIVENESS_TIMEOUT_MS = 90_000
@@ -47,7 +48,7 @@ export class IndexerWebSocketService {
   private generation = 0
   private chain: Promise<void> = Promise.resolve()
   private syncBuffer: IndexerEventRecord[] = []
-  private settleSubscribed: ((acknowledged: boolean) => void) | null = null
+  private settleSubscribed: ((outcome: SubscribeOutcome) => void) | null = null
   private readonly indexer: VeranaIndexerService
   private readonly handlerRegistry: IndexerHandlerRegistry
 
@@ -85,13 +86,17 @@ export class IndexerWebSocketService {
     this.syncing = true
     this.syncBuffer = []
 
-    const subscribed = new Promise<boolean>(resolve => {
+    const subscribed = new Promise<SubscribeOutcome>(resolve => {
       this.settleSubscribed = resolve
     })
     this.openWebSocket()
-    const acknowledged = await Promise.race([subscribed, delay(SUBSCRIBE_TIMEOUT_MS).then(() => false)])
+    const outcome = await Promise.race([
+      subscribed,
+      delay(SUBSCRIBE_TIMEOUT_MS).then((): SubscribeOutcome => 'timed-out'),
+    ])
     if (this.stopped || generation !== this.generation) return
-    if (!acknowledged) {
+    if (outcome === 'disconnected') return
+    if (outcome === 'timed-out') {
       this.logger.warn(
         `[IndexerWS] No 'subscribed' acknowledgement within ${SUBSCRIBE_TIMEOUT_MS}ms; starting the catch-up anyway. Events landing before the subscription becomes active may be missed.`,
       )
@@ -125,7 +130,7 @@ export class IndexerWebSocketService {
       if (ws === this.ws) this.logger.info(`[IndexerWS] Connected to indexer`)
     })
 
-    const abandonSubscribeWait = (): void => this.resolveSubscribed(false)
+    const abandonSubscribeWait = (): void => this.resolveSubscribed('disconnected')
     ws.on('error', abandonSubscribeWait)
     ws.on('close', abandonSubscribeWait)
 
@@ -150,8 +155,8 @@ export class IndexerWebSocketService {
     })
   }
 
-  private resolveSubscribed(acknowledged: boolean): void {
-    this.settleSubscribed?.(acknowledged)
+  private resolveSubscribed(outcome: SubscribeOutcome): void {
+    this.settleSubscribed?.(outcome)
     this.settleSubscribed = null
   }
 
@@ -176,7 +181,7 @@ export class IndexerWebSocketService {
 
     if (message.type === 'subscribed') {
       this.logger.debug(`[IndexerWS] Subscription active, delivery starts at block ${message.block}`)
-      this.resolveSubscribed(true)
+      this.resolveSubscribed('acknowledged')
       return
     }
 

--- a/packages/agent-sdk/src/blockchain/types.ts
+++ b/packages/agent-sdk/src/blockchain/types.ts
@@ -65,6 +65,11 @@ export interface IndexerSubscribeMessage {
   corporationId?: number
 }
 
+export interface IndexerSubscribedMessage {
+  type: 'subscribed'
+  block: number
+}
+
 export interface IndexerEventsResponse {
   events: IndexerEventRecord[]
   count: number

--- a/packages/agent-sdk/tests/IndexerWebSocketService.test.ts
+++ b/packages/agent-sdk/tests/IndexerWebSocketService.test.ts
@@ -204,6 +204,22 @@ describe('IndexerWebSocketService', () => {
     expect(fetchJsonMock).toHaveBeenCalled()
   })
 
+  it('skips the catch-up when the socket closes before the acknowledgement', async () => {
+    FakeWebSocket.autoAcknowledgeSubscribe = false
+    vi.useFakeTimers()
+    service = new IndexerWebSocketService({
+      indexerUrl: 'http://indexer.test',
+      agent,
+      handlerRegistry: registry,
+    })
+    const started = service.start()
+    lastWs().emit('message', readyFrame())
+    lastWs().close()
+    await started
+
+    expect(fetchJsonMock).not.toHaveBeenCalled()
+  })
+
   it('buffers a block that arrives before the acknowledgement instead of dropping it', async () => {
     FakeWebSocket.autoAcknowledgeSubscribe = false
     const dispatched: string[] = []

--- a/packages/agent-sdk/tests/IndexerWebSocketService.test.ts
+++ b/packages/agent-sdk/tests/IndexerWebSocketService.test.ts
@@ -11,8 +11,10 @@ const { FakeWebSocket } = vi.hoisted(() => {
   type Listener = (...args: unknown[]) => void
   class FakeWebSocket {
     static instances: FakeWebSocket[] = []
+    static autoAcknowledgeSubscribe = true
     static reset(): void {
       FakeWebSocket.instances = []
+      FakeWebSocket.autoAcknowledgeSubscribe = true
     }
     private listeners: Record<string, Listener[]> = {}
     url: string
@@ -32,6 +34,17 @@ const { FakeWebSocket } = vi.hoisted(() => {
     send(data: string, cb?: () => void): void {
       this.sent.push(data)
       cb?.()
+      if (!FakeWebSocket.autoAcknowledgeSubscribe) return
+      let action: unknown
+      try {
+        action = (JSON.parse(data) as { action?: unknown }).action
+      } catch {
+        return
+      }
+      if (action !== 'subscribe') return
+      queueMicrotask(() =>
+        this.emit('message', Buffer.from(JSON.stringify({ type: 'subscribed', block: 2 }))),
+      )
     }
     close(): void {
       this.emit('close')
@@ -154,7 +167,7 @@ describe('IndexerWebSocketService', () => {
     expect(subscribe).toContainEqual({ action: 'subscribe', dids: ['did:web:agent.test'] })
   })
 
-  it('waits for subscribe to be sent before reading old events', async () => {
+  it('waits for the subscribed acknowledgement before reading old events', async () => {
     service = new IndexerWebSocketService({
       indexerUrl: 'http://indexer.test',
       agent,
@@ -169,6 +182,45 @@ describe('IndexerWebSocketService', () => {
     await started
 
     expect(fetchJsonMock).toHaveBeenCalled()
+  })
+
+  it('starts the catch-up anyway when the indexer never acknowledges the subscribe', async () => {
+    FakeWebSocket.autoAcknowledgeSubscribe = false
+    vi.useFakeTimers()
+    service = new IndexerWebSocketService({
+      indexerUrl: 'http://indexer.test',
+      agent,
+      handlerRegistry: registry,
+    })
+    const started = service.start()
+    lastWs().emit('message', readyFrame())
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetchJsonMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    await started
+
+    expect(fetchJsonMock).toHaveBeenCalled()
+  })
+
+  it('buffers a block that arrives before the acknowledgement instead of dropping it', async () => {
+    FakeWebSocket.autoAcknowledgeSubscribe = false
+    const dispatched: string[] = []
+    registry.register({ msg: 'TestMsg', handle: async a => void dispatched.push(String(a.entity_id)) })
+    service = new IndexerWebSocketService({
+      indexerUrl: 'http://indexer.test',
+      agent,
+      handlerRegistry: registry,
+    })
+    const started = service.start()
+    const ws = lastWs()
+    ws.emit('message', readyFrame())
+    ws.emit('message', blockFrame(11, [mkEvent({ block_height: 10, tx_hash: 'aa', entity_id: 'A' })]))
+    ws.emit('message', Buffer.from(JSON.stringify({ type: 'subscribed', block: 8 })))
+    await started
+
+    await vi.waitFor(() => expect(dispatched).toEqual(['A']))
   })
 
   it('sends a corp-scoped subscribe and catch-up when corporationId is set', async () => {

--- a/packages/agent-sdk/tests/e2e/helpers.ts
+++ b/packages/agent-sdk/tests/e2e/helpers.ts
@@ -4,6 +4,7 @@ import type {
   IndexerEventRecord,
   IndexerReadyMessage,
   IndexerSubscribeMessage,
+  IndexerSubscribedMessage,
 } from '../../src/blockchain/types'
 
 import { GenericContainer, Network, Wait, type StartedTestContainer } from 'testcontainers'
@@ -26,6 +27,7 @@ const POSTGRES_DB = 'verana_indexer_e2e'
 const POLL_TIMEOUT_MS = Number(process.env.FLOW_POLL_TIMEOUT_MS || 300_000)
 const POLL_INTERVAL_MS = Number(process.env.FLOW_POLL_INTERVAL_MS || 3_000)
 const WS_PATHNAME = 'v4/indexer/subscribe'
+const SUBSCRIBED_TIMEOUT_MS = Number(process.env.FLOW_SUBSCRIBED_TIMEOUT_MS || 10_000)
 
 export const CHAIN_ID = 'vna-testnet-1'
 export const COOLUSER_MNEMONIC = 'pink glory help gown abstract eight nice crazy forward ketchup skill cheese'
@@ -203,16 +205,37 @@ export class IndexerSubscriber {
       const ws = new WebSocket(`${baseWsUrl}/${WS_PATHNAME}`)
       const subscriber = new IndexerSubscriber(ws)
 
+      let settled = false
+      const ready = (): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve(subscriber)
+      }
+      const timer = setTimeout(() => {
+        console.warn(
+          `[flow] no 'subscribed' acknowledgement within ${SUBSCRIBED_TIMEOUT_MS}ms; continuing without it`,
+        )
+        ready()
+      }, SUBSCRIBED_TIMEOUT_MS)
+
       ws.on('message', (data: WebSocket.RawData) => {
-        const message = JSON.parse(data.toString()) as IndexerReadyMessage | IndexerBlockMessage
+        const message = JSON.parse(data.toString()) as
+          | IndexerReadyMessage
+          | IndexerSubscribedMessage
+          | IndexerBlockMessage
         if (message.type === 'ready') {
           ws.send(JSON.stringify({ action: 'subscribe', ...filter } as IndexerSubscribeMessage))
-          resolve(subscriber)
+        } else if (message.type === 'subscribed') {
+          ready()
         } else if (message.type === 'block') {
           for (const event of message.events) subscriber.handleEvent(event)
         }
       })
-      ws.on('error', reject)
+      ws.on('error', error => {
+        clearTimeout(timer)
+        reject(error)
+      })
     })
   }
 

--- a/packages/agent-sdk/tests/e2e/verana-flow.e2e.test.ts
+++ b/packages/agent-sdk/tests/e2e/verana-flow.e2e.test.ts
@@ -100,4 +100,33 @@ describe('Verana blockchain integration (node + indexer, CosmJS + WebSocket)', (
     },
     SETUP_TIMEOUT_MS,
   )
+
+  it(
+    'waits for the indexer subscribed acknowledgement before draining the catch-up',
+    async () => {
+      const logger = agent.config.logger
+      const debugSpy = vi.spyOn(logger, 'debug')
+      const warnSpy = vi.spyOn(logger, 'warn')
+
+      const service = new IndexerWebSocketService({
+        indexerUrl: stack.indexerWsUrl.replace(/^ws:/, 'http:'),
+        agent,
+      })
+
+      try {
+        await service.start()
+      } finally {
+        service.stop()
+      }
+
+      const messages = (spy: typeof debugSpy) => spy.mock.calls.map(call => String(call[0]))
+
+      expect(messages(debugSpy).some(m => m.includes('[IndexerWS] Subscription active'))).toBe(true)
+      expect(messages(warnSpy).some(m => m.includes("No 'subscribed' acknowledgement"))).toBe(false)
+
+      debugSpy.mockRestore()
+      warnSpy.mockRestore()
+    },
+    SETUP_TIMEOUT_MS,
+  )
 })


### PR DESCRIPTION
**Changes**
- The catch-up now waits for the `subscribed` message instead of the send callback.
- The 5s timeout stays and now logs a warning. Against an indexer that never
  acknowledges (older deployment) the agent degrades and keeps starting, rather than
  reconnecting in a loop.
- The e2e helper `IndexerSubscriber.connect` had the same race and now resolves on
  `subscribed` too.
