### PR TITLE
fix: prevent duplicated connections by using publicDid tag

### DIFF
--- a/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
+++ b/packages/agent-sdk/src/bootstrap/EcsBootstrapService.ts
@@ -18,6 +18,7 @@ import {
   VeranaIndexerService,
 } from '../blockchain'
 import { HOLDER_PARTICIPANT_TYPE, ISSUER_PARTICIPANT_TYPE } from '../types'
+import { connectToPublicDid } from '../utils/agent'
 import { waitUntilOwnDidIsPubliclyResolvable } from '../utils/didReadiness'
 
 const START_OP_MSG = '/verana.pp.v1.MsgStartParticipantOP'
@@ -413,15 +414,7 @@ export class EcsBootstrapService {
   ): Promise<void> {
     let connectionId: string
     try {
-      const { connectionRecord } = await this.agent.didcomm.oob.receiveImplicitInvitation({
-        did: parentDid,
-        ourDid: this.agent.did,
-        label: this.agent.label,
-        didCommVersion: 'v2',
-      })
-      if (!connectionRecord) throw new Error('no connection record returned')
-      const ready = await this.agent.didcomm.connections.returnWhenIsConnected(connectionRecord.id)
-      connectionId = ready.id
+      connectionId = await connectToPublicDid(this.agent, parentDid)
     } catch (error) {
       throw new Error(`parent VS ${parentDid} is unreachable: ${(error as Error).message}`)
     }

--- a/packages/agent-sdk/src/transports/VsAgentWsInboundTransport.ts
+++ b/packages/agent-sdk/src/transports/VsAgentWsInboundTransport.ts
@@ -114,7 +114,10 @@ export class VsAgentWsInboundTransport implements DidCommInboundTransport {
         const messageReceiver = agentContext.dependencyManager.resolve(DidCommMessageReceiver)
         await messageReceiver.receiveMessage(JSON.parse(event.data), { session })
       } catch (error) {
-        this.logger.error('Error processing message')
+        this.logger.error(
+          `Error processing inbound message: ${error instanceof Error ? error.message : String(error)}`,
+          { error },
+        )
       }
     })
   }

--- a/packages/agent-sdk/src/utils/agent.ts
+++ b/packages/agent-sdk/src/utils/agent.ts
@@ -1,7 +1,12 @@
 import type { VsAgent } from '../agent/VsAgent'
 
 import { parseDid } from '@credo-ts/core'
-import { DidCommHandshakeProtocol, DidCommMessage, type DidCommVersion } from '@credo-ts/didcomm'
+import {
+  DidCommConnectionRepository,
+  DidCommHandshakeProtocol,
+  DidCommMessage,
+  type DidCommVersion,
+} from '@credo-ts/didcomm'
 
 /**
  * Creates an out of band invitation that will equal to the public DID in case the agent has one defined,
@@ -56,6 +61,55 @@ export async function createInvitation(options: {
     url: outOfBandInvitation.toUrl({
       domain: invitationBaseUrl,
     }),
+  }
+}
+
+/**
+ * Connects to a peer that publishes a public DID, and reuses the connection that the
+ * agent already has to that peer.
+ *
+ * The agent must keep one connection record only for each peer. A second record for the
+ * same pair of DIDs makes the `findByDids` lookup of the message receiver throw
+ * `RecordDuplicateError`, and the agent then fails to process every inbound message from
+ * that peer. To find the existing record, the agent reads the `publicDid` tag that it
+ * sets on each connection to a peer that publishes a public DID.
+ *
+ * @param agent the local agent
+ * @param peerPublicDid the public DID of the peer
+ * @returns the id of a ready connection record
+ */
+export async function connectToPublicDid(agent: VsAgent, peerPublicDid: string): Promise<string> {
+  if (!agent.did) throw new Error('Agent has no public DID')
+
+  const [existing] = await agent.didcomm.connections.findAllByQuery({
+    publicDid: peerPublicDid,
+  })
+  if (existing) return (await agent.didcomm.connections.returnWhenIsConnected(existing.id)).id
+
+  const { connectionRecord } = await agent.didcomm.oob.receiveImplicitInvitation({
+    did: peerPublicDid,
+    ourDid: agent.did,
+    label: agent.label,
+    didCommVersion: 'v2',
+  })
+  if (!connectionRecord) throw new Error(`Failed to establish a DIDComm connection to ${peerPublicDid}`)
+
+  try {
+    // Tag the record with the public DID of the peer, to find it on the next call.
+    connectionRecord.setTag('publicDid', peerPublicDid)
+    await agent.context.resolve(DidCommConnectionRepository).update(agent.context, connectionRecord)
+
+    const ready = await agent.didcomm.connections.returnWhenIsConnected(connectionRecord.id)
+    return ready.id
+  } catch (error) {
+    // Delete the incomplete record. If it stays, the next call reuses a connection that
+    // the peer never completed, and a later retry adds a duplicate record for the pair.
+    await agent.didcomm.connections.deleteById(connectionRecord.id).catch(deleteError => {
+      agent.config.logger.warn(`Failed to delete the incomplete connection ${connectionRecord.id}`, {
+        error: deleteError,
+      })
+    })
+    throw error
   }
 }
 

--- a/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
+++ b/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
@@ -27,6 +27,7 @@ import {
   VERIFIER_PARTICIPANT_TYPE,
 } from '../types'
 import {
+  connectToPublicDid,
   createCredential,
   createVtc,
   removeStoredTrustCredential,
@@ -125,15 +126,7 @@ export class VtFlowOrchestrator {
       if (connection?.isReady) connectionId = connection.id
     }
     if (!connectionId) {
-      const { connectionRecord } = await this.agent.didcomm.oob.receiveImplicitInvitation({
-        did: validatorParticipant.did,
-        ourDid: this.agent.did,
-        label: this.agent.label,
-        didCommVersion: 'v2',
-      })
-      if (!connectionRecord) throw new Error('Failed to establish DIDComm connection to validator')
-      const ready = await this.agent.didcomm.connections.returnWhenIsConnected(connectionRecord.id)
-      connectionId = ready.id
+      connectionId = await connectToPublicDid(this.agent, validatorParticipant.did)
     }
 
     return vtFlowApi.sendOnboardingRequest({

--- a/packages/agent-sdk/tests/EcsBootstrapService.test.ts
+++ b/packages/agent-sdk/tests/EcsBootstrapService.test.ts
@@ -70,9 +70,18 @@ function makeMocks() {
       },
     },
     dependencyManager: { resolve: () => vtFlowApi },
+    context: { resolve: () => ({ update: vi.fn().mockResolvedValue(undefined) }) },
     didcomm: {
-      oob: { receiveImplicitInvitation: vi.fn().mockResolvedValue({ connectionRecord: { id: 'conn-1' } }) },
-      connections: { returnWhenIsConnected: vi.fn().mockResolvedValue({ id: 'conn-1' }) },
+      oob: {
+        receiveImplicitInvitation: vi
+          .fn()
+          .mockResolvedValue({ connectionRecord: { id: 'conn-1', setTag: vi.fn() } }),
+      },
+      connections: {
+        findAllByQuery: vi.fn().mockResolvedValue([]),
+        returnWhenIsConnected: vi.fn().mockResolvedValue({ id: 'conn-1' }),
+        deleteById: vi.fn().mockResolvedValue(undefined),
+      },
       credentials: { acceptOffer: vi.fn().mockResolvedValue(undefined) },
     },
   }

--- a/packages/agent-sdk/tests/VtFlowOrchestrator.test.ts
+++ b/packages/agent-sdk/tests/VtFlowOrchestrator.test.ts
@@ -97,13 +97,18 @@ describe('VtFlowOrchestrator.startOnboardingProcess renewal/reconnection', () =>
       config: { logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
       veranaChain: { getParticipant: vi.fn(async (id: number) => (id === 5 ? holder : validator)) },
       dependencyManager: { resolve: () => vtFlowApi },
+      context: { resolve: () => ({ update: vi.fn().mockResolvedValue(undefined) }) },
       didcomm: {
         connections: {
           findById: vi.fn().mockResolvedValue(previousConnection),
+          findAllByQuery: vi.fn().mockResolvedValue([]),
           returnWhenIsConnected: vi.fn().mockResolvedValue({ id: 'conn-new' }),
+          deleteById: vi.fn().mockResolvedValue(undefined),
         },
         oob: {
-          receiveImplicitInvitation: vi.fn().mockResolvedValue({ connectionRecord: { id: 'conn-new' } }),
+          receiveImplicitInvitation: vi
+            .fn()
+            .mockResolvedValue({ connectionRecord: { id: 'conn-new', setTag: vi.fn() } }),
         },
       },
     }

--- a/packages/agent-sdk/tests/connectToPublicDid.test.ts
+++ b/packages/agent-sdk/tests/connectToPublicDid.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { connectToPublicDid } from '../src/utils/agent'
+
+const AGENT_DID = 'did:webvh:QmAgent:agent.example'
+const PEER_DID = 'did:webvh:QmPeer:peer.example'
+
+function makeAgent(records: { id: string }[]) {
+  const repository = { update: vi.fn(async () => undefined) }
+  return {
+    did: AGENT_DID,
+    label: 'Agent',
+    config: {
+      logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    },
+    context: { resolve: vi.fn(() => repository) },
+    repository,
+    didcomm: {
+      connections: {
+        findAllByQuery: vi.fn(async () => records),
+        returnWhenIsConnected: vi.fn(async (id: string) => ({ id })),
+        deleteById: vi.fn(async () => undefined),
+      },
+      oob: {
+        receiveImplicitInvitation: vi.fn(async () => ({
+          connectionRecord: { id: 'fresh-record', setTag: vi.fn() },
+        })),
+      },
+    },
+  }
+}
+
+describe('connectToPublicDid', () => {
+  it('reuses the connection that the agent already has to the peer', async () => {
+    const agent = makeAgent([{ id: 'existing' }])
+
+    const id = await connectToPublicDid(agent as never, PEER_DID)
+
+    expect(id).toBe('existing')
+    expect(agent.didcomm.connections.findAllByQuery).toHaveBeenCalledWith({
+      publicDid: PEER_DID,
+    })
+    expect(agent.didcomm.oob.receiveImplicitInvitation).not.toHaveBeenCalled()
+  })
+
+  it('creates a connection when the agent has none to the peer', async () => {
+    const agent = makeAgent([])
+
+    const id = await connectToPublicDid(agent as never, PEER_DID)
+
+    expect(id).toBe('fresh-record')
+    expect(agent.didcomm.oob.receiveImplicitInvitation).toHaveBeenCalledWith({
+      did: PEER_DID,
+      ourDid: AGENT_DID,
+      label: 'Agent',
+      didCommVersion: 'v2',
+    })
+  })
+
+  it('tags the new connection with the public DID of the peer', async () => {
+    const agent = makeAgent([])
+
+    await connectToPublicDid(agent as never, PEER_DID)
+
+    const { connectionRecord } = await agent.didcomm.oob.receiveImplicitInvitation.mock.results[0].value
+    expect(connectionRecord.setTag).toHaveBeenCalledWith('publicDid', PEER_DID)
+    expect(agent.repository.update).toHaveBeenCalled()
+  })
+
+  it('deletes the new connection when it does not become ready', async () => {
+    const agent = makeAgent([])
+    agent.didcomm.connections.returnWhenIsConnected = vi.fn(async () => {
+      throw new Error('timeout')
+    })
+
+    await expect(connectToPublicDid(agent as never, PEER_DID)).rejects.toThrow('timeout')
+    expect(agent.didcomm.connections.deleteById).toHaveBeenCalledWith('fresh-record')
+  })
+
+  it('throws when the agent has no public DID', async () => {
+    const agent = makeAgent([])
+    agent.did = undefined as never
+
+    await expect(connectToPublicDid(agent as never, PEER_DID)).rejects.toThrow('Agent has no public DID')
+  })
+})

--- a/packages/vt-flow/src/services/VtFlowService.ts
+++ b/packages/vt-flow/src/services/VtFlowService.ts
@@ -346,7 +346,10 @@ export class VtFlowService {
     agentContext: AgentContext,
     recordId: string,
     params: RejectRequestParams,
-  ): Promise<{ record: VtFlowRecord; problemReport: ReturnType<typeof buildVtFlowProblemReport> }> {
+  ): Promise<{
+    record: VtFlowRecord
+    problemReport: ReturnType<typeof buildVtFlowProblemReport>
+  }> {
     const record = await this.repository.getById(agentContext, recordId)
 
     const problemReport = buildVtFlowProblemReport({
@@ -373,7 +376,10 @@ export class VtFlowService {
     agentContext: AgentContext,
     recordId: string,
     params: Partial<RejectRequestParams> = {},
-  ): Promise<{ record: VtFlowRecord; problemReport: ReturnType<typeof buildVtFlowProblemReport> }> {
+  ): Promise<{
+    record: VtFlowRecord
+    problemReport: ReturnType<typeof buildVtFlowProblemReport>
+  }> {
     const record = await this.repository.getById(agentContext, recordId)
     record.assertRole(VtFlowRole.Applicant)
 
@@ -397,7 +403,10 @@ export class VtFlowService {
     agentContext: AgentContext,
     recordId: string,
     params: Partial<RejectRequestParams> = {},
-  ): Promise<{ record: VtFlowRecord; problemReport: ReturnType<typeof buildVtFlowProblemReport> }> {
+  ): Promise<{
+    record: VtFlowRecord
+    problemReport: ReturnType<typeof buildVtFlowProblemReport>
+  }> {
     const record = await this.repository.getById(agentContext, recordId)
     record.assertRole(VtFlowRole.Validator)
 
@@ -425,7 +434,10 @@ export class VtFlowService {
       state: VtFlowState.ParticipantRevoked | VtFlowState.ParticipantSlashed
       enDescription?: string
     },
-  ): Promise<{ record: VtFlowRecord; problemReport: ReturnType<typeof buildVtFlowProblemReport> }> {
+  ): Promise<{
+    record: VtFlowRecord
+    problemReport: ReturnType<typeof buildVtFlowProblemReport>
+  }> {
     const record = await this.repository.getById(agentContext, recordId)
 
     const problemReport = buildVtFlowProblemReport({
@@ -745,7 +757,11 @@ export class VtFlowService {
     }
     let permitted = false
     try {
-      permitted = await hook({ agentContext, peerDid, connectionId: connection.id })
+      permitted = await hook({
+        agentContext,
+        peerDid,
+        connectionId: connection.id,
+      })
     } catch (error) {
       throw new CredoError(
         `vt-flow.not-a-verifiable-service: peer '${peerDid}' failed VS-CONN-VS check (${(error as Error).message})`,
@@ -753,6 +769,13 @@ export class VtFlowService {
     }
     if (!permitted) {
       throw new CredoError(`vt-flow.not-a-verifiable-service: peer '${peerDid}' failed VS-CONN-VS check`)
+    }
+
+    // Tag the record with the public DID of the peer. The agent reads that tag to reuse
+    // this connection, instead of adding a second record for the same pair of DIDs.
+    if (connection.getTag('publicDid') !== peerDid) {
+      connection.setTag('publicDid', peerDid)
+      await agentContext.resolve(DidCommConnectionRepository).update(agentContext, connection)
     }
   }
 }


### PR DESCRIPTION
Addresses https://github.com/verana-labs/vs-agent/issues/617 by using a `publicDid` tag for each DidCommConnection. This query is quite fast, since it will only use a tag. 

Additionally, it will delete the connection record automatically in case of any issue (e.g. timeout). This will make it easier to prevent stale connection records.