### PR TITLE
fix: admin api global error envelope and code vocabulary

### DIFF
--- a/apps/vs-agent/src/common/AdminApiError.ts
+++ b/apps/vs-agent/src/common/AdminApiError.ts
@@ -1,0 +1,20 @@
+export enum AdminApiErrorCode {
+  InvalidInput = 'INVALID_INPUT',
+  InvalidCursor = 'INVALID_CURSOR',
+  Unauthenticated = 'UNAUTHENTICATED',
+  Forbidden = 'FORBIDDEN',
+  UnknownId = 'UNKNOWN_ID',
+  InvalidState = 'INVALID_STATE',
+  Internal = 'INTERNAL',
+}
+
+export class AdminApiError extends Error {
+  public constructor(
+    public readonly code: string,
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = 'AdminApiError'
+  }
+}

--- a/apps/vs-agent/src/common/ErrorEnvelopeFilter.ts
+++ b/apps/vs-agent/src/common/ErrorEnvelopeFilter.ts
@@ -37,6 +37,8 @@ export class ErrorEnvelopeFilter extends BaseExceptionFilter {
     }
 
     const response = http.getResponse<Response>()
+    if (response.headersSent) return
+
     response.status(envelope.status).json({ error: { code: envelope.code, message: envelope.message } })
   }
 
@@ -74,11 +76,29 @@ export class ErrorEnvelopeFilter extends BaseExceptionFilter {
       }
     }
 
+    const status = this.statusOf(exception)
+    if (status) {
+      return {
+        status,
+        code: this.codeForStatus(status),
+        message:
+          status >= HttpStatus.INTERNAL_SERVER_ERROR
+            ? INTERNAL_MESSAGE
+            : ((exception as Error).message ?? INTERNAL_MESSAGE),
+      }
+    }
+
     return {
       status: HttpStatus.INTERNAL_SERVER_ERROR,
       code: AdminApiErrorCode.Internal,
       message: INTERNAL_MESSAGE,
     }
+  }
+
+  private statusOf(exception: unknown): number | undefined {
+    const candidate = exception as { status?: unknown; statusCode?: unknown } | null
+    const status = typeof candidate?.status === 'number' ? candidate.status : candidate?.statusCode
+    return typeof status === 'number' && status >= 400 && status <= 599 ? status : undefined
   }
 
   private codeForStatus(status: number): string {

--- a/apps/vs-agent/src/common/ErrorEnvelopeFilter.ts
+++ b/apps/vs-agent/src/common/ErrorEnvelopeFilter.ts
@@ -1,0 +1,127 @@
+import type { Request, Response } from 'express'
+
+import { ArgumentsHost, Catch, HttpException, HttpStatus, Logger } from '@nestjs/common'
+import { BaseExceptionFilter } from '@nestjs/core'
+
+import {
+  ServiceEndpointError,
+  ServiceEndpointErrorCode,
+} from '../controllers/admin/service-endpoints/ServiceEndpointsService'
+
+import { AdminApiError, AdminApiErrorCode } from './AdminApiError'
+
+interface ErrorEnvelope {
+  status: number
+  code: string
+  message: string
+}
+
+const INTERNAL_MESSAGE = 'the agent failed to complete the request'
+
+@Catch()
+export class ErrorEnvelopeFilter extends BaseExceptionFilter {
+  private readonly logger = new Logger(ErrorEnvelopeFilter.name)
+
+  public catch(exception: unknown, host: ArgumentsHost): void {
+    const http = host.switchToHttp()
+    const request = http.getRequest<Request>()
+
+    if (!this.isV2Request(request)) {
+      super.catch(exception, host)
+      return
+    }
+
+    const envelope = this.envelopeFor(exception)
+    if (envelope.status >= HttpStatus.INTERNAL_SERVER_ERROR) {
+      this.logger.error(`${request.method} ${this.pathOf(request)} failed`, exception as Error)
+    }
+
+    const response = http.getResponse<Response>()
+    response.status(envelope.status).json({ error: { code: envelope.code, message: envelope.message } })
+  }
+
+  private isV2Request(request: Request): boolean {
+    const path = this.pathOf(request)
+    return path === '/v2' || path.startsWith('/v2/')
+  }
+
+  private pathOf(request: Request): string {
+    return (request.originalUrl ?? request.url ?? '').split('?')[0]
+  }
+
+  private envelopeFor(exception: unknown): ErrorEnvelope {
+    if (exception instanceof AdminApiError) {
+      return { status: exception.status, code: exception.code, message: exception.message }
+    }
+
+    if (exception instanceof ServiceEndpointError) {
+      return {
+        status: this.statusForServiceEndpointCode(exception.code),
+        code: this.codeForServiceEndpointCode(exception.code),
+        message: exception.message,
+      }
+    }
+
+    if (exception instanceof HttpException) {
+      const status = exception.getStatus()
+      return {
+        status,
+        code: this.codeForStatus(status),
+        message:
+          status >= HttpStatus.INTERNAL_SERVER_ERROR
+            ? INTERNAL_MESSAGE
+            : this.messageOf(exception.getResponse(), exception.message),
+      }
+    }
+
+    return {
+      status: HttpStatus.INTERNAL_SERVER_ERROR,
+      code: AdminApiErrorCode.Internal,
+      message: INTERNAL_MESSAGE,
+    }
+  }
+
+  private codeForStatus(status: number): string {
+    switch (status) {
+      case HttpStatus.UNAUTHORIZED:
+        return AdminApiErrorCode.Unauthenticated
+      case HttpStatus.FORBIDDEN:
+        return AdminApiErrorCode.Forbidden
+      case HttpStatus.NOT_FOUND:
+        return AdminApiErrorCode.UnknownId
+      case HttpStatus.CONFLICT:
+        return AdminApiErrorCode.InvalidState
+      default:
+        return status >= HttpStatus.INTERNAL_SERVER_ERROR
+          ? AdminApiErrorCode.Internal
+          : AdminApiErrorCode.InvalidInput
+    }
+  }
+
+  private statusForServiceEndpointCode(code: ServiceEndpointErrorCode): number {
+    switch (code) {
+      case ServiceEndpointErrorCode.NotFound:
+        return HttpStatus.NOT_FOUND
+      case ServiceEndpointErrorCode.DuplicateId:
+      case ServiceEndpointErrorCode.DidcommEntry:
+      case ServiceEndpointErrorCode.LinkedVpEntry:
+      case ServiceEndpointErrorCode.AdminApiEntry:
+        return HttpStatus.CONFLICT
+      default:
+        return HttpStatus.BAD_REQUEST
+    }
+  }
+
+  private codeForServiceEndpointCode(code: ServiceEndpointErrorCode): string {
+    return code === ServiceEndpointErrorCode.NotFound ? AdminApiErrorCode.UnknownId : code
+  }
+
+  private messageOf(payload: string | object, fallback: string): string {
+    if (typeof payload === 'string') return payload
+
+    const message = (payload as { message?: unknown }).message
+    if (typeof message === 'string') return message
+    if (Array.isArray(message)) return message.join('; ')
+    return fallback
+  }
+}

--- a/apps/vs-agent/src/common/index.ts
+++ b/apps/vs-agent/src/common/index.ts
@@ -1,0 +1,2 @@
+export * from './AdminApiError'
+export * from './ErrorEnvelopeFilter'

--- a/apps/vs-agent/src/utils/setupAgent.ts
+++ b/apps/vs-agent/src/utils/setupAgent.ts
@@ -4,6 +4,7 @@ import { AskarModuleConfigStoreOptions } from '@credo-ts/askar'
 import { LogLevel, ParsedDid } from '@credo-ts/core'
 import { agentDependencies } from '@credo-ts/node'
 import { INestApplication, ValidationPipe, VersioningType } from '@nestjs/common'
+import { HttpAdapterHost } from '@nestjs/core'
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'
 import {
   assertVerifiableService,
@@ -20,6 +21,7 @@ import {
 import express from 'express'
 import WebSocket from 'ws'
 
+import { ErrorEnvelopeFilter } from '../common'
 import {
   ADMIN_V2_TAGS,
   AGENT_DIDCOMM_VERSIONS,
@@ -270,6 +272,9 @@ export function commonAppConfig(
 
   // Pipes
   app.useGlobalPipes(new ValidationPipe())
+
+  // Error envelope for every v2 route
+  app.useGlobalFilters(new ErrorEnvelopeFilter(app.get(HttpAdapterHost).httpAdapter))
 
   // CORS
   if (cors) {

--- a/apps/vs-agent/tests/errorEnvelopeFilter.test.ts
+++ b/apps/vs-agent/tests/errorEnvelopeFilter.test.ts
@@ -1,0 +1,213 @@
+import type { INestApplication } from '@nestjs/common'
+
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  NotFoundException,
+  Post,
+  UseFilters,
+  ValidationPipe,
+} from '@nestjs/common'
+import { APP_GUARD } from '@nestjs/core'
+import { Test } from '@nestjs/testing'
+import { IsString } from 'class-validator'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { AdminApiError, AdminApiErrorCode } from '../src/common/AdminApiError'
+import { ServiceEndpointExceptionFilter } from '../src/controllers/admin/service-endpoints/ServiceEndpointExceptionFilter'
+import {
+  ServiceEndpointError,
+  ServiceEndpointErrorCode,
+} from '../src/controllers/admin/service-endpoints/ServiceEndpointsService'
+import { AccessMode, AdminAuthGuard, AdminAuthService } from '../src/security'
+import { commonAppConfig } from '../src/utils/setupAgent'
+
+class SendMessageDto {
+  @IsString()
+  connectionId!: string
+
+  @IsString()
+  type!: string
+}
+
+@AccessMode('PUBLIC')
+@Controller({ path: 'didcomm', version: '2' })
+class V2DidcommFixtureController {
+  @Get('connections/:connectionId')
+  getConnection(): never {
+    throw new NotFoundException('no connection with the given id')
+  }
+
+  @Get('connections')
+  listConnections(): never {
+    throw new AdminApiError(
+      AdminApiErrorCode.InvalidCursor,
+      HttpStatus.BAD_REQUEST,
+      'the cursor is malformed',
+    )
+  }
+
+  // esbuild drops the design:type metadata that the global pipe infers from, so the
+  // expected type is named here instead.
+  @Post('send-message')
+  sendMessage(@Body(new ValidationPipe({ expectedType: SendMessageDto })) body: SendMessageDto) {
+    return body
+  }
+
+  @Get('boom')
+  boom(): never {
+    throw new Error('askar storage is corrupted at /var/lib/agent/wallet.db')
+  }
+
+  @AccessMode('CORPORATION')
+  @Get('presentations')
+  listPresentations() {
+    return { items: [], nextCursor: null }
+  }
+}
+
+@AccessMode('PUBLIC')
+@Controller({ path: 'vt/service-endpoints', version: '2' })
+class V2ServiceEndpointsFixtureController {
+  @Post()
+  addServiceEndpoint(): never {
+    throw new ServiceEndpointError(
+      ServiceEndpointErrorCode.DuplicateId,
+      'an entry with that id already exists',
+    )
+  }
+}
+
+@AccessMode('PUBLIC')
+@Controller({ path: 'connections', version: '1' })
+class V1ConnectionsFixtureController {
+  @Get(':connectionId')
+  getConnection(): never {
+    throw new NotFoundException('connection not found')
+  }
+}
+
+@AccessMode('PUBLIC')
+@UseFilters(ServiceEndpointExceptionFilter)
+@Controller({ path: 'vt/service-endpoints', version: '1' })
+class V1ServiceEndpointsFixtureController {
+  @Post()
+  addServiceEndpoint(): never {
+    throw new ServiceEndpointError(
+      ServiceEndpointErrorCode.DuplicateId,
+      'an entry with that id already exists',
+    )
+  }
+}
+
+describe('v2 error envelope', () => {
+  let app: INestApplication
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [
+        V2DidcommFixtureController,
+        V2ServiceEndpointsFixtureController,
+        V1ConnectionsFixtureController,
+        V1ServiceEndpointsFixtureController,
+      ],
+      providers: [
+        AdminAuthService,
+        { provide: 'VSAGENT', useValue: {} },
+        { provide: 'ADMIN_ALLOWED_ACCOUNTS', useValue: [] },
+        { provide: APP_GUARD, useClass: AdminAuthGuard },
+      ],
+    }).compile()
+
+    app = moduleRef.createNestApplication()
+    commonAppConfig(app, false, true, false)
+    await app.init()
+  })
+
+  afterAll(async () => {
+    await app?.close()
+  })
+
+  it('derives the code from the status of a nest exception', async () => {
+    const response = await request(app.getHttpServer()).get('/v2/didcomm/connections/unknown-id')
+
+    expect(response.status).toBe(404)
+    expect(response.body).toEqual({
+      error: { code: 'UNKNOWN_ID', message: 'no connection with the given id' },
+    })
+  })
+
+  it('reports the code that the status alone cannot express', async () => {
+    const response = await request(app.getHttpServer()).get('/v2/didcomm/connections?cursor=zzz')
+
+    expect(response.status).toBe(400)
+    expect(response.body).toEqual({
+      error: { code: 'INVALID_CURSOR', message: 'the cursor is malformed' },
+    })
+  })
+
+  it('envelopes what the validation pipe rejects', async () => {
+    const response = await request(app.getHttpServer()).post('/v2/didcomm/send-message').send({})
+
+    expect(response.status).toBe(400)
+    expect(response.body.error.code).toBe('INVALID_INPUT')
+    expect(response.body.error.message).toContain('connectionId')
+    expect(response.body.error.message).toContain('type')
+    expect(Object.keys(response.body)).toEqual(['error'])
+  })
+
+  it('envelopes the 404 that the router raises on a path that no v2 method serves', async () => {
+    const response = await request(app.getHttpServer()).get('/v2/didcomm/there-is-no-such-method')
+
+    expect(response.status).toBe(404)
+    expect(response.body.error.code).toBe('UNKNOWN_ID')
+  })
+
+  it('envelopes the rejection of the auth guard', async () => {
+    const response = await request(app.getHttpServer()).get('/v2/didcomm/presentations')
+
+    expect(response.status).toBe(401)
+    expect(response.body).toEqual({
+      error: { code: 'UNAUTHENTICATED', message: 'a valid bearer token is required' },
+    })
+  })
+
+  it('reports an unexpected failure as INTERNAL without leaking its detail', async () => {
+    const response = await request(app.getHttpServer()).get('/v2/didcomm/boom')
+
+    expect(response.status).toBe(500)
+    expect(response.body).toEqual({
+      error: { code: 'INTERNAL', message: 'the agent failed to complete the request' },
+    })
+    expect(JSON.stringify(response.body)).not.toContain('askar')
+  })
+
+  it('envelopes a service endpoint error on a v2 method', async () => {
+    const response = await request(app.getHttpServer()).post('/v2/vt/service-endpoints').send({})
+
+    expect(response.status).toBe(409)
+    expect(response.body).toEqual({
+      error: { code: 'DUPLICATE_ID', message: 'an entry with that id already exists' },
+    })
+  })
+
+  it('leaves the body of a v1 method untouched', async () => {
+    const response = await request(app.getHttpServer()).get('/v1/connections/unknown-id')
+
+    expect(response.status).toBe(404)
+    expect(response.body).toEqual({ statusCode: 404, message: 'connection not found', error: 'Not Found' })
+  })
+
+  it('keeps the v1 service endpoint filter ahead of the envelope', async () => {
+    const response = await request(app.getHttpServer()).post('/v1/vt/service-endpoints').send({})
+
+    expect(response.status).toBe(409)
+    expect(response.body).toEqual({
+      code: 'DUPLICATE_ID',
+      reason: 'an entry with that id already exists',
+    })
+  })
+})

--- a/apps/vs-agent/tests/errorEnvelopeFilter.test.ts
+++ b/apps/vs-agent/tests/errorEnvelopeFilter.test.ts
@@ -159,6 +159,26 @@ describe('v2 error envelope', () => {
     expect(Object.keys(response.body)).toEqual(['error'])
   })
 
+  it('envelopes what the body parser rejects before any v2 method runs', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/v2/didcomm/send-message')
+      .set('Content-Type', 'application/json')
+      .send('{"connectionId": ')
+
+    expect(response.status).toBe(400)
+    expect(response.body.error.code).toBe('INVALID_INPUT')
+  })
+
+  it('envelopes a body that exceeds the size limit', async () => {
+    const response = await request(app.getHttpServer())
+      .post('/v2/didcomm/send-message')
+      .set('Content-Type', 'application/json')
+      .send(JSON.stringify({ connectionId: 'x'.repeat(6 * 1024 * 1024) }))
+
+    expect(response.status).toBe(413)
+    expect(response.body.error.code).toBe('INVALID_INPUT')
+  })
+
   it('envelopes the 404 that the router raises on a path that no v2 method serves', async () => {
     const response = await request(app.getHttpServer()).get('/v2/didcomm/there-is-no-such-method')
 


### PR DESCRIPTION
**Changes**

- Create explicit error code handling for `AdminApiError`.
- Create normalized error code handling for `ServiceEndpointError`, mapping `NOT_FOUND` to `UNKNOWN_ID`.
- Create error code mapping for `HttpException` based on the HTTP status:

  * `401` / `403` / `404` / `409` → corresponding error code.
  * Other `4xx` → `INVALID_INPUT`.
  * `5xx` → `INTERNAL`.
- Create the same HTTP status-based error handling for Express middleware errors with a `status` property.
- Create a fallback for unexpected errors, returning `500 INTERNAL` while keeping the error details only in the logs.
