### PR TITLE
feat: admin api v2 liveness and readiness probes

### DIFF
--- a/apps/vs-agent/src/admin.module.ts
+++ b/apps/vs-agent/src/admin.module.ts
@@ -24,6 +24,7 @@ import {
   V1VsAgentController,
   MESSAGE_HANDLERS,
 } from './controllers'
+import { BOOTSTRAP_STATE, BootstrapState } from './common'
 import { AdminAuthGuard, AdminAuthService, V1AuthController } from './security'
 import { UrlShorteningService } from './services/UrlShorteningService'
 import { VsAgentService } from './services/VsAgentService'
@@ -34,9 +35,10 @@ export class VsAgentModule {
     agent: VsAgent,
     publicApiBaseUrl: string,
     nestPlugins: VsAgentNestPlugin[] = [],
-    options: { external?: boolean; allowedAccounts?: string[] } = {},
+    options: { external?: boolean; allowedAccounts?: string[]; bootstrapState?: BootstrapState } = {},
   ): DynamicModule {
     const agentRef = { get: () => agent, toJSON: () => 'VsAgent' }
+    const bootstrapState = options.bootstrapState ?? new BootstrapState()
 
     const baseControllers = [
       V1VsAgentController,
@@ -68,6 +70,10 @@ export class VsAgentModule {
       {
         provide: 'PUBLIC_API_BASE_URL',
         useFactory: () => publicApiBaseUrl,
+      },
+      {
+        provide: BOOTSTRAP_STATE,
+        useFactory: () => bootstrapState,
       },
       VsAgentService,
       UrlShorteningService,

--- a/apps/vs-agent/src/common/AdminApiError.ts
+++ b/apps/vs-agent/src/common/AdminApiError.ts
@@ -5,6 +5,7 @@ export enum AdminApiErrorCode {
   Forbidden = 'FORBIDDEN',
   UnknownId = 'UNKNOWN_ID',
   InvalidState = 'INVALID_STATE',
+  NotReady = 'NOT_READY',
   Internal = 'INTERNAL',
 }
 

--- a/apps/vs-agent/src/common/BootstrapState.ts
+++ b/apps/vs-agent/src/common/BootstrapState.ts
@@ -19,6 +19,11 @@ export interface ReadinessResult {
   message?: string
 }
 
+export interface LivenessResult {
+  live: boolean
+  message?: string
+}
+
 export class BootstrapState {
   private readonly steps = new Map<BootstrapStep, BootstrapStepState>()
   private readonly failures = new Map<BootstrapStep, string>()
@@ -58,6 +63,16 @@ export class BootstrapState {
 
   public get ecsBootstrapRecord(): EcsBootstrapRecord | undefined {
     return this.ecsBootstrap
+  }
+
+  public get liveness(): LivenessResult {
+    for (const [step, state] of this.steps) {
+      if (state === 'failed') {
+        return { live: false, message: `bootstrap step '${step}' failed and could not be recovered` }
+      }
+    }
+
+    return { live: true }
   }
 
   public get readiness(): ReadinessResult {

--- a/apps/vs-agent/src/common/BootstrapState.ts
+++ b/apps/vs-agent/src/common/BootstrapState.ts
@@ -1,0 +1,78 @@
+import type { IndexerSyncStatus } from '@verana-labs/vs-agent-sdk'
+
+export const BOOTSTRAP_STATE = 'BOOTSTRAP_STATE'
+
+export type BootstrapStep = 'vtjsc-service-id-migration' | 'self-trust-registry' | 'indexer-subscription'
+
+export type BootstrapStepState = 'pending' | 'completed' | 'skipped' | 'failed'
+
+export type EcsBootstrapOutcome = 'pending' | 'completed' | 'failed'
+
+export interface EcsBootstrapRecord {
+  mode: string
+  outcome: EcsBootstrapOutcome
+  reason?: string
+}
+
+export interface ReadinessResult {
+  ready: boolean
+  message?: string
+}
+
+export class BootstrapState {
+  private readonly steps = new Map<BootstrapStep, BootstrapStepState>()
+  private readonly failures = new Map<BootstrapStep, string>()
+  private indexerSyncStatus?: () => IndexerSyncStatus
+  private ecsBootstrap?: EcsBootstrapRecord
+
+  require(step: BootstrapStep): void {
+    this.steps.set(step, 'pending')
+  }
+
+  complete(step: BootstrapStep): void {
+    this.steps.set(step, 'completed')
+    this.failures.delete(step)
+  }
+
+  skip(step: BootstrapStep): void {
+    this.steps.set(step, 'skipped')
+    this.failures.delete(step)
+  }
+
+  fail(step: BootstrapStep, reason: string): void {
+    this.steps.set(step, 'failed')
+    this.failures.set(step, reason)
+  }
+
+  watchIndexer(probe: () => IndexerSyncStatus): void {
+    this.indexerSyncStatus = probe
+  }
+
+  recordEcsBootstrap(mode: string, outcome: EcsBootstrapOutcome, reason?: string): void {
+    this.ecsBootstrap = { mode, outcome, reason }
+  }
+
+  get stepStates(): Record<string, BootstrapStepState> {
+    return Object.fromEntries(this.steps)
+  }
+
+  get ecsBootstrapRecord(): EcsBootstrapRecord | undefined {
+    return this.ecsBootstrap
+  }
+
+  get readiness(): ReadinessResult {
+    for (const [step, state] of this.steps) {
+      if (state === 'pending') return { ready: false, message: `bootstrap step '${step}' has not completed` }
+      if (state === 'failed') return { ready: false, message: `bootstrap step '${step}' failed` }
+    }
+
+    switch (this.indexerSyncStatus?.()) {
+      case 'never-synced':
+        return { ready: false, message: 'the initial indexer catch-up has not completed' }
+      case 'catching-up':
+        return { ready: false, message: 'the agent is catching up with the indexer' }
+      default:
+        return { ready: true }
+    }
+  }
+}

--- a/apps/vs-agent/src/common/BootstrapState.ts
+++ b/apps/vs-agent/src/common/BootstrapState.ts
@@ -25,42 +25,42 @@ export class BootstrapState {
   private indexerSyncStatus?: () => IndexerSyncStatus
   private ecsBootstrap?: EcsBootstrapRecord
 
-  require(step: BootstrapStep): void {
+  public require(step: BootstrapStep): void {
     this.steps.set(step, 'pending')
   }
 
-  complete(step: BootstrapStep): void {
+  public complete(step: BootstrapStep): void {
     this.steps.set(step, 'completed')
     this.failures.delete(step)
   }
 
-  skip(step: BootstrapStep): void {
+  public skip(step: BootstrapStep): void {
     this.steps.set(step, 'skipped')
     this.failures.delete(step)
   }
 
-  fail(step: BootstrapStep, reason: string): void {
+  public fail(step: BootstrapStep, reason: string): void {
     this.steps.set(step, 'failed')
     this.failures.set(step, reason)
   }
 
-  watchIndexer(probe: () => IndexerSyncStatus): void {
+  public watchIndexer(probe: () => IndexerSyncStatus): void {
     this.indexerSyncStatus = probe
   }
 
-  recordEcsBootstrap(mode: string, outcome: EcsBootstrapOutcome, reason?: string): void {
+  public recordEcsBootstrap(mode: string, outcome: EcsBootstrapOutcome, reason?: string): void {
     this.ecsBootstrap = { mode, outcome, reason }
   }
 
-  get stepStates(): Record<string, BootstrapStepState> {
+  public get stepStates(): Record<string, BootstrapStepState> {
     return Object.fromEntries(this.steps)
   }
 
-  get ecsBootstrapRecord(): EcsBootstrapRecord | undefined {
+  public get ecsBootstrapRecord(): EcsBootstrapRecord | undefined {
     return this.ecsBootstrap
   }
 
-  get readiness(): ReadinessResult {
+  public get readiness(): ReadinessResult {
     for (const [step, state] of this.steps) {
       if (state === 'pending') return { ready: false, message: `bootstrap step '${step}' has not completed` }
       if (state === 'failed') return { ready: false, message: `bootstrap step '${step}' failed` }

--- a/apps/vs-agent/src/common/ErrorEnvelopeFilter.ts
+++ b/apps/vs-agent/src/common/ErrorEnvelopeFilter.ts
@@ -32,7 +32,7 @@ export class ErrorEnvelopeFilter extends BaseExceptionFilter {
     }
 
     const envelope = this.envelopeFor(exception)
-    if (envelope.status >= HttpStatus.INTERNAL_SERVER_ERROR) {
+    if (envelope.code === AdminApiErrorCode.Internal) {
       this.logger.error(`${request.method} ${this.pathOf(request)} failed`, exception as Error)
     }
 

--- a/apps/vs-agent/src/common/index.ts
+++ b/apps/vs-agent/src/common/index.ts
@@ -1,2 +1,3 @@
 export * from './AdminApiError'
+export * from './BootstrapState'
 export * from './ErrorEnvelopeFilter'

--- a/apps/vs-agent/src/controllers/admin/v2/agent/V2AgentController.ts
+++ b/apps/vs-agent/src/controllers/admin/v2/agent/V2AgentController.ts
@@ -4,11 +4,13 @@ import { ApiOkResponse, ApiOperation, ApiServiceUnavailableResponse, ApiTags } f
 import { AdminApiError, AdminApiErrorCode, BOOTSTRAP_STATE, BootstrapState } from '../../../../common'
 import { AccessMode } from '../../../../security'
 
+import { LivenessDto, ReadinessDto } from './health.dto'
+
 @ApiTags('v2/agent')
 @AccessMode('INTERNAL')
 @Controller({ path: 'agent', version: '2' })
 export class V2AgentController {
-  constructor(@Inject(BOOTSTRAP_STATE) private readonly bootstrapState: BootstrapState) {}
+  public constructor(@Inject(BOOTSTRAP_STATE) private readonly bootstrapState: BootstrapState) {}
 
   @Get('health/live')
   @AccessMode('PUBLIC')
@@ -17,8 +19,8 @@ export class V2AgentController {
     description:
       'Answers as soon as the HTTP listener accepts a connection. Never fails because an external dependency failed.',
   })
-  @ApiOkResponse({ description: 'The agent process is alive' })
-  getLiveness() {
+  @ApiOkResponse({ description: 'The agent process is alive', type: LivenessDto })
+  public getLiveness(): LivenessDto {
     return { status: 'live' }
   }
 
@@ -29,9 +31,9 @@ export class V2AgentController {
     description:
       'Answers 200 once every bootstrap step completed and the agent is up to date with the indexer.',
   })
-  @ApiOkResponse({ description: 'The agent is ready to serve' })
+  @ApiOkResponse({ description: 'The agent is ready to serve', type: ReadinessDto })
   @ApiServiceUnavailableResponse({ description: 'A bootstrap step is still pending' })
-  getReadiness() {
+  public getReadiness(): ReadinessDto {
     const { ready, message } = this.bootstrapState.readiness
 
     if (!ready) {

--- a/apps/vs-agent/src/controllers/admin/v2/agent/V2AgentController.ts
+++ b/apps/vs-agent/src/controllers/admin/v2/agent/V2AgentController.ts
@@ -20,7 +20,18 @@ export class V2AgentController {
       'Answers as soon as the HTTP listener accepts a connection. Never fails because an external dependency failed.',
   })
   @ApiOkResponse({ description: 'The agent process is alive', type: LivenessDto })
+  @ApiServiceUnavailableResponse({ description: 'A bootstrap step failed beyond recovery' })
   public getLiveness(): LivenessDto {
+    const { live, message } = this.bootstrapState.liveness
+
+    if (!live) {
+      throw new AdminApiError(
+        AdminApiErrorCode.Internal,
+        HttpStatus.SERVICE_UNAVAILABLE,
+        message ?? 'the agent cannot recover without a restart',
+      )
+    }
+
     return { status: 'live' }
   }
 

--- a/apps/vs-agent/src/controllers/admin/v2/agent/V2AgentController.ts
+++ b/apps/vs-agent/src/controllers/admin/v2/agent/V2AgentController.ts
@@ -1,9 +1,47 @@
-import { Controller } from '@nestjs/common'
-import { ApiTags } from '@nestjs/swagger'
+import { Controller, Get, HttpStatus, Inject } from '@nestjs/common'
+import { ApiOkResponse, ApiOperation, ApiServiceUnavailableResponse, ApiTags } from '@nestjs/swagger'
 
+import { AdminApiError, AdminApiErrorCode, BOOTSTRAP_STATE, BootstrapState } from '../../../../common'
 import { AccessMode } from '../../../../security'
 
 @ApiTags('v2/agent')
 @AccessMode('INTERNAL')
 @Controller({ path: 'agent', version: '2' })
-export class V2AgentController {}
+export class V2AgentController {
+  constructor(@Inject(BOOTSTRAP_STATE) private readonly bootstrapState: BootstrapState) {}
+
+  @Get('health/live')
+  @AccessMode('PUBLIC')
+  @ApiOperation({
+    summary: 'Liveness probe',
+    description:
+      'Answers as soon as the HTTP listener accepts a connection. Never fails because an external dependency failed.',
+  })
+  @ApiOkResponse({ description: 'The agent process is alive' })
+  getLiveness() {
+    return { status: 'live' }
+  }
+
+  @Get('health/ready')
+  @AccessMode('PUBLIC')
+  @ApiOperation({
+    summary: 'Readiness probe',
+    description:
+      'Answers 200 once every bootstrap step completed and the agent is up to date with the indexer.',
+  })
+  @ApiOkResponse({ description: 'The agent is ready to serve' })
+  @ApiServiceUnavailableResponse({ description: 'A bootstrap step is still pending' })
+  getReadiness() {
+    const { ready, message } = this.bootstrapState.readiness
+
+    if (!ready) {
+      throw new AdminApiError(
+        AdminApiErrorCode.NotReady,
+        HttpStatus.SERVICE_UNAVAILABLE,
+        message ?? 'the agent is not ready',
+      )
+    }
+
+    return { status: 'ready' }
+  }
+}

--- a/apps/vs-agent/src/controllers/admin/v2/agent/health.dto.ts
+++ b/apps/vs-agent/src/controllers/admin/v2/agent/health.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger'
+
+export class LivenessDto {
+  @ApiProperty({
+    type: String,
+    enum: ['live'],
+    description: 'Fixed marker that the agent process accepted the request',
+    example: 'live',
+  })
+  status!: 'live'
+}
+
+export class ReadinessDto {
+  @ApiProperty({
+    type: String,
+    enum: ['ready'],
+    description: 'Fixed marker that every bootstrap step completed and the agent is up to date',
+    example: 'ready',
+  })
+  status!: 'ready'
+}

--- a/apps/vs-agent/src/controllers/admin/v2/agent/index.ts
+++ b/apps/vs-agent/src/controllers/admin/v2/agent/index.ts
@@ -1,1 +1,2 @@
+export * from './health.dto'
 export * from './V2AgentController'

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -422,7 +422,7 @@ const run = async () => {
     bootstrapState.require('vtjsc-service-id-migration')
     bootstrapState.require('self-trust-registry')
   }
-  if (VERANA_INDEXER_BASE_URL) bootstrapState.require('indexer-subscription')
+  bootstrapState.require('indexer-subscription')
 
   const conf: ServerConfig = {
     port: ADMIN_PORT,

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -98,6 +98,7 @@ import {
   commonAppConfig,
   type ServerConfig,
   setupAgent,
+  runWithRetries,
   toNestLogLevels,
   TsLogger,
   webhookEvent,
@@ -169,6 +170,8 @@ export const startServers = async (agent: VsAgent, serverConfig: ServerConfig) =
 }
 
 const AUTHORIZATION_SEED_RETRY_MS = 30_000
+const VTJSC_MIGRATION_RETRY_MS = 30_000
+const VTJSC_MIGRATION_MAX_ATTEMPTS = 5
 
 const run = async () => {
   const serverLogger = new TsLogger(ADMIN_LOG_LEVEL, 'Server')
@@ -351,22 +354,12 @@ const run = async () => {
       logger: serverLogger,
       corporationId: VERANA_CORPORATION_ID ? Number(VERANA_CORPORATION_ID) : undefined,
     })
-    const seedAuthorizationCache = async (): Promise<boolean> =>
-      authorizationService!
-        .refreshForOperator()
-        .then(() => true)
-        .catch(error => {
-          serverLogger.error(
-            `[Authorization] failed to seed the authorization cache: ${(error as Error).message}`,
-          )
-          return false
-        })
-    if (!(await seedAuthorizationCache())) {
-      const retry = setInterval(async () => {
-        if (await seedAuthorizationCache()) clearInterval(retry)
-      }, AUTHORIZATION_SEED_RETRY_MS)
-      retry.unref()
-    }
+    await runWithRetries({
+      run: () => authorizationService!.refreshForOperator(),
+      intervalMs: AUTHORIZATION_SEED_RETRY_MS,
+      onError: error =>
+        serverLogger.error(`[Authorization] failed to seed the authorization cache: ${error.message}`),
+    })
 
     try {
       const balance = await veranaChain.getBalance()
@@ -436,13 +429,17 @@ const run = async () => {
   const { httpServer, webSocketServer } = await startServers(agent, conf)
 
   if (agent.did) {
-    await migrateVtjscServiceIds(agent).then(
-      () => bootstrapState.complete('vtjsc-service-id-migration'),
-      (error: Error) => {
-        bootstrapState.fail('vtjsc-service-id-migration', error.message)
-        serverLogger.error(`[VTJSC] service id migration failed: ${error.message}`)
-      },
-    )
+    await runWithRetries({
+      run: () => migrateVtjscServiceIds(agent),
+      intervalMs: VTJSC_MIGRATION_RETRY_MS,
+      maxAttempts: VTJSC_MIGRATION_MAX_ATTEMPTS,
+      onSuccess: () => bootstrapState.complete('vtjsc-service-id-migration'),
+      onError: (error, attempt) =>
+        serverLogger.error(
+          `[VTJSC] service id migration failed (attempt ${attempt}/${VTJSC_MIGRATION_MAX_ATTEMPTS}): ${error.message}`,
+        ),
+      onExhausted: error => bootstrapState.fail('vtjsc-service-id-migration', error.message),
+    })
   }
 
   // Initialize Self-Trust Registry

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -31,6 +31,7 @@ import * as path from 'path'
 import packageJson from '../package.json'
 
 import { VsAgentModule } from './admin.module'
+import { BootstrapState } from './common'
 import {
   ADMIN_LOG_LEVEL,
   ADMIN_PORT,
@@ -103,15 +104,16 @@ import {
 } from './utils'
 
 export const startServers = async (agent: VsAgent, serverConfig: ServerConfig) => {
-  const { port, cors, endpoints, publicApiBaseUrl, nestPlugins = [] } = serverConfig
+  const { port, cors, endpoints, publicApiBaseUrl, nestPlugins = [], bootstrapState } = serverConfig
 
   // Nest's global level governs the plain @nestjs/common loggers (the credo agent uses AGENT_LOG_LEVEL).
   const nestLogLevels = toNestLogLevels(ADMIN_LOG_LEVEL)
 
   if (ADMIN_API_AUTH_MODE.includes('internal')) {
-    const adminApp = await NestFactory.create(VsAgentModule.register(agent, publicApiBaseUrl, nestPlugins), {
-      logger: nestLogLevels,
-    })
+    const adminApp = await NestFactory.create(
+      VsAgentModule.register(agent, publicApiBaseUrl, nestPlugins, { bootstrapState }),
+      { logger: nestLogLevels },
+    )
     commonAppConfig(adminApp, cors)
     await adminApp.listen(port)
   }
@@ -121,6 +123,7 @@ export const startServers = async (agent: VsAgent, serverConfig: ServerConfig) =
       VsAgentModule.register(agent, publicApiBaseUrl, nestPlugins, {
         external: true,
         allowedAccounts: ADMIN_API_CORPORATION_ALLOWED_ACCOUNTS,
+        bootstrapState,
       }),
       { logger: nestLogLevels },
     )
@@ -414,6 +417,13 @@ const run = async () => {
     adminApiServiceEndpoint,
   })
 
+  const bootstrapState = new BootstrapState()
+  if (agent.did) {
+    bootstrapState.require('vtjsc-service-id-migration')
+    bootstrapState.require('self-trust-registry')
+  }
+  if (VERANA_INDEXER_BASE_URL) bootstrapState.require('indexer-subscription')
+
   const conf: ServerConfig = {
     port: ADMIN_PORT,
     cors: USE_CORS,
@@ -421,12 +431,17 @@ const run = async () => {
     publicApiBaseUrl,
     endpoints,
     nestPlugins,
+    bootstrapState,
   }
   const { httpServer, webSocketServer } = await startServers(agent, conf)
 
   if (agent.did) {
-    await migrateVtjscServiceIds(agent).catch((error: Error) =>
-      serverLogger.error(`[VTJSC] service id migration failed: ${error.message}`),
+    await migrateVtjscServiceIds(agent).then(
+      () => bootstrapState.complete('vtjsc-service-id-migration'),
+      (error: Error) => {
+        bootstrapState.fail('vtjsc-service-id-migration', error.message)
+        serverLogger.error(`[VTJSC] service id migration failed: ${error.message}`)
+      },
     )
   }
 
@@ -457,12 +472,14 @@ const run = async () => {
     orgOrganizationKind: SELF_ISSUED_VTC_ORG_ORGANIZATIONKIND,
     orgCountryCode: SELF_ISSUED_VTC_ORG_COUNTRYCODE,
   }
-  if (agent.did)
+  if (agent.did) {
     await setupSelfTr({
       agent,
       publicApiBaseUrl,
       defaults: selfTrDefaults,
     })
+    bootstrapState.complete('self-trust-registry')
+  }
 
   // Deliver domain events emitted on the agent bus to the configured webhook endpoint
   webhookEvent(agent, EVENTS_BASE_URL, serverLogger)
@@ -507,8 +524,11 @@ const run = async () => {
         corporationId: indexerCorporationId,
         agentCorporationId: Number(VERANA_CORPORATION_ID),
       })
+      bootstrapState.watchIndexer(() => indexerWs.syncStatus)
+      bootstrapState.complete('indexer-subscription')
       await indexerWs.start()
     } else {
+      bootstrapState.skip('indexer-subscription')
       serverLogger.warn(
         '[IndexerWS] subscription skipped: agent has no public DID and VERANA_INDEXER_SUBSCRIPTION_SCOPE is not corporation',
       )
@@ -535,10 +555,15 @@ const run = async () => {
     },
     serverLogger,
   )
-  void ecsBootstrap.run().catch((error: Error) => {
-    serverLogger.error(`[EcsBootstrap] ${error.message}`)
-    if (AGENT_MODE === 'delegated') process.exit(1)
-  })
+  bootstrapState.recordEcsBootstrap(AGENT_MODE, 'pending')
+  void ecsBootstrap.run().then(
+    () => bootstrapState.recordEcsBootstrap(AGENT_MODE, 'completed'),
+    (error: Error) => {
+      bootstrapState.recordEcsBootstrap(AGENT_MODE, 'failed', error.message)
+      serverLogger.error(`[EcsBootstrap] ${error.message}`)
+      if (AGENT_MODE === 'delegated') process.exit(1)
+    },
+  )
 
   // Accept incoming DIDComm only after the catch-up, so the agent does not act on stale chain state.
   if (webSocketServer) {

--- a/apps/vs-agent/src/main.ts
+++ b/apps/vs-agent/src/main.ts
@@ -96,9 +96,9 @@ import { MessagingPlugin, VtFlowNestPlugin } from './plugins'
 import { PublicModule } from './public.module'
 import {
   commonAppConfig,
+  runWithRetries,
   type ServerConfig,
   setupAgent,
-  runWithRetries,
   toNestLogLevels,
   TsLogger,
   webhookEvent,

--- a/apps/vs-agent/src/utils/ServerConfig.ts
+++ b/apps/vs-agent/src/utils/ServerConfig.ts
@@ -1,6 +1,8 @@
 import type { VsAgentNestPlugin } from '@verana-labs/vs-agent-sdk'
 import type { Express } from 'express'
 
+import type { BootstrapState } from '../common'
+
 import { TsLogger } from './logger'
 
 export interface ServerConfig {
@@ -11,6 +13,7 @@ export interface ServerConfig {
   logger: TsLogger
   endpoints: string[]
   nestPlugins?: VsAgentNestPlugin[]
+  bootstrapState?: BootstrapState
 }
 
 export interface DidWebServerConfig extends ServerConfig {

--- a/apps/vs-agent/src/utils/index.ts
+++ b/apps/vs-agent/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './ServerConfig'
 export * from './logger'
+export * from './runWithRetries'
 export * from './setupAgent'
 export * from './webhookEvent'

--- a/apps/vs-agent/src/utils/runWithRetries.ts
+++ b/apps/vs-agent/src/utils/runWithRetries.ts
@@ -1,0 +1,42 @@
+export interface RunWithRetriesOptions {
+  run: () => Promise<void>
+  intervalMs: number
+  maxAttempts?: number
+  onError: (error: Error, attempt: number) => void
+  onSuccess?: () => void
+  onExhausted?: (error: Error) => void
+}
+
+export async function runWithRetries({
+  run,
+  intervalMs,
+  maxAttempts,
+  onError,
+  onSuccess,
+  onExhausted,
+}: RunWithRetriesOptions): Promise<void> {
+  let attempt = 0
+
+  const attemptOnce = async (): Promise<boolean> => {
+    attempt++
+    try {
+      await run()
+      onSuccess?.()
+      return true
+    } catch (error) {
+      onError(error as Error, attempt)
+      if (maxAttempts !== undefined && attempt >= maxAttempts) {
+        onExhausted?.(error as Error)
+        return true
+      }
+      return false
+    }
+  }
+
+  if (await attemptOnce()) return
+
+  const retry = setInterval(async () => {
+    if (await attemptOnce()) clearInterval(retry)
+  }, intervalMs)
+  retry.unref()
+}

--- a/apps/vs-agent/tests/errorEnvelopeFilter.test.ts
+++ b/apps/vs-agent/tests/errorEnvelopeFilter.test.ts
@@ -14,7 +14,7 @@ import { APP_GUARD } from '@nestjs/core'
 import { Test } from '@nestjs/testing'
 import { IsString } from 'class-validator'
 import request from 'supertest'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 import { AdminApiError, AdminApiErrorCode } from '../src/common/AdminApiError'
 import { BOOTSTRAP_STATE, BootstrapState } from '../src/common/BootstrapState'
@@ -105,6 +105,8 @@ class V1ServiceEndpointsFixtureController {
   }
 }
 
+const BOOTSTRAP_STEPS = ['vtjsc-service-id-migration', 'self-trust-registry', 'indexer-subscription'] as const
+
 describe('v2 error envelope', () => {
   let app: INestApplication
   const bootstrapState = new BootstrapState()
@@ -134,6 +136,11 @@ describe('v2 error envelope', () => {
 
   afterAll(async () => {
     await app?.close()
+  })
+
+  beforeEach(() => {
+    for (const step of BOOTSTRAP_STEPS) bootstrapState.complete(step)
+    bootstrapState.watchIndexer(() => 'synced')
   })
 
   it('derives the code from the status of a nest exception', async () => {
@@ -243,6 +250,32 @@ describe('v2 error envelope', () => {
         message: "bootstrap step 'self-trust-registry' has not completed",
       },
     })
+  })
+
+  it('keeps the liveness probe green while a bootstrap step is only pending', async () => {
+    bootstrapState.require('vtjsc-service-id-migration')
+
+    const response = await request(app.getHttpServer()).get('/v2/agent/health/live')
+
+    expect(response.status).toBe(HttpStatus.OK)
+    expect(response.body).toEqual({ status: 'live' })
+  })
+
+  it('fails the liveness probe once a bootstrap step is beyond recovery, so the pod can restart', async () => {
+    bootstrapState.require('vtjsc-service-id-migration')
+    bootstrapState.fail('vtjsc-service-id-migration', 'askar rejected the write')
+
+    const live = await request(app.getHttpServer()).get('/v2/agent/health/live')
+    const ready = await request(app.getHttpServer()).get('/v2/agent/health/ready')
+
+    expect(live.status).toBe(HttpStatus.SERVICE_UNAVAILABLE)
+    expect(live.body).toEqual({
+      error: {
+        code: AdminApiErrorCode.Internal,
+        message: "bootstrap step 'vtjsc-service-id-migration' failed and could not be recovered",
+      },
+    })
+    expect(ready.status).toBe(HttpStatus.SERVICE_UNAVAILABLE)
   })
 
   it('keeps secrets, tokens, accounts, DIDs and peers out of both probe bodies', async () => {

--- a/apps/vs-agent/tests/errorEnvelopeFilter.test.ts
+++ b/apps/vs-agent/tests/errorEnvelopeFilter.test.ts
@@ -17,6 +17,8 @@ import request from 'supertest'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 import { AdminApiError, AdminApiErrorCode } from '../src/common/AdminApiError'
+import { BOOTSTRAP_STATE, BootstrapState } from '../src/common/BootstrapState'
+import { V2AgentController } from '../src/controllers/admin/v2/agent/V2AgentController'
 import { ServiceEndpointExceptionFilter } from '../src/controllers/admin/service-endpoints/ServiceEndpointExceptionFilter'
 import {
   ServiceEndpointError,
@@ -105,6 +107,7 @@ class V1ServiceEndpointsFixtureController {
 
 describe('v2 error envelope', () => {
   let app: INestApplication
+  const bootstrapState = new BootstrapState()
 
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
@@ -113,11 +116,13 @@ describe('v2 error envelope', () => {
         V2ServiceEndpointsFixtureController,
         V1ConnectionsFixtureController,
         V1ServiceEndpointsFixtureController,
+        V2AgentController,
       ],
       providers: [
         AdminAuthService,
         { provide: 'VSAGENT', useValue: {} },
         { provide: 'ADMIN_ALLOWED_ACCOUNTS', useValue: [] },
+        { provide: BOOTSTRAP_STATE, useValue: bootstrapState },
         { provide: APP_GUARD, useClass: AdminAuthGuard },
       ],
     }).compile()
@@ -212,6 +217,64 @@ describe('v2 error envelope', () => {
     expect(response.body).toEqual({
       error: { code: 'DUPLICATE_ID', message: 'an entry with that id already exists' },
     })
+  })
+
+  it('serves both health probes without a token, and never answers 401 or 403', async () => {
+    bootstrapState.require('self-trust-registry')
+
+    const live = await request(app.getHttpServer()).get('/v2/agent/health/live')
+    const ready = await request(app.getHttpServer()).get('/v2/agent/health/ready')
+
+    expect(live.status).toBe(HttpStatus.OK)
+    expect(live.body).toEqual({ status: 'live' })
+    expect(ready.status).not.toBe(HttpStatus.UNAUTHORIZED)
+    expect(ready.status).not.toBe(HttpStatus.FORBIDDEN)
+  })
+
+  it('envelopes the readiness probe as NOT_READY instead of collapsing it into INTERNAL', async () => {
+    bootstrapState.require('self-trust-registry')
+
+    const response = await request(app.getHttpServer()).get('/v2/agent/health/ready')
+
+    expect(response.status).toBe(HttpStatus.SERVICE_UNAVAILABLE)
+    expect(response.body).toEqual({
+      error: {
+        code: AdminApiErrorCode.NotReady,
+        message: "bootstrap step 'self-trust-registry' has not completed",
+      },
+    })
+  })
+
+  it('keeps secrets, tokens, accounts, DIDs and peers out of both probe bodies', async () => {
+    const secrets = [
+      'did:web:agent.test',
+      'did:web:parent.test',
+      'verana1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq',
+      'super-secret-bearer-token',
+    ]
+    bootstrapState.require('self-trust-registry')
+    bootstrapState.fail('self-trust-registry', `could not publish ${secrets.join(' ')}`)
+    bootstrapState.recordEcsBootstrap('delegated', 'failed', `parent ${secrets[1]} refused ${secrets[2]}`)
+
+    const bodies = [
+      await request(app.getHttpServer()).get('/v2/agent/health/live'),
+      await request(app.getHttpServer()).get('/v2/agent/health/ready'),
+    ].map(response => JSON.stringify(response.body))
+
+    for (const body of bodies) {
+      for (const secret of secrets) expect(body).not.toContain(secret)
+    }
+  })
+
+  it('answers the readiness probe once every step completed', async () => {
+    bootstrapState.require('self-trust-registry')
+    bootstrapState.complete('self-trust-registry')
+    bootstrapState.watchIndexer(() => 'synced')
+
+    const response = await request(app.getHttpServer()).get('/v2/agent/health/ready')
+
+    expect(response.status).toBe(HttpStatus.OK)
+    expect(response.body).toEqual({ status: 'ready' })
   })
 
   it('leaves the body of a v1 method untouched', async () => {

--- a/charts/vs-agent/templates/deployment.yaml
+++ b/charts/vs-agent/templates/deployment.yaml
@@ -218,39 +218,28 @@ spec:
             resources:
 {{- toYaml .Values.resources | nindent 14 }}
             {{- end }}
-            {{- if contains "internal" (.Values.adminApiAuthMode | default "internal") }}
+            {{- $probePort := ternary .Values.adminPort (.Values.adminApiExternalPort | default 3010) (contains "internal" (.Values.adminApiAuthMode | default "internal")) }}
+            startupProbe:
+              httpGet:
+                path: /v2/agent/health/live
+                port: {{ $probePort }}
+              periodSeconds: 10
+              timeoutSeconds: 5
+              failureThreshold: 60
             livenessProbe:
               httpGet:
-                path: /v1/health
-                port: {{ .Values.adminPort }}
-              initialDelaySeconds: 30
+                path: /v2/agent/health/live
+                port: {{ $probePort }}
               periodSeconds: 60
               timeoutSeconds: 5
               failureThreshold: 2
             readinessProbe:
               httpGet:
-                path: /v1/health
-                port: {{ .Values.adminPort }}
-              initialDelaySeconds: 15
-              periodSeconds: 60
+                path: /v2/agent/health/ready
+                port: {{ $probePort }}
+              periodSeconds: 15
               timeoutSeconds: 5
               failureThreshold: 2
-            {{- else }}
-            livenessProbe:
-              tcpSocket:
-                port: {{ .Values.adminApiExternalPort | default 3010 }}
-              initialDelaySeconds: 30
-              periodSeconds: 60
-              timeoutSeconds: 5
-              failureThreshold: 2
-            readinessProbe:
-              tcpSocket:
-                port: {{ .Values.adminApiExternalPort | default 3010 }}
-              initialDelaySeconds: 15
-              periodSeconds: 60
-              timeoutSeconds: 5
-              failureThreshold: 2
-            {{- end }}
             volumeMounts:
             - name: {{ .Values.name }}-vsa-pv
               mountPath: /root/.afj

--- a/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
+++ b/packages/agent-sdk/src/blockchain/IndexerWebSocketService.ts
@@ -34,6 +34,9 @@ const REST_PAGE_LIMIT = 500
 const MAX_SYNC_BUFFER = 10_000
 const SUBSCRIBE_TIMEOUT_MS = 5_000
 type SubscribeOutcome = 'acknowledged' | 'timed-out' | 'disconnected'
+type ConnectionPhase = 'connecting' | 'catching-up' | 'synced'
+
+export type IndexerSyncStatus = 'never-synced' | 'catching-up' | 'disconnected' | 'synced'
 const delay = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms))
 // The indexer pings every 30 seconds, so a longer gap means the socket is dead.
 const LIVENESS_TIMEOUT_MS = 90_000
@@ -45,6 +48,8 @@ export class IndexerWebSocketService {
   private watchdog: ReturnType<typeof setTimeout> | null = null
   private stopped = false
   private syncing = false
+  private phase: ConnectionPhase = 'connecting'
+  private everSynced = false
   private generation = 0
   private chain: Promise<void> = Promise.resolve()
   private syncBuffer: IndexerEventRecord[] = []
@@ -63,6 +68,12 @@ export class IndexerWebSocketService {
   async start(): Promise<void> {
     this.stopped = false
     await this.connect()
+  }
+
+  get syncStatus(): IndexerSyncStatus {
+    if (this.phase === 'catching-up') return 'catching-up'
+    if (this.phase === 'synced') return 'synced'
+    return this.everSynced ? 'disconnected' : 'never-synced'
   }
 
   stop(): void {
@@ -84,6 +95,7 @@ export class IndexerWebSocketService {
     if (this.stopped) return
     const generation = ++this.generation
     this.syncing = true
+    this.phase = 'connecting'
     this.syncBuffer = []
 
     const subscribed = new Promise<SubscribeOutcome>(resolve => {
@@ -102,6 +114,8 @@ export class IndexerWebSocketService {
       )
     }
 
+    this.phase = 'catching-up'
+
     try {
       await this.syncRest(generation)
     } catch (error) {
@@ -112,6 +126,8 @@ export class IndexerWebSocketService {
 
     if (this.stopped || generation !== this.generation) return
     this.syncing = false
+    this.phase = 'synced'
+    this.everSynced = true
     this.drainSyncBuffer(generation)
   }
 
@@ -147,6 +163,7 @@ export class IndexerWebSocketService {
     ws.on('close', () => {
       if (ws !== this.ws) return
       this.clearWatchdog()
+      this.phase = 'connecting'
       if (!this.stopped) this.scheduleReconnect()
     })
 
@@ -368,6 +385,7 @@ export class IndexerWebSocketService {
   private forceReconnect(reason: string): void {
     if (this.stopped) return
     this.logger.warn(`[IndexerWS] Forcing reconnect: ${reason}`)
+    this.phase = 'connecting'
     this.generation++ // stops queued work so it cannot move the height past the failed event
     this.clearWatchdog()
     const ws = this.ws

--- a/packages/agent-sdk/tests/IndexerWebSocketService.test.ts
+++ b/packages/agent-sdk/tests/IndexerWebSocketService.test.ts
@@ -127,6 +127,9 @@ const readyFrame = (): Buffer =>
 const blockFrame = (block: number, events: IndexerEventRecord[]): Buffer =>
   Buffer.from(JSON.stringify({ type: 'block', block, blockTime: '', events }))
 
+const lastWs = (): InstanceType<typeof FakeWebSocket> =>
+  FakeWebSocket.instances.at(-1) as InstanceType<typeof FakeWebSocket>
+
 describe('IndexerWebSocketService', () => {
   let agent: VsAgent
   let registry: IndexerHandlerRegistry
@@ -157,8 +160,6 @@ describe('IndexerWebSocketService', () => {
     FakeWebSocket.instances.at(-1)?.emit('message', readyFrame())
     return started
   }
-
-  const lastWs = (): InstanceType<typeof FakeWebSocket> => FakeWebSocket.instances.at(-1)!
 
   it('sends a DID-scoped subscribe when the indexer is ready', async () => {
     await startWith(async () => undefined)
@@ -469,5 +470,96 @@ describe('IndexerWebSocketService', () => {
     session2.stop()
 
     expect(dispatched).toEqual(['A'])
+  })
+
+  describe('syncStatus', () => {
+    const makeService = (): IndexerWebSocketService =>
+      new IndexerWebSocketService({ indexerUrl: 'http://indexer.test', agent, handlerRegistry: registry })
+
+    it('reports never-synced until the first catch-up completes, then synced', async () => {
+      service = makeService()
+      const started = service.start()
+
+      expect(service.syncStatus).toBe('never-synced')
+
+      lastWs().emit('message', readyFrame())
+      await started
+
+      expect(service.syncStatus).toBe('synced')
+    })
+
+    it('stays never-synced when the socket closes before the acknowledgement', async () => {
+      FakeWebSocket.autoAcknowledgeSubscribe = false
+      vi.useFakeTimers()
+      service = makeService()
+      const started = service.start()
+      lastWs().emit('message', readyFrame())
+      lastWs().close()
+      await started
+
+      expect(service.syncStatus).toBe('never-synced')
+    })
+
+    it('reports catching-up while the REST catch-up is running', async () => {
+      let releaseCatchUp: () => void = () => undefined
+      fetchJsonMock.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            releaseCatchUp = () => resolve({ events: [], count: 0, after_block_height: 0 })
+          }),
+      )
+      service = makeService()
+      const started = service.start()
+      lastWs().emit('message', readyFrame())
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(service.syncStatus).toBe('catching-up')
+
+      releaseCatchUp()
+      await started
+
+      expect(service.syncStatus).toBe('synced')
+    })
+
+    it('reports disconnected, not catching-up, when the socket drops after a successful sync', async () => {
+      service = makeService()
+      const started = service.start()
+      lastWs().emit('message', readyFrame())
+      await started
+      expect(service.syncStatus).toBe('synced')
+
+      lastWs().close()
+
+      expect(service.syncStatus).toBe('disconnected')
+    })
+    it('goes through catching-up again after a reconnection, then back to synced', async () => {
+      vi.useFakeTimers()
+      service = makeService()
+      const started = service.start()
+      lastWs().emit('message', readyFrame())
+      await started
+      expect(service.syncStatus).toBe('synced')
+
+      lastWs().close()
+      expect(service.syncStatus).toBe('disconnected')
+
+      let releaseCatchUp: () => void = () => undefined
+      fetchJsonMock.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            releaseCatchUp = () => resolve({ events: [], count: 0, after_block_height: 0 })
+          }),
+      )
+      await vi.advanceTimersByTimeAsync(1_000)
+      lastWs().emit('message', readyFrame())
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(service.syncStatus).toBe('catching-up')
+
+      releaseCatchUp()
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(service.syncStatus).toBe('synced')
+    })
   })
 })


### PR DESCRIPTION
**Changes**
- Add GET /v2/agent/health/live and /v2/agent/health/ready, both public so neither can answer 401 or 403.
- New BootstrapState gating readiness on the agent's own bootstrap steps and on the indexer catch-up, with the ECS bootstrap recorded but not gating.
- Expose syncStatus on IndexerWebSocketService; an unreachable indexer keeps the agent ready, a catch-up does not.
- Add the NOT_READY code so the v2 error envelope preserves it, and log an envelope only when its code is INTERNAL.
- Chart: startupProbe/livenessProbe on live, readinessProbe on ready.