### PR TITLE
feat(vt-flow): support onboarding without credential offer

### DIFF
--- a/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsService.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsService.ts
@@ -18,7 +18,7 @@ import {
   VtFlowVariant,
   isVtFlowTerminalState,
 } from '@verana-labs/credo-ts-didcomm-vt-flow'
-import { VeranaIndexerService, VtFlowOrchestrator } from '@verana-labs/vs-agent-sdk'
+import { HOLDER_PARTICIPANT_TYPE, VeranaIndexerService, VtFlowOrchestrator } from '@verana-labs/vs-agent-sdk'
 
 import { ADMIN_LOG_LEVEL, VERANA_INDEXER_BASE_URL } from '../../../config'
 import { VsAgentService } from '../../../services/VsAgentService'
@@ -161,20 +161,32 @@ export class VtFlowsService {
     }
     if (!record.participantId) throw new BadRequestException('Record has no participantId')
 
-    const holderParticipant = await this.getIndexer().getParticipant(Number(record.participantId))
-    if (!holderParticipant)
-      throw new BadRequestException(`Holder participant ${record.participantId} not found on indexer`)
-    if (holderParticipant.schema_id == null)
-      throw new BadRequestException('Holder participant has no schema_id')
+    const applicant = await this.getIndexer().getParticipant(Number(record.participantId))
+    if (!applicant)
+      throw new BadRequestException(`Applicant participant ${record.participantId} not found on indexer`)
+    if (applicant.schema_id == null) throw new BadRequestException('Applicant participant has no schema_id')
 
     const orchestrator = new VtFlowOrchestrator(agent, {
       publicApiBaseUrl: agent.publicApiBaseUrl,
       indexer: this.getIndexer(),
     })
     try {
-      const offered = await orchestrator.validateAndOfferCredential({
+      const { record: validated, participant } = await orchestrator.validateOnboardingProcess({
         vtFlowRecordId: record.id,
-        credentialSchemaId: String(holderParticipant.schema_id),
+      })
+
+      // Only a HOLDER receives a credential. For every other role the chain records the outcome
+      // with SetParticipantOPToValidated, and the process ends there. The schema of an ISSUER
+      // entry describes what that issuer will give to others, so building a credential from it
+      // for the issuer itself fails on the required subject claims.
+      if (participant.role !== HOLDER_PARTICIPANT_TYPE) {
+        return toDto(await orchestrator.completeOnboardingProcess(validated.id))
+      }
+
+      const offered = await orchestrator.offerOnboardingCredential({
+        vtFlowRecordId: validated.id,
+        credentialSchemaId: String(applicant.schema_id),
+        participant,
       })
       return toDto(offered)
     } catch (error) {

--- a/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsService.ts
+++ b/apps/vs-agent/src/controllers/admin/vt-flow/VtFlowsService.ts
@@ -156,8 +156,14 @@ export class VtFlowsService {
         `This record is variant '${record.variant}'; validate only applies to OnboardingProcess`,
       )
     }
-    if (record.state !== VtFlowState.AwaitingOr) {
-      throw new BadRequestException(`Record state is '${record.state}', expected '${VtFlowState.AwaitingOr}'`)
+    // A repeat call re-drives the offer of a record that reached VALIDATED and has no credential
+    // exchange. It recovers a credential build or an offer that failed after the chain write.
+    const resumeOffer = record.state === VtFlowState.Validated && !record.credentialExchangeRecordId
+    if (record.state !== VtFlowState.AwaitingOr && !resumeOffer) {
+      throw new BadRequestException(
+        `Record state is '${record.state}'; validate applies to '${VtFlowState.AwaitingOr}', or to ` +
+          `'${VtFlowState.Validated}' with no credential exchange`,
+      )
     }
     if (!record.participantId) throw new BadRequestException('Record has no participantId')
 
@@ -171,8 +177,13 @@ export class VtFlowsService {
       indexer: this.getIndexer(),
     })
     try {
-      const { record: validated, participant } = await orchestrator.validateOnboardingProcess({
+      const {
+        record: validated,
+        participant,
+        credential,
+      } = await orchestrator.validateOnboardingProcess({
         vtFlowRecordId: record.id,
+        credentialSchemaId: String(applicant.schema_id),
       })
 
       // Only a HOLDER receives a credential. For every other role the chain records the outcome
@@ -187,6 +198,7 @@ export class VtFlowsService {
         vtFlowRecordId: validated.id,
         credentialSchemaId: String(applicant.schema_id),
         participant,
+        credential,
       })
       return toDto(offered)
     } catch (error) {

--- a/apps/vs-agent/tests/e2e/fullLifecycle.e2e.test.ts
+++ b/apps/vs-agent/tests/e2e/fullLifecycle.e2e.test.ts
@@ -301,14 +301,20 @@ describe('v4 full lifecycle on a live chain and indexer', () => {
         indexer,
         publicApiBaseUrl: validator.publicApiBaseUrl,
       })
-      // This applicant is a HOLDER, so the validation is followed by a credential offer.
-      const { record: validatedRecord, participant } = await orchestrator.validateOnboardingProcess({
+      // This applicant is a HOLDER, so the validation builds the credential and the offer sends it.
+      const {
+        record: validatedRecord,
+        participant,
+        credential,
+      } = await orchestrator.validateOnboardingProcess({
         vtFlowRecordId: validatorFlow.id,
+        credentialSchemaId: String(orgSchemaId),
       })
       const validated = await orchestrator.offerOnboardingCredential({
         vtFlowRecordId: validatedRecord.id,
         credentialSchemaId: String(orgSchemaId),
         participant,
+        credential,
       })
       expect(validated.state).toBe(VtFlowState.CredOffered)
       await applicantCompleted

--- a/apps/vs-agent/tests/e2e/fullLifecycle.e2e.test.ts
+++ b/apps/vs-agent/tests/e2e/fullLifecycle.e2e.test.ts
@@ -297,12 +297,18 @@ describe('v4 full lifecycle on a live chain and indexer', () => {
         isVtFlowStateChangedEvent(VtFlowState.Completed),
       )
       const validatorFlow = (await flowsService.listFlows({ role: VtFlowRole.Validator }))[0]
-      const validated = await new VtFlowOrchestrator(validator, {
+      const orchestrator = new VtFlowOrchestrator(validator, {
         indexer,
         publicApiBaseUrl: validator.publicApiBaseUrl,
-      }).validateAndOfferCredential({
+      })
+      // This applicant is a HOLDER, so the validation is followed by a credential offer.
+      const { record: validatedRecord, participant } = await orchestrator.validateOnboardingProcess({
         vtFlowRecordId: validatorFlow.id,
+      })
+      const validated = await orchestrator.offerOnboardingCredential({
+        vtFlowRecordId: validatedRecord.id,
         credentialSchemaId: String(orgSchemaId),
+        participant,
       })
       expect(validated.state).toBe(VtFlowState.CredOffered)
       await applicantCompleted

--- a/packages/agent-sdk/src/blockchain/handlers/defaultHandlers.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/defaultHandlers.ts
@@ -1,5 +1,6 @@
 import { IndexerEventHandler, IndexerHandlerRegistry } from './IndexerHandlerRegistry'
 import {
+  completeVtFlowRecordsWithoutCredential,
   markVtFlowRecordsValidated,
   publishVtjscIfOwner,
   removeHolderTrustCredentialIfRevoked,
@@ -98,6 +99,8 @@ export const defaultHandlers: IndexerEventHandler[] = [
         `[IndexerWS] SetParticipantOPToValidated participant=${activity.entity_id} block=${ctx.blockHeight}`,
       )
       await markVtFlowRecordsValidated(ctx.agent, String(activity.entity_id))
+      // An onboarding process that carries no credential exchange ends here for both sides.
+      await completeVtFlowRecordsWithoutCredential(ctx.agent, String(activity.entity_id))
     },
   },
   {

--- a/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
+++ b/packages/agent-sdk/src/blockchain/handlers/stateMutations.ts
@@ -11,6 +11,7 @@ import {
 import { identifySchema } from '@verana-labs/vs-agent-model'
 
 import { VsAgent } from '../../agent/VsAgent'
+import { HOLDER_PARTICIPANT_TYPE } from '../../types'
 import { getEcsSchemas } from '../../utils/data'
 import { waitUntilOwnDidIsPubliclyResolvable } from '../../utils/didReadiness'
 import { SelfTrDefaults, generateDigestSRI } from '../../utils/setupSelfTr'
@@ -209,6 +210,33 @@ export async function markVtFlowRecordsValidated(agent: VsAgent, participantId: 
       return 'VALIDATED'
     },
     'Failed to markValidated',
+  )
+}
+
+/**
+ * Close the onboarding records of a participant that receives no credential.
+ *
+ * Only a HOLDER takes part in a credential exchange, and the exchange is what moves a record to
+ * COMPLETED. An ISSUER, a VERIFIER or a grantor is finished the moment the chain records
+ * SetParticipantOPToValidated, so without this both sides would sit at OR_SENT and VALIDATED for
+ * ever. The applicant reaches its own record here, because it watches the same chain event.
+ */
+export async function completeVtFlowRecordsWithoutCredential(
+  agent: VsAgent,
+  participantId: string,
+): Promise<void> {
+  const participant = await agent.veranaChain?.getParticipant(Number(participantId))
+  if (!participant || participant.role === HOLDER_PARTICIPANT_TYPE) return
+
+  await reconcileVtFlowRecordsForParticipant(
+    agent,
+    participantId,
+    async (record, service, agentContext) => {
+      if (record.state === VtFlowState.Completed || isVtFlowTerminalState(record.state)) return null
+      await service.markCompleted(agentContext, record.id)
+      return 'COMPLETED'
+    },
+    'Failed to mark COMPLETED',
   )
 }
 

--- a/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
+++ b/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
@@ -50,11 +50,18 @@ export interface StartOnboardingProcessInput {
 
 export interface ValidateOnboardingProcessInput {
   vtFlowRecordId: string
+  /** Only for a HOLDER. It defaults to the schema of the applicant participant. */
+  credentialSchemaId?: string
+  credentialType?: string[]
+  credentialContext?: string[]
 }
 
 export interface OfferOnboardingCredentialInput {
   vtFlowRecordId: string
-  credentialSchemaId: string
+  /** The credential validateOnboardingProcess built. Without it the method builds one. */
+  credential?: JsonCredential
+  /** It defaults to the schema of the applicant participant. */
+  credentialSchemaId?: string
   /** The participant validateOnboardingProcess returned; saves a second chain read. */
   participant?: Participant
   credentialType?: string[]
@@ -145,13 +152,20 @@ export class VtFlowOrchestrator {
 
   /**
    * Validate an onboarding process: record the outcome on-chain, accept the onboarding request and
-   * move the record to VALIDATED. It offers no credential. Only a HOLDER takes part in a credential
+   * move the record to VALIDATED. It sends no credential. Only a HOLDER takes part in a credential
    * exchange; an ISSUER, a VERIFIER or a grantor joins the Ecosystem, and SetParticipantOPToValidated
    * is the whole of it. The caller decides what follows, from the role of the returned participant.
+   *
+   * For a HOLDER it builds the credential before the chain write, and returns it for
+   * offerOnboardingCredential. Claims that do not satisfy the schema, or a schema fetch that fails,
+   * must stop the process while the chain holds no outcome yet and the caller can repeat the call.
+   *
+   * A record that is already VALIDATED and has no credential exchange keeps the chain outcome and
+   * only builds the credential again. A repeat call thus re-drives an offer that did not complete.
    */
   async validateOnboardingProcess(
     input: ValidateOnboardingProcessInput,
-  ): Promise<{ record: VtFlowRecord; participant: Participant }> {
+  ): Promise<{ record: VtFlowRecord; participant: Participant; credential?: JsonCredential }> {
     const chain = this.requireChain()
     if (!this.agent.did) throw new Error('Agent has no public DID')
 
@@ -162,8 +176,12 @@ export class VtFlowOrchestrator {
     if (record.variant !== VtFlowVariant.OnboardingProcess) {
       throw new Error(`Record variant is '${record.variant}', expected OnboardingProcess`)
     }
-    if (record.state !== VtFlowState.AwaitingOr) {
-      throw new Error(`Record state is '${record.state}', expected '${VtFlowState.AwaitingOr}'`)
+    const resumeOffer = record.state === VtFlowState.Validated && !record.credentialExchangeRecordId
+    if (record.state !== VtFlowState.AwaitingOr && !resumeOffer) {
+      throw new Error(
+        `Record state is '${record.state}', expected '${VtFlowState.AwaitingOr}', or ` +
+          `'${VtFlowState.Validated}' with no credential exchange`,
+      )
     }
     if (!record.participantId) throw new Error('Record has no participantId')
 
@@ -172,17 +190,31 @@ export class VtFlowOrchestrator {
     if (!participant) throw new Error(`Applicant participant ${participantId} not found on chain`)
     if (!participant.did) throw new Error('Applicant participant has no DID')
 
+    const credential =
+      Number(participant.role) === HOLDER_PARTICIPANT_TYPE
+        ? await this.buildCredential({
+            credentialSchemaId: input.credentialSchemaId ?? String(participant.schemaId),
+            subjectDid: participant.did,
+            claims: (record.claims ?? {}) as JsonObject,
+            credentialType: input.credentialType,
+            credentialContext: input.credentialContext,
+          })
+        : undefined
+
+    if (resumeOffer) return { record, participant, credential }
+
     // op_summary_digest (MOD-PP-MSG-3) digests the applicant's submission, not the credential
     await chain.setParticipantOPToValidated({ id: participantId, corporation: participant.corporation })
 
     await vtFlowApi.acceptOnboardingRequest(record.id)
     const validated = await vtFlowApi.markValidated(record.id)
-    return { record: validated, participant }
+    return { record: validated, participant, credential }
   }
 
   /**
    * Offer the credential of an onboarding process to its applicant. Call it only for a HOLDER, and
-   * only after validateOnboardingProcess has moved the record to VALIDATED.
+   * only after validateOnboardingProcess has moved the record to VALIDATED. Give it the credential
+   * that validateOnboardingProcess built, so that the process does not build the credential twice.
    */
   async offerOnboardingCredential(input: OfferOnboardingCredentialInput): Promise<VtFlowRecord> {
     const chain = this.requireChain()
@@ -194,13 +226,15 @@ export class VtFlowOrchestrator {
     const participant = input.participant ?? (await chain.getParticipant(Number(record.participantId)))
     if (!participant?.did) throw new Error('Applicant participant has no DID')
 
-    const unsignedCredentialJson = await this.buildCredential({
-      credentialSchemaId: input.credentialSchemaId,
-      subjectDid: participant.did,
-      claims: (record.claims ?? {}) as JsonObject,
-      credentialType: input.credentialType,
-      credentialContext: input.credentialContext,
-    })
+    const unsignedCredentialJson =
+      input.credential ??
+      (await this.buildCredential({
+        credentialSchemaId: input.credentialSchemaId ?? String(participant.schemaId),
+        subjectDid: participant.did,
+        claims: (record.claims ?? {}) as JsonObject,
+        credentialType: input.credentialType,
+        credentialContext: input.credentialContext,
+      }))
 
     const { record: offered } = await vtFlowApi.offerCredentialForSession({
       vtFlowRecordId: record.id,

--- a/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
+++ b/packages/agent-sdk/src/vtFlow/VtFlowOrchestrator.ts
@@ -18,7 +18,7 @@ import { computeCredentialDigestJCS } from '@verana-labs/verre'
 
 import { BaseAgentModules, VsAgent } from '../agent'
 import { VeranaIndexerService } from '../blockchain/VeranaIndexerService'
-import { ParticipantRole, ParticipantState } from '../blockchain/types'
+import { Participant, ParticipantRole, ParticipantState } from '../blockchain/types'
 import {
   HOLDER_PARTICIPANT_TYPE,
   ISSUER_GRANTOR_PARTICIPANT_TYPE,
@@ -48,13 +48,17 @@ export interface StartOnboardingProcessInput {
   claims?: Record<string, unknown>
 }
 
-export interface ValidateAndOfferCredentialInput {
+export interface ValidateOnboardingProcessInput {
   vtFlowRecordId: string
+}
+
+export interface OfferOnboardingCredentialInput {
+  vtFlowRecordId: string
+  credentialSchemaId: string
+  /** The participant validateOnboardingProcess returned; saves a second chain read. */
+  participant?: Participant
   credentialType?: string[]
   credentialContext?: string[]
-  credentialSchemaId: string
-  agentParticipantId?: number
-  walletAgentParticipantId?: number
 }
 
 export interface AcceptCredentialInput {
@@ -139,7 +143,15 @@ export class VtFlowOrchestrator {
     })
   }
 
-  async validateAndOfferCredential(input: ValidateAndOfferCredentialInput): Promise<VtFlowRecord> {
+  /**
+   * Validate an onboarding process: record the outcome on-chain, accept the onboarding request and
+   * move the record to VALIDATED. It offers no credential. Only a HOLDER takes part in a credential
+   * exchange; an ISSUER, a VERIFIER or a grantor joins the Ecosystem, and SetParticipantOPToValidated
+   * is the whole of it. The caller decides what follows, from the role of the returned participant.
+   */
+  async validateOnboardingProcess(
+    input: ValidateOnboardingProcessInput,
+  ): Promise<{ record: VtFlowRecord; participant: Participant }> {
     const chain = this.requireChain()
     if (!this.agent.did) throw new Error('Agent has no public DID')
 
@@ -155,31 +167,44 @@ export class VtFlowOrchestrator {
     }
     if (!record.participantId) throw new Error('Record has no participantId')
 
-    const holderParticipantId = Number(record.participantId)
-    const holderParticipant = await chain.getParticipant(holderParticipantId)
-    if (!holderParticipant) throw new Error(`Holder participant ${holderParticipantId} not found on chain`)
-    if (!holderParticipant.did) throw new Error('Holder participant has no DID')
+    const participantId = Number(record.participantId)
+    const participant = await chain.getParticipant(participantId)
+    if (!participant) throw new Error(`Applicant participant ${participantId} not found on chain`)
+    if (!participant.did) throw new Error('Applicant participant has no DID')
+
+    // op_summary_digest (MOD-PP-MSG-3) digests the applicant's submission, not the credential
+    await chain.setParticipantOPToValidated({ id: participantId, corporation: participant.corporation })
+
+    await vtFlowApi.acceptOnboardingRequest(record.id)
+    const validated = await vtFlowApi.markValidated(record.id)
+    return { record: validated, participant }
+  }
+
+  /**
+   * Offer the credential of an onboarding process to its applicant. Call it only for a HOLDER, and
+   * only after validateOnboardingProcess has moved the record to VALIDATED.
+   */
+  async offerOnboardingCredential(input: OfferOnboardingCredentialInput): Promise<VtFlowRecord> {
+    const chain = this.requireChain()
+    const vtFlowApi = this.resolveVtFlowApi()
+    const record = await vtFlowApi.findById(input.vtFlowRecordId)
+    if (!record) throw new Error(`vt-flow record ${input.vtFlowRecordId} not found`)
+    if (!record.participantId) throw new Error('Record has no participantId')
+
+    const participant = input.participant ?? (await chain.getParticipant(Number(record.participantId)))
+    if (!participant?.did) throw new Error('Applicant participant has no DID')
 
     const unsignedCredentialJson = await this.buildCredential({
       credentialSchemaId: input.credentialSchemaId,
-      subjectDid: holderParticipant.did,
+      subjectDid: participant.did,
       claims: (record.claims ?? {}) as JsonObject,
       credentialType: input.credentialType,
       credentialContext: input.credentialContext,
     })
 
-    // op_summary_digest (MOD-PP-MSG-3) digests the applicant's submission, not the credential
-    await chain.setParticipantOPToValidated({
-      id: holderParticipantId,
-      corporation: holderParticipant.corporation,
-    })
-
-    await vtFlowApi.acceptOnboardingRequest(record.id)
-    await vtFlowApi.markValidated(record.id)
-
     const { record: offered } = await vtFlowApi.offerCredentialForSession({
       vtFlowRecordId: record.id,
-      issuerParticipantId: Number(holderParticipant.validatorParticipantId),
+      issuerParticipantId: Number(participant.validatorParticipantId),
       credentialFormats: {
         jsonld: {
           credential: unsignedCredentialJson,
@@ -188,6 +213,14 @@ export class VtFlowOrchestrator {
       },
     })
     return offered
+  }
+
+  /**
+   * Close an onboarding process that carries no credential exchange, on the validator side. The
+   * applicant reaches the same state from the SetParticipantOPToValidated chain event.
+   */
+  async completeOnboardingProcess(vtFlowRecordId: string): Promise<VtFlowRecord> {
+    return this.resolveVtFlowApi().markCompleted(vtFlowRecordId)
   }
 
   async acceptCredential(input: AcceptCredentialInput): Promise<VtFlowRecord> {

--- a/packages/agent-sdk/tests/VtFlowOrchestrator.test.ts
+++ b/packages/agent-sdk/tests/VtFlowOrchestrator.test.ts
@@ -157,3 +157,99 @@ describe('VtFlowOrchestrator.startOnboardingProcess renewal/reconnection', () =>
     expect(agent.didcomm.oob.receiveImplicitInvitation).not.toHaveBeenCalled()
   })
 })
+
+describe('VtFlowOrchestrator onboarding validation', () => {
+  const validatorRecord = {
+    id: 'rec-v',
+    role: VtFlowRole.Validator,
+    variant: 'onboarding-process',
+    state: 'AWAITING_OR',
+    participantId: '94',
+    claims: {},
+  }
+
+  function makeAgent(role: number) {
+    const vtFlowApi = {
+      findById: vi.fn(async () => validatorRecord),
+      acceptOnboardingRequest: vi.fn(async () => validatorRecord),
+      markValidated: vi.fn(async () => ({ ...validatorRecord, state: 'VALIDATED' })),
+      markCompleted: vi.fn(async () => ({ ...validatorRecord, state: 'COMPLETED' })),
+      offerCredentialForSession: vi.fn(async () => ({
+        record: { ...validatorRecord, state: 'CRED_OFFERED' },
+      })),
+    }
+    const agent = {
+      did: 'did:web:validator',
+      config: { logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+      dependencyManager: { resolve: () => vtFlowApi },
+      veranaChain: {
+        getParticipant: vi.fn(async () => ({
+          id: 94,
+          role,
+          did: 'did:web:applicant',
+          corporation: 'verana1corp',
+          validatorParticipantId: 93,
+        })),
+        setParticipantOPToValidated: vi.fn(async () => undefined),
+      },
+    }
+    return { agent, vtFlowApi }
+  }
+
+  it('validateOnboardingProcess records the outcome on-chain and offers no credential', async () => {
+    const { agent, vtFlowApi } = makeAgent(1) // ISSUER
+
+    const { record, participant } = await new VtFlowOrchestrator(agent as never).validateOnboardingProcess({
+      vtFlowRecordId: 'rec-v',
+    })
+
+    expect(agent.veranaChain.setParticipantOPToValidated).toHaveBeenCalledWith({
+      id: 94,
+      corporation: 'verana1corp',
+    })
+    expect(vtFlowApi.acceptOnboardingRequest).toHaveBeenCalledWith('rec-v')
+    expect(vtFlowApi.markValidated).toHaveBeenCalledWith('rec-v')
+    expect(vtFlowApi.offerCredentialForSession).not.toHaveBeenCalled()
+    expect(record.state).toBe('VALIDATED')
+    // The caller decides what follows from the role.
+    expect(participant.role).toBe(1)
+  })
+
+  it('validateOnboardingProcess reports the HOLDER role so the caller can offer a credential', async () => {
+    const { agent } = makeAgent(6) // HOLDER
+
+    const { participant } = await new VtFlowOrchestrator(agent as never).validateOnboardingProcess({
+      vtFlowRecordId: 'rec-v',
+    })
+
+    expect(participant.role).toBe(6)
+  })
+
+  it('offerOnboardingCredential offers against the validator participant', async () => {
+    const { agent, vtFlowApi } = makeAgent(6) // HOLDER
+    const orchestrator = new VtFlowOrchestrator(agent as never)
+    // buildCredential needs an indexer and a schema; assert the wiring, not the credential body.
+    ;(orchestrator as unknown as { buildCredential: unknown }).buildCredential = vi.fn(async () => ({
+      id: 'urn:cred',
+    }))
+
+    const offered = await orchestrator.offerOnboardingCredential({
+      vtFlowRecordId: 'rec-v',
+      credentialSchemaId: '22',
+    })
+
+    expect(vtFlowApi.offerCredentialForSession).toHaveBeenCalledWith(
+      expect.objectContaining({ vtFlowRecordId: 'rec-v', issuerParticipantId: 93 }),
+    )
+    expect(offered.state).toBe('CRED_OFFERED')
+  })
+
+  it('completeOnboardingProcess closes a flow that carries no credential', async () => {
+    const { agent, vtFlowApi } = makeAgent(1) // ISSUER
+
+    const completed = await new VtFlowOrchestrator(agent as never).completeOnboardingProcess('rec-v')
+
+    expect(vtFlowApi.markCompleted).toHaveBeenCalledWith('rec-v')
+    expect(completed.state).toBe('COMPLETED')
+  })
+})

--- a/packages/agent-sdk/tests/VtFlowOrchestrator.test.ts
+++ b/packages/agent-sdk/tests/VtFlowOrchestrator.test.ts
@@ -168,14 +168,15 @@ describe('VtFlowOrchestrator onboarding validation', () => {
     claims: {},
   }
 
-  function makeAgent(role: number) {
+  function makeAgent(role: number, recordOverrides: Record<string, unknown> = {}) {
+    const flowRecord = { ...validatorRecord, ...recordOverrides }
     const vtFlowApi = {
-      findById: vi.fn(async () => validatorRecord),
-      acceptOnboardingRequest: vi.fn(async () => validatorRecord),
-      markValidated: vi.fn(async () => ({ ...validatorRecord, state: 'VALIDATED' })),
-      markCompleted: vi.fn(async () => ({ ...validatorRecord, state: 'COMPLETED' })),
+      findById: vi.fn(async () => flowRecord),
+      acceptOnboardingRequest: vi.fn(async () => flowRecord),
+      markValidated: vi.fn(async () => ({ ...flowRecord, state: 'VALIDATED' })),
+      markCompleted: vi.fn(async () => ({ ...flowRecord, state: 'COMPLETED' })),
       offerCredentialForSession: vi.fn(async () => ({
-        record: { ...validatorRecord, state: 'CRED_OFFERED' },
+        record: { ...flowRecord, state: 'CRED_OFFERED' },
       })),
     }
     const agent = {
@@ -186,6 +187,7 @@ describe('VtFlowOrchestrator onboarding validation', () => {
         getParticipant: vi.fn(async () => ({
           id: 94,
           role,
+          schemaId: 22,
           did: 'did:web:applicant',
           corporation: 'verana1corp',
           validatorParticipantId: 93,
@@ -194,6 +196,16 @@ describe('VtFlowOrchestrator onboarding validation', () => {
       },
     }
     return { agent, vtFlowApi }
+  }
+
+  /** buildCredential needs an indexer and a schema; assert the wiring, not the credential body. */
+  function stubBuildCredential(
+    orchestrator: VtFlowOrchestrator,
+    build: () => Promise<unknown> = async () => ({ id: 'urn:cred' }),
+  ) {
+    const spy = vi.fn(build)
+    ;(orchestrator as unknown as { buildCredential: unknown }).buildCredential = spy
+    return spy
   }
 
   it('validateOnboardingProcess records the outcome on-chain and offers no credential', async () => {
@@ -217,21 +229,80 @@ describe('VtFlowOrchestrator onboarding validation', () => {
 
   it('validateOnboardingProcess reports the HOLDER role so the caller can offer a credential', async () => {
     const { agent } = makeAgent(6) // HOLDER
+    const orchestrator = new VtFlowOrchestrator(agent as never)
+    stubBuildCredential(orchestrator)
 
-    const { participant } = await new VtFlowOrchestrator(agent as never).validateOnboardingProcess({
+    const { participant, credential } = await orchestrator.validateOnboardingProcess({
       vtFlowRecordId: 'rec-v',
     })
 
     expect(participant.role).toBe(6)
+    expect(credential).toEqual({ id: 'urn:cred' })
+  })
+
+  it('validateOnboardingProcess builds the HOLDER credential before it writes to the chain', async () => {
+    const { agent } = makeAgent(6) // HOLDER
+    const orchestrator = new VtFlowOrchestrator(agent as never)
+    const order: string[] = []
+    stubBuildCredential(orchestrator, async () => {
+      order.push('build')
+      return { id: 'urn:cred' }
+    })
+    agent.veranaChain.setParticipantOPToValidated = vi.fn(async () => {
+      order.push('chain')
+      return undefined
+    })
+
+    await orchestrator.validateOnboardingProcess({ vtFlowRecordId: 'rec-v' })
+
+    expect(order).toEqual(['build', 'chain'])
+  })
+
+  it('validateOnboardingProcess leaves the flow repeatable when the HOLDER credential fails', async () => {
+    const { agent, vtFlowApi } = makeAgent(6) // HOLDER
+    const orchestrator = new VtFlowOrchestrator(agent as never)
+    stubBuildCredential(orchestrator, async () => {
+      throw new Error('claims do not satisfy the schema')
+    })
+
+    await expect(orchestrator.validateOnboardingProcess({ vtFlowRecordId: 'rec-v' })).rejects.toThrow(
+      /claims do not satisfy the schema/,
+    )
+    expect(agent.veranaChain.setParticipantOPToValidated).not.toHaveBeenCalled()
+    expect(vtFlowApi.acceptOnboardingRequest).not.toHaveBeenCalled()
+    expect(vtFlowApi.markValidated).not.toHaveBeenCalled()
+  })
+
+  it('validateOnboardingProcess re-drives a VALIDATED record that has no credential exchange', async () => {
+    const { agent, vtFlowApi } = makeAgent(6, { state: 'VALIDATED' }) // HOLDER
+    const orchestrator = new VtFlowOrchestrator(agent as never)
+    stubBuildCredential(orchestrator)
+
+    const { record, credential } = await orchestrator.validateOnboardingProcess({
+      vtFlowRecordId: 'rec-v',
+    })
+
+    // The chain already holds the outcome, so only the credential is built again.
+    expect(agent.veranaChain.setParticipantOPToValidated).not.toHaveBeenCalled()
+    expect(vtFlowApi.markValidated).not.toHaveBeenCalled()
+    expect(record.state).toBe('VALIDATED')
+    expect(credential).toEqual({ id: 'urn:cred' })
+  })
+
+  it('validateOnboardingProcess rejects a VALIDATED record that has a credential exchange', async () => {
+    const { agent } = makeAgent(6, { state: 'VALIDATED', credentialExchangeRecordId: 'cx-1' })
+    const orchestrator = new VtFlowOrchestrator(agent as never)
+    stubBuildCredential(orchestrator)
+
+    await expect(orchestrator.validateOnboardingProcess({ vtFlowRecordId: 'rec-v' })).rejects.toThrow(
+      /Record state is 'VALIDATED'/,
+    )
   })
 
   it('offerOnboardingCredential offers against the validator participant', async () => {
     const { agent, vtFlowApi } = makeAgent(6) // HOLDER
     const orchestrator = new VtFlowOrchestrator(agent as never)
-    // buildCredential needs an indexer and a schema; assert the wiring, not the credential body.
-    ;(orchestrator as unknown as { buildCredential: unknown }).buildCredential = vi.fn(async () => ({
-      id: 'urn:cred',
-    }))
+    stubBuildCredential(orchestrator)
 
     const offered = await orchestrator.offerOnboardingCredential({
       vtFlowRecordId: 'rec-v',
@@ -242,6 +313,26 @@ describe('VtFlowOrchestrator onboarding validation', () => {
       expect.objectContaining({ vtFlowRecordId: 'rec-v', issuerParticipantId: 93 }),
     )
     expect(offered.state).toBe('CRED_OFFERED')
+  })
+
+  it('offerOnboardingCredential sends the credential that validateOnboardingProcess built', async () => {
+    const { agent, vtFlowApi } = makeAgent(6) // HOLDER
+    const orchestrator = new VtFlowOrchestrator(agent as never)
+    const build = stubBuildCredential(orchestrator)
+
+    await orchestrator.offerOnboardingCredential({
+      vtFlowRecordId: 'rec-v',
+      credential: { id: 'urn:prebuilt' } as never,
+    })
+
+    expect(build).not.toHaveBeenCalled()
+    expect(vtFlowApi.offerCredentialForSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentialFormats: expect.objectContaining({
+          jsonld: expect.objectContaining({ credential: { id: 'urn:prebuilt' } }),
+        }),
+      }),
+    )
   })
 
   it('completeOnboardingProcess closes a flow that carries no credential', async () => {

--- a/packages/vt-flow/src/VtFlowApi.ts
+++ b/packages/vt-flow/src/VtFlowApi.ts
@@ -216,6 +216,10 @@ export class VtFlowApi {
     return this.vtFlowService.markValidated(this.agentContext, vtFlowRecordId)
   }
 
+  public markCompleted(vtFlowRecordId: string): Promise<VtFlowRecord> {
+    return this.vtFlowService.markCompleted(this.agentContext, vtFlowRecordId)
+  }
+
   public async offerCredentialForSession(
     options: OfferCredentialForSessionOptions,
   ): Promise<{ record: VtFlowRecord; credentialExchangeRecord: DidCommCredentialExchangeRecord }> {

--- a/packages/vt-flow/src/services/VtFlowService.ts
+++ b/packages/vt-flow/src/services/VtFlowService.ts
@@ -514,6 +514,25 @@ export class VtFlowService {
     return record
   }
 
+  /**
+   * Close an onboarding process that carries no credential exchange. Only a HOLDER receives a
+   * credential; for every other role the chain records the outcome with
+   * SetParticipantOPToValidated, and nothing else follows. Both sides use this, so it asserts no
+   * role: the validator calls it after it validates, and the applicant reaches it from the chain
+   * event.
+   */
+  public async markCompleted(agentContext: AgentContext, recordId: string): Promise<VtFlowRecord> {
+    const record = await this.repository.getById(agentContext, recordId)
+    record.assertVariant(VtFlowVariant.OnboardingProcess)
+    if (record.state === VtFlowState.Completed) return record
+    if (isVtFlowTerminalState(record.state)) {
+      throw new CredoError(`VtFlow record is in terminal state '${record.state}'; cannot complete it.`)
+    }
+
+    await this.updateState(agentContext, record, VtFlowState.Completed)
+    return record
+  }
+
   /** Link a Credo exchange record to the session and transition to `CRED_OFFERED`. */
   public async attachCredentialExchangeRecord(
     agentContext: AgentContext,


### PR DESCRIPTION
`POST /v1/vt/flows/:participantSessionId/validate` always built and offered a credential of the applicant's credential schema. Only a HOLDER takes part in a credential exchange. An ISSUER, a VERIFIER or a grantor joins the Ecosystem, and the chain records that with `SetParticipantOPToValidated` alone.

The schema of an ISSUER entry describes the credential that the issuer will give to other subjects later. It does not describe the issuer. Such an applicant sends no claims, so a schema with required properties always fails. The credential was built before the chain transaction, so the participant did not become VALIDATED either: the operator had to send `MsgSetParticipantOPToValidated` with the CLI.

## What changed

**`VtFlowOrchestrator` now has one method for each step.** The old `validateAndOfferCredential` did two different things, and only one of them applied to every role:

`VtFlowsService` chooses between them from the role of the participant that `validateOnboardingProcess` returns. The role no longer decides anything inside the orchestrator, so each method does what its name says.

**Both sides now reach COMPLETED.** Only the credential exchange moved a record to COMPLETED, so an ISSUER left the validator at VALIDATED and the applicant at OR_SENT for ever. Two additions close that:

- `VtFlowService.markCompleted` (and `VtFlowApi.markCompleted`) refuses a terminal record, and answers with the record when it is already COMPLETED.
- `completeVtFlowRecordsWithoutCredential` in the `SetParticipantOPToValidated`  handler  reads the role of the participant and closes its records when that role is not HOLDER. The applicant reaches its own record here, because it  watches the same chain event. It follows the shape of `markVtFlowRecordsValidated` beside it.

The validator does not wait for the event: `VtFlowsService` calls `completeOnboardingProcess` directly, so the HTTP answer already says COMPLETED.

## Not in this change

An applicant that never learns of the validation from the chain — one that runs without an indexer subscription — still stays at OR_SENT. A message from the validator would close that gap, and needs a new vt-flow message type.
