### PR TITLE
fix: rebuild the self-issued ECS credential when the stored one no longer matches the DID Document

### DIFF
--- a/apps/vs-agent/tests/e2e/fullLifecycle.e2e.test.ts
+++ b/apps/vs-agent/tests/e2e/fullLifecycle.e2e.test.ts
@@ -621,6 +621,57 @@ describe('v4 full lifecycle on a live chain and indexer', () => {
   )
 
   it(
+    'rebuilds the self-issued ECS credential when its stored proof leaves the DID Document',
+    async () => {
+      const baseUrl = applicant.publicApiBaseUrl
+      const didRecordOf = async () => (await applicant.dids.getCreatedDids({ did: applicant.did }))[0]
+      const storedEntry = async (key: string) => (await didRecordOf()).metadata.get('_vt/vtc')?.[key]
+
+      const jscUrl = await resolveJsonSchemaCredentialId(
+        applicant,
+        indexer,
+        serviceSchemaId,
+        seederChain.getChainId,
+      )
+      const rebind = async () =>
+        await rebindEcsCredentialSchema(
+          applicant,
+          baseUrl,
+          String(serviceSchemaId),
+          'ecs-service',
+          selfTrDefaults,
+          jscUrl,
+          applicantIssuerParticipantId,
+        )
+
+      await rebind()
+      const stored = await storedEntry(jscUrl)
+      expect(stored?.credential?.proof?.verificationMethod).toBeDefined()
+      const integrityData = stored.integrityData
+
+      const rotated = `${applicant.did}#rotated-key`
+      const didRecord = await didRecordOf()
+      const record = didRecord.metadata.get('_vt/vtc') ?? {}
+      record[jscUrl].credential.proof.verificationMethod = rotated
+      didRecord.metadata.set('_vt/vtc', record)
+      await applicant.context.dependencyManager.resolve(DidRepository).update(applicant.context, didRecord)
+      expect((await storedEntry(jscUrl)).credential.proof.verificationMethod).toBe(rotated)
+
+      await rebind()
+
+      const rebuilt = await storedEntry(jscUrl)
+      const assertionMethods = ((await didRecordOf()).didDocument?.assertionMethod ?? []).map(entry =>
+        typeof entry === 'string' ? entry : entry.id,
+      )
+      expect(rebuilt.integrityData).toBe(integrityData)
+      expect(rebuilt.credential.proof.verificationMethod).not.toBe(rotated)
+      expect(assertionMethods).toContain(rebuilt.credential.proof.verificationMethod)
+      expect(rebuilt.credential.credentialSchema.id).toBe(jscUrl)
+    },
+    SETUP_TIMEOUT_MS,
+  )
+
+  it(
     'withdraws the self-issued ECS credential when its ISSUER participant is revoked on chain',
     async () => {
       const baseUrl = applicant.publicApiBaseUrl

--- a/packages/agent-sdk/src/utils/setupSelfTr.ts
+++ b/packages/agent-sdk/src/utils/setupSelfTr.ts
@@ -314,6 +314,43 @@ export async function signerW3c(
   }
 }
 
+interface StoredSelfIssuedCredential {
+  issuer?: string | { id?: string }
+  credentialSchema?: { id?: string } | Array<{ id?: string }>
+  proof?: { verificationMethod?: string } | Array<{ verificationMethod?: string }>
+}
+
+function storedCredentialIsCurrent(
+  credential: StoredSelfIssuedCredential | undefined,
+  credentialSchemaId: string,
+  did: string,
+  didRecord: DidRecord,
+): boolean {
+  if (!credential) return false
+
+  const issuer = typeof credential.issuer === 'string' ? credential.issuer : credential.issuer?.id
+  if (issuer !== did) return false
+
+  const schema = Array.isArray(credential.credentialSchema)
+    ? credential.credentialSchema[0]
+    : credential.credentialSchema
+  if (schema?.id !== credentialSchemaId) return false
+
+  const proofs = !credential.proof
+    ? []
+    : Array.isArray(credential.proof)
+      ? credential.proof
+      : [credential.proof]
+  if (proofs.length === 0) return false
+
+  const assertionMethods = new Set(
+    (didRecord.didDocument?.assertionMethod ?? []).map(entry =>
+      typeof entry === 'string' ? entry : entry.id,
+    ),
+  )
+  return proofs.every(proof => !!proof.verificationMethod && assertionMethods.has(proof.verificationMethod))
+}
+
 /**
  * Generates and signs a verifiable presentation containing a verifiable credential.
  * Stores the signed presentation and its integrity metadata in the DID record.
@@ -352,8 +389,17 @@ export async function generateVerifiablePresentation(
   const integrityData = buildIntegrityData({ id, type, credentialSchema, claims })
   const record = didRecord.metadata.get('_vt/vtc') ?? {}
   const metadata = record[credentialSchema.id]
-  const attached = metadata?.attached ?? true
-  if (metadata?.integrityData === integrityData) {
+  const superseded = Object.entries(record).some(
+    ([storedSchemaId, entry]) =>
+      storedSchemaId !== credentialSchema.id &&
+      entry?.verifiablePresentation?.id === id &&
+      entry?.attached !== false,
+  )
+  const attached = (metadata?.attached ?? true) && !superseded
+  if (
+    metadata?.integrityData === integrityData &&
+    storedCredentialIsCurrent(metadata?.credential, credentialSchema.id, agent.did, didRecord)
+  ) {
     // the presentation is already public, so a failed beforePublish step still needs a retry here
     if (attached) await beforePublish?.(metadata.verifiablePresentation)
     return metadata.verifiablePresentation

--- a/packages/agent-sdk/src/utils/trustCredentialStore.ts
+++ b/packages/agent-sdk/src/utils/trustCredentialStore.ts
@@ -50,8 +50,13 @@ export function findMetadataEntry(
   const metadata = didRecord.metadata.get(key)
   if (!metadata) return null
   if (!id && !jsonSchemaRef) return { schemaId: '', data: metadata, didDocumentServiceId: '' }
+  const entries = Object.entries(metadata)
+
+  // the metadata key identifies one entry, so it answers before any preference between entries
+  const exact = jsonSchemaRef ? entries.find(([schemaId]) => schemaId === jsonSchemaRef) : undefined
+  if (exact) return { schemaId: exact[0], ...exact[1], data: exact[1].verifiablePresentation }
+
   const match = ([schemaId, entry]: [string, (typeof metadata)[string]]) => {
-    if (schemaId === jsonSchemaRef) return { schemaId, ...entry, data: entry.verifiablePresentation }
     if (entry.credential?.id === id) return { schemaId, ...entry, data: entry.credential }
     if (entry.verifiablePresentation?.id === id)
       return { schemaId, ...entry, data: entry.verifiablePresentation }
@@ -60,9 +65,7 @@ export function findMetadataEntry(
 
   // several entries can carry the same presentation URL while a binding is replaced, so the entry
   // the DID Document announces wins over a detached leftover
-  const matched = Object.entries(metadata)
-    .map(match)
-    .filter(entry => entry !== null)
+  const matched = entries.map(match).filter(entry => entry !== null)
   return matched.find(entry => entry.attached !== false) ?? matched[0] ?? null
 }
 
@@ -474,6 +477,17 @@ export async function rebindEcsCredentialSchema(
 
   const didRecord = await getDidRecord(agent)
   const record = didRecord.metadata.get('_vt/vtc') ?? {}
+
+  const stored = record[jscUrl]
+  const storedIssuer =
+    typeof stored?.credential?.issuer === 'string' ? stored.credential.issuer : stored?.credential?.issuer?.id
+  if (stored?.credential && !stored.integrityData && storedIssuer !== agent.did) {
+    agent.config.logger.debug(
+      `[SelfTR] Keeping the ${schemaKey} credential issued by ${storedIssuer} instead of rebinding a self-issued one`,
+    )
+    return
+  }
+
   let removedStale = false
   for (const [key, entry] of Object.entries(record)) {
     // findMetadataEntry serves the first entry matching the VP url, so stale bindings must go

--- a/packages/agent-sdk/src/utils/trustCredentialStore.ts
+++ b/packages/agent-sdk/src/utils/trustCredentialStore.ts
@@ -50,22 +50,20 @@ export function findMetadataEntry(
   const metadata = didRecord.metadata.get(key)
   if (!metadata) return null
   if (!id && !jsonSchemaRef) return { schemaId: '', data: metadata, didDocumentServiceId: '' }
-  for (const [schemaId, entry] of Object.entries(metadata)) {
-    if (schemaId === jsonSchemaRef) {
+  const match = ([schemaId, entry]: [string, (typeof metadata)[string]]) => {
+    if (schemaId === jsonSchemaRef) return { schemaId, ...entry, data: entry.verifiablePresentation }
+    if (entry.credential?.id === id) return { schemaId, ...entry, data: entry.credential }
+    if (entry.verifiablePresentation?.id === id)
       return { schemaId, ...entry, data: entry.verifiablePresentation }
-    }
-    const credId = entry.credential?.id
-    const presId = entry.verifiablePresentation?.id
-
-    if (credId === id) {
-      return { schemaId, ...entry, data: entry.credential }
-    }
-
-    if (presId === id) {
-      return { schemaId, ...entry, data: entry.verifiablePresentation }
-    }
+    return null
   }
-  return null
+
+  // several entries can carry the same presentation URL while a binding is replaced, so the entry
+  // the DID Document announces wins over a detached leftover
+  const matched = Object.entries(metadata)
+    .map(match)
+    .filter(entry => entry !== null)
+  return matched.find(entry => entry.attached !== false) ?? matched[0] ?? null
 }
 
 export async function saveMetadataEntry(

--- a/packages/agent-sdk/tests/ecsDigestAnchoring.test.ts
+++ b/packages/agent-sdk/tests/ecsDigestAnchoring.test.ts
@@ -50,7 +50,7 @@ function makeAgent(chain?: Record<string, unknown>) {
     context: { dependencyManager: { resolve: () => ({ update: repositoryUpdate }) } },
     veranaChain: chain,
   }
-  return { agent, didDocument, didsUpdate }
+  return { agent, didDocument, didsUpdate, metadata }
 }
 
 function makeChain(overrides: Record<string, unknown> = {}) {
@@ -144,6 +144,42 @@ describe('ECS credential digest anchoring', () => {
 
     await expect(rebind(agent)).rejects.toThrow('not on chain')
     expect(chain.createOrUpdateParticipantSession).not.toHaveBeenCalled()
+  })
+
+  it('keeps a trust credential a validator issued under the same VTJSC key', async () => {
+    const chain = makeChain()
+    const { agent, metadata, didsUpdate } = makeAgent(chain)
+    const received = {
+      credential: { id: 'did:web:validator.example#1', issuer: 'did:web:validator.example' },
+      verifiablePresentation: { id: 'https://agent.example/vt/schemas-5-vtc-vp.json' },
+      didDocumentServiceId: `${DID}#vpr-schemas-5-vtc-vp`,
+    }
+    metadata.set('_vt/vtc', { [JSC_ID]: received })
+
+    await rebind(agent)
+
+    expect(generateVerifiablePresentation).not.toHaveBeenCalled()
+    expect(chain.createOrUpdateParticipantSession).not.toHaveBeenCalled()
+    expect(didsUpdate).not.toHaveBeenCalled()
+    expect(metadata.get('_vt/vtc')?.[JSC_ID]).toEqual(received)
+  })
+
+  it('rebinds its own stored credential after the agent DID changed', async () => {
+    const chain = makeChain()
+    const { agent, metadata } = makeAgent(chain)
+    // a webvh migration leaves the previous DID as the issuer, but the entry is still this pass's
+    metadata.set('_vt/vtc', {
+      [JSC_ID]: {
+        integrityData: 'sha384-stale',
+        credential: { id: 'did:web:agent.example', issuer: 'did:web:old.example' },
+        verifiablePresentation: { id: 'https://agent.example/vt/ecs-service-vtc-vp.json' },
+      },
+    })
+
+    await rebind(agent)
+
+    expect(generateVerifiablePresentation).toHaveBeenCalledTimes(1)
+    expect(chain.createOrUpdateParticipantSession).toHaveBeenCalledTimes(1)
   })
 
   it('publishes the credential of an agent that has no chain connection', async () => {

--- a/packages/agent-sdk/tests/selfTrPublishOrder.test.ts
+++ b/packages/agent-sdk/tests/selfTrPublishOrder.test.ts
@@ -7,6 +7,7 @@ import { generateVerifiablePresentation, SelfTrDefaults, sortKeysDeep } from '..
 const DID = 'did:web:agent.example'
 const VP_URL = 'https://agent.example/vt/ecs-service-vtc-vp.json'
 const JSC_URL = 'https://agent.example/vt/schemas-5-jsc.json'
+const SELF_TR_URL = 'https://agent.example/vt/cs/v1/js/ecs-service'
 
 vi.mock('axios', () => ({
   default: { get: vi.fn(async (url: string) => ({ data: Buffer.from(`bytes of ${url}`) })) },
@@ -56,24 +57,37 @@ function makeAgent() {
     dids: { getCreatedDids: async () => [didRecord], update: didsUpdate },
     context: { dependencyManager: { resolve: () => ({ update: repositoryUpdate }) } },
     w3cCredentials: {
-      signCredential: async ({ credential }: { credential: unknown }) => credential,
+      signCredential: async ({ credential }: { credential: object }) => ({
+        ...credential,
+        proof: { type: 'Ed25519Signature2020', verificationMethod: `${DID}#key-1` },
+      }),
       signPresentation: async ({ presentation }: { presentation: unknown }) => presentation,
     },
   }
   return { agent, metadata, repositoryUpdate, didsUpdate }
 }
 
-async function publish(agent: unknown, beforePublish: (vp: unknown) => Promise<void>) {
+async function publish(
+  agent: unknown,
+  beforePublish: (vp: unknown) => Promise<void>,
+  credentialSchemaId = JSC_URL,
+) {
   return await generateVerifiablePresentation(
     agent as never,
     VP_URL,
     getEcsSchemas('https://agent.example'),
     'ecs-service',
     ['VerifiableCredential', 'VerifiableTrustCredential'],
-    { id: JSC_URL, type: 'JsonSchemaCredential' },
+    { id: credentialSchemaId, type: 'JsonSchemaCredential' },
     defaults,
     beforePublish,
   )
+}
+
+function storedEntry(metadata: Map<string, any>, schemaId: string) {
+  const entry = metadata.get('_vt/vtc')?.[schemaId]
+  if (!entry) throw new Error(`no stored entry for ${schemaId}`)
+  return entry
 }
 
 describe('generateVerifiablePresentation beforePublish step', () => {
@@ -129,6 +143,59 @@ describe('generateVerifiablePresentation beforePublish step', () => {
       beforePublish,
     )
     expect(repositoryUpdate).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('stored self-issued VTC revalidation', () => {
+  // integrityData never changes here: only the checks on the stored credential can regenerate it
+  const beforePublish = async () => {}
+
+  it('rebuilds when the proof names a verification method the DID Document no longer asserts', async () => {
+    const { agent, metadata, repositoryUpdate } = makeAgent()
+
+    await publish(agent, beforePublish)
+    storedEntry(metadata, JSC_URL).credential.proof.verificationMethod = `${DID}#rotated-key`
+
+    await publish(agent, beforePublish)
+
+    expect(repositoryUpdate).toHaveBeenCalledTimes(2)
+    expect(storedEntry(metadata, JSC_URL).credential.proof.verificationMethod).toBe(`${DID}#key-1`)
+  })
+
+  it('rebuilds when the stored credential is bound to another json schema credential', async () => {
+    const { agent, metadata, repositoryUpdate } = makeAgent()
+
+    await publish(agent, beforePublish)
+    storedEntry(metadata, JSC_URL).credential.credentialSchema = { id: 'https://other.example/jsc.json' }
+
+    await publish(agent, beforePublish)
+
+    expect(repositoryUpdate).toHaveBeenCalledTimes(2)
+    expect(storedEntry(metadata, JSC_URL).credential.credentialSchema.id).toBe(JSC_URL)
+  })
+
+  it('rebuilds when the stored credential was issued by another DID', async () => {
+    const { agent, metadata, repositoryUpdate } = makeAgent()
+
+    await publish(agent, beforePublish)
+    storedEntry(metadata, JSC_URL).credential.issuer = 'did:web:someone-else.example'
+
+    await publish(agent, beforePublish)
+
+    expect(repositoryUpdate).toHaveBeenCalledTimes(2)
+    expect(storedEntry(metadata, JSC_URL).credential.issuer).toBe(DID)
+  })
+
+  it('stores the self-issued default detached while another entry serves the same presentation URL', async () => {
+    const { agent, metadata, didsUpdate } = makeAgent()
+
+    await publish(agent, beforePublish)
+    didsUpdate.mockClear()
+
+    await publish(agent, beforePublish, SELF_TR_URL)
+
+    expect(storedEntry(metadata, SELF_TR_URL).attached).toBe(false)
+    expect(didsUpdate).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/agent-sdk/tests/selfVtcAttachState.test.ts
+++ b/packages/agent-sdk/tests/selfVtcAttachState.test.ts
@@ -14,7 +14,7 @@ import {
   presentations,
   SelfTrDefaults,
 } from '../src/utils/setupSelfTr'
-import { saveMetadataEntry } from '../src/utils/trustCredentialStore'
+import { findMetadataEntry, saveMetadataEntry } from '../src/utils/trustCredentialStore'
 
 const PUBLIC_URL = 'https://agent.example'
 const DID = 'did:web:agent.example'
@@ -151,6 +151,39 @@ function agentAfterRealCredential(integrityData: string) {
     didDocument,
   }
 }
+
+describe('findMetadataEntry with several entries for one presentation URL', () => {
+  const vpUrl = `${PUBLIC_URL}/vt/ecs-service-vtc-vp.json`
+  const jscUrl = `${PUBLIC_URL}/vt/schemas-5-jsc.json`
+  const recordWith = (entries: Record<string, unknown>) => ({ metadata: { get: () => entries } }) as never
+
+  it('serves the entry the DID Document announces, whatever the insertion order', () => {
+    const found = findMetadataEntry(
+      recordWith({
+        [selfIds[0]]: { attached: false, verifiablePresentation: { id: vpUrl, holder: 'detached' } },
+        [jscUrl]: { attached: true, verifiablePresentation: { id: vpUrl, holder: 'attached' } },
+      }),
+      '_vt/vtc',
+      vpUrl,
+    )
+
+    expect(found?.schemaId).toBe(jscUrl)
+    expect(found?.data.holder).toBe('attached')
+  })
+
+  it('falls back to a detached entry when no announced one matches', () => {
+    const found = findMetadataEntry(
+      recordWith({
+        [selfIds[0]]: { attached: false, verifiablePresentation: { id: vpUrl, holder: 'detached' } },
+      }),
+      '_vt/vtc',
+      vpUrl,
+    )
+
+    expect(found?.schemaId).toBe(selfIds[0])
+    expect(found?.data.holder).toBe('detached')
+  })
+})
 
 describe('self-issued VTC attach state', () => {
   it('keeps the self-issued entries when a json schema credential is stored', async () => {


### PR DESCRIPTION
**Changes**
- `generateVerifiablePresentation` now revalidates the stored credential before the cache
  hit: `issuer`, `credentialSchema.id` against the record key, and every
  `proof.verificationMethod` against the DID Document's current `assertionMethod`. Any
  mismatch falls through to the rebuild path that already existed. The verification method
  id is derived from the key material, so a key rotation always changes it.
- The self-issued default is stored detached while another entry already serves the same
  presentation URL. `setupSelfTr` runs before `reconcileVtjscPublications`, so every boot
  re-inserted a competing entry for the URL a rebound credential owns.
- `findMetadataEntry` stops depending on insertion order: among entries matching one URL,
  the one the DID Document announces wins, with a detached entry as the fallback.